### PR TITLE
Feature/#28 - Rename "config_name" into "config_id"

### DIFF
--- a/taipy/core/config/checker/checkers/config_checker.py
+++ b/taipy/core/config/checker/checkers/config_checker.py
@@ -23,12 +23,12 @@ class ConfigChecker:
     def _info(self, field: str, value: Any, message: str):
         self.collector.add_info(field, value, message, self.__class__.__name__)
 
-    def _check_children(self, parent_config_class, config_name: str, config_key: str, config_value, child_config_class):
+    def _check_children(self, parent_config_class, config_id: str, config_key: str, config_value, child_config_class):
         if not config_value:
             self._warning(
                 config_key,
                 config_value,
-                f"{config_key} field of {parent_config_class.__name__} {config_name} is empty.",
+                f"{config_key} field of {parent_config_class.__name__} {config_id} is empty.",
             )
         else:
             if not (
@@ -37,13 +37,13 @@ class ConfigChecker:
                 self._error(
                     config_key,
                     config_value,
-                    f"{config_key} field of {parent_config_class.__name__} {config_name} must be populated with a list of {child_config_class.__name__} objects.",
+                    f"{config_key} field of {parent_config_class.__name__} {config_id} must be populated with a list of {child_config_class.__name__} objects.",
                 )
 
-    def _check_existing_config_name(self, config):
+    def _check_existing_config_id(self, config):
         if not config.name:
             self._error(
-                "config_name",
+                "config_id",
                 config.name,
-                f"config_name of {config.__name__} {config.name} is empty.",
+                f"config_id of {config.__name__} {config.name} is empty.",
             )

--- a/taipy/core/config/checker/checkers/data_node_config_checker.py
+++ b/taipy/core/config/checker/checkers/data_node_config_checker.py
@@ -15,32 +15,32 @@ class DataNodeConfigChecker(ConfigChecker):
 
     def check(self) -> IssueCollector:
         data_node_configs = self.config.data_nodes
-        for data_node_config_name, data_node_config in data_node_configs.items():
-            self._check_existing_config_name(data_node_config)
-            self._check_storage_type(data_node_config_name, data_node_config)
-            self._check_scope(data_node_config_name, data_node_config)
-            self._check_required_properties(data_node_config_name, data_node_config)
+        for data_node_config_id, data_node_config in data_node_configs.items():
+            self._check_existing_config_id(data_node_config)
+            self._check_storage_type(data_node_config_id, data_node_config)
+            self._check_scope(data_node_config_id, data_node_config)
+            self._check_required_properties(data_node_config_id, data_node_config)
             if data_node_config.storage_type == GenericDataNode.storage_type():
-                self._check_read_write_fct(data_node_config_name, data_node_config)
+                self._check_read_write_fct(data_node_config_id, data_node_config)
         return self.collector
 
-    def _check_storage_type(self, data_node_config_name: str, data_node_config: DataNodeConfig):
+    def _check_storage_type(self, data_node_config_id: str, data_node_config: DataNodeConfig):
         if data_node_config.storage_type not in self.storage_types:
             self._error(
                 data_node_config.STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
-                f"{data_node_config.STORAGE_TYPE_KEY} field of DataNode {data_node_config_name} must be either csv, sql, pickle, excel or in_memory.",
+                f"{data_node_config.STORAGE_TYPE_KEY} field of DataNode {data_node_config_id} must be either csv, sql, pickle, excel or in_memory.",
             )
 
-    def _check_scope(self, data_node_config_name: str, data_node_config: DataNodeConfig):
+    def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):
         if not isinstance(data_node_config.scope, Scope):
             self._error(
                 data_node_config.SCOPE_KEY,
                 data_node_config.scope,
-                f"{data_node_config.SCOPE_KEY} field of DataNode {data_node_config_name} must be populated with a Scope value.",
+                f"{data_node_config.SCOPE_KEY} field of DataNode {data_node_config_id} must be populated with a Scope value.",
             )
 
-    def _check_read_write_fct(self, data_node_config_name: str, data_node_config: DataNodeConfig):
+    def _check_read_write_fct(self, data_node_config_id: str, data_node_config: DataNodeConfig):
         key_names = [
             GenericDataNode._REQUIRED_READ_FUNCTION_PROPERTY,
             GenericDataNode._REQUIRED_WRITE_FUNCTION_PROPERTY,
@@ -50,10 +50,10 @@ class DataNodeConfigChecker(ConfigChecker):
                 self._error(
                     key_name,
                     data_node_config.properties[key_name],
-                    f"{key_name} field of DataNode {data_node_config_name} must be populated with a Callable function.",
+                    f"{key_name} field of DataNode {data_node_config_id} must be populated with a Callable function.",
                 )
 
-    def _check_required_properties(self, data_node_config_name: str, data_node_config: DataNodeConfig):
+    def _check_required_properties(self, data_node_config_id: str, data_node_config: DataNodeConfig):
         if storage_type := data_node_config.storage_type:
             if storage_type in self.required_properties.keys():
                 for required_property in self.required_properties[storage_type]:
@@ -61,5 +61,5 @@ class DataNodeConfigChecker(ConfigChecker):
                         self._error(
                             "properties",
                             required_property,
-                            f"properties field of DataNode {data_node_config_name} is missing the required property {required_property} for type {storage_type}",
+                            f"properties field of DataNode {data_node_config_id} is missing the required property {required_property} for type {storage_type}",
                         )

--- a/taipy/core/config/checker/checkers/pipeline_config_checker.py
+++ b/taipy/core/config/checker/checkers/pipeline_config_checker.py
@@ -11,13 +11,13 @@ class PipelineConfigChecker(ConfigChecker):
 
     def check(self) -> IssueCollector:
         pipeline_configs = self.config.pipelines
-        for pipeline_config_name, pipeline_config in pipeline_configs.items():
-            if pipeline_config_name != _Config.DEFAULT_KEY:
-                self._check_existing_config_name(pipeline_config)
-                self._check_tasks(pipeline_config_name, pipeline_config)
+        for pipeline_config_id, pipeline_config in pipeline_configs.items():
+            if pipeline_config_id != _Config.DEFAULT_KEY:
+                self._check_existing_config_id(pipeline_config)
+                self._check_tasks(pipeline_config_id, pipeline_config)
         return self.collector
 
-    def _check_tasks(self, pipeline_config_name: str, pipeline_config: PipelineConfig):
+    def _check_tasks(self, pipeline_config_id: str, pipeline_config: PipelineConfig):
         self._check_children(
-            PipelineConfig, pipeline_config_name, pipeline_config.TASK_KEY, pipeline_config.tasks, TaskConfig
+            PipelineConfig, pipeline_config_id, pipeline_config.TASK_KEY, pipeline_config.tasks, TaskConfig
         )

--- a/taipy/core/config/checker/checkers/scenario_config_checker.py
+++ b/taipy/core/config/checker/checkers/scenario_config_checker.py
@@ -12,35 +12,35 @@ class ScenarioConfigChecker(ConfigChecker):
 
     def check(self) -> IssueCollector:
         scenario_configs = self.config.scenarios
-        for scenario_config_name, scenario_config in scenario_configs.items():
-            if scenario_config_name != _Config.DEFAULT_KEY:
-                self._check_existing_config_name(scenario_config)
-                self._check_frequency(scenario_config_name, scenario_config)
-                self._check_pipelines(scenario_config_name, scenario_config)
-                self._check_comparators(scenario_config_name, scenario_config)
+        for scenario_config_id, scenario_config in scenario_configs.items():
+            if scenario_config_id != _Config.DEFAULT_KEY:
+                self._check_existing_config_id(scenario_config)
+                self._check_frequency(scenario_config_id, scenario_config)
+                self._check_pipelines(scenario_config_id, scenario_config)
+                self._check_comparators(scenario_config_id, scenario_config)
         return self.collector
 
-    def _check_pipelines(self, scenario_config_name: str, scenario_config: ScenarioConfig):
+    def _check_pipelines(self, scenario_config_id: str, scenario_config: ScenarioConfig):
         self._check_children(
             ScenarioConfig,
-            scenario_config_name,
+            scenario_config_id,
             scenario_config.PIPELINE_KEY,
             scenario_config.pipelines,
             PipelineConfig,
         )
 
-    def _check_frequency(self, scenario_config_name: str, scenario_config: ScenarioConfig):
+    def _check_frequency(self, scenario_config_id: str, scenario_config: ScenarioConfig):
         if scenario_config.frequency and not isinstance(scenario_config.frequency, Frequency):
             self._error(
                 scenario_config.FREQUENCY_KEY,
                 scenario_config.frequency,
-                f"{scenario_config.FREQUENCY_KEY} field of Scenario {scenario_config_name} must be populated with a Frequency value.",
+                f"{scenario_config.FREQUENCY_KEY} field of Scenario {scenario_config_id} must be populated with a Frequency value.",
             )
 
-    def _check_comparators(self, scenario_config_name: str, scenario_config: ScenarioConfig):
+    def _check_comparators(self, scenario_config_id: str, scenario_config: ScenarioConfig):
         if not scenario_config.comparators:
             self._info(
                 scenario_config.COMPARATOR_KEY,
                 scenario_config.comparators,
-                f"No scenario {scenario_config.COMPARATOR_KEY} defined for scenario {scenario_config_name}",
+                f"No scenario {scenario_config.COMPARATOR_KEY} defined for scenario {scenario_config_id}",
             )

--- a/taipy/core/config/checker/checkers/task_config_checker.py
+++ b/taipy/core/config/checker/checkers/task_config_checker.py
@@ -11,31 +11,31 @@ class TaskConfigChecker(ConfigChecker):
 
     def check(self) -> IssueCollector:
         task_configs = self.config.tasks
-        for task_config_name, task_config in task_configs.items():
-            if task_config_name != _Config.DEFAULT_KEY:
-                self._check_existing_config_name(task_config)
-                self._check_existing_function(task_config_name, task_config)
-                self._check_inputs(task_config_name, task_config)
-                self._check_outputs(task_config_name, task_config)
+        for task_config_id, task_config in task_configs.items():
+            if task_config_id != _Config.DEFAULT_KEY:
+                self._check_existing_config_id(task_config)
+                self._check_existing_function(task_config_id, task_config)
+                self._check_inputs(task_config_id, task_config)
+                self._check_outputs(task_config_id, task_config)
         return self.collector
 
-    def _check_inputs(self, task_config_name: str, task_config: TaskConfig):
-        self._check_children(TaskConfig, task_config_name, task_config.INPUT_KEY, task_config.inputs, DataNodeConfig)
+    def _check_inputs(self, task_config_id: str, task_config: TaskConfig):
+        self._check_children(TaskConfig, task_config_id, task_config.INPUT_KEY, task_config.inputs, DataNodeConfig)
 
-    def _check_outputs(self, task_config_name: str, task_config: TaskConfig):
-        self._check_children(TaskConfig, task_config_name, task_config.OUTPUT_KEY, task_config.outputs, DataNodeConfig)
+    def _check_outputs(self, task_config_id: str, task_config: TaskConfig):
+        self._check_children(TaskConfig, task_config_id, task_config.OUTPUT_KEY, task_config.outputs, DataNodeConfig)
 
-    def _check_existing_function(self, task_config_name: str, task_config: TaskConfig):
+    def _check_existing_function(self, task_config_id: str, task_config: TaskConfig):
         if not task_config.function:
             self._error(
                 task_config.FUNCTION,
                 task_config.function,
-                f"{task_config.FUNCTION} field of Task {task_config_name} is empty.",
+                f"{task_config.FUNCTION} field of Task {task_config_id} is empty.",
             )
         else:
             if not callable(task_config.function):
                 self._error(
                     task_config.FUNCTION,
                     task_config.function,
-                    f"{task_config.FUNCTION} field of task {task_config_name} must be populated with Callable value.",
+                    f"{task_config.FUNCTION} field of task {task_config_id} must be populated with Callable value.",
                 )

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -92,11 +92,11 @@ class ScenarioConfig:
         for k, v in self.properties.items():
             self.properties[k] = tpl.replace_templates(v)
 
-    def add_comparator(self, dn_config_name: str, comparator: Callable):
-        self.comparators[dn_config_name].append(comparator)
+    def add_comparator(self, dn_config_id: str, comparator: Callable):
+        self.comparators[dn_config_id].append(comparator)
 
-    def delete_comparator(self, dn_config_name: str):
-        if dn_config_name in self.comparators:
-            del self.comparators[dn_config_name]
+    def delete_comparator(self, dn_config_id: str):
+        if dn_config_id in self.comparators:
+            del self.comparators[dn_config_id]
         else:
             raise NonExistingComparator

--- a/taipy/core/data/csv.py
+++ b/taipy/core/data/csv.py
@@ -16,7 +16,7 @@ class CSVDataNode(DataNode):
     A Data Node stored as a CSV file.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str): Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -44,7 +44,7 @@ class CSVDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -65,7 +65,7 @@ class CSVDataNode(DataNode):
             properties[self.__HAS_HEADER_PROPERTY] = True
 
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/data/data_manager.py
+++ b/taipy/core/data/data_manager.py
@@ -52,7 +52,7 @@ class DataManager(Manager[DataNode]):
         """
         scope = data_node_config.scope
         parent_id = pipeline_id if scope == Scope.PIPELINE else scenario_id if scope == Scope.SCENARIO else None
-        dn_from_data_node_config = cls._get_all_by_config_name(data_node_config.name)
+        dn_from_data_node_config = cls._get_all_by_config_id(data_node_config.name)
         dn_from_parent = [dn for dn in dn_from_data_node_config if dn.parent_id == parent_id]
         if len(dn_from_parent) == 1:
             return dn_from_parent[0]
@@ -73,7 +73,7 @@ class DataManager(Manager[DataNode]):
             props = data_node_config.properties.copy()
             validity_period = props.pop("validity_period", None)
             return cls.__DATA_NODE_CLASS_MAP[data_node_config.storage_type](  # type: ignore
-                config_name=data_node_config.name,
+                config_id=data_node_config.name,
                 scope=data_node_config.scope or DataNodeConfig.DEFAULT_SCOPE,
                 parent_id=parent_id,
                 validity_period=validity_period,
@@ -83,5 +83,5 @@ class DataManager(Manager[DataNode]):
             raise InvalidDataNodeType(data_node_config.storage_type)
 
     @classmethod
-    def _get_all_by_config_name(cls, config_name: str) -> List[DataNode]:
-        return cls._repository.search_all("config_name", config_name)
+    def _get_all_by_config_id(cls, config_id: str) -> List[DataNode]:
+        return cls._repository.search_all("config_id", config_id)

--- a/taipy/core/data/data_model.py
+++ b/taipy/core/data/data_model.py
@@ -15,7 +15,7 @@ class DataNodeModel:
 
     Attributes:
         id (str): Identifier of a DataNode.
-        config_name (int): Name of the `DataNodeConfig`.
+        config_id (int): Identifier of the `DataNodeConfig`.
         scope (taipy.core.data.node.scope.Scope): Scope of the usage of a DataNode.
         type (str):  Name of the class that represents a DataNode.
         name (str): User-readable name of the data node.
@@ -36,11 +36,11 @@ class DataNodeModel:
         data_node_properties (Dict[str, Any]): Additional properties of the data node.
 
     Note:
-        The tuple `(config_name, parent_id)` forms a unique key.
+        The tuple `(config_id, parent_id)` forms a unique key.
     """
 
     id: str
-    config_name: str
+    config_id: str
     scope: Scope
     storage_type: str
     name: str
@@ -59,7 +59,7 @@ class DataNodeModel:
     def from_dict(data: Dict[str, Any]):
         return DataNodeModel(
             id=data["id"],
-            config_name=data["config_name"],
+            config_id=data["config_id"],
             scope=Scope.from_repr(data["scope"]),
             storage_type=data["storage_type"],
             name=data["name"],

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -30,7 +30,7 @@ class DataNode:
     only instantiate children classes of Data Node through a Data Manager.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -57,7 +57,7 @@ class DataNode:
 
     def __init__(
         self,
-        config_name,
+        config_id,
         scope: Scope = Scope(Scope.PIPELINE),
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -68,8 +68,8 @@ class DataNode:
         edition_in_progress: bool = False,
         **kwargs,
     ):
-        self.config_name = protect_name(config_name)
-        self.id = id or DataNodeId(self.__ID_SEPARATOR.join([self.ID_PREFIX, self.config_name, str(uuid.uuid4())]))
+        self.config_id = protect_name(config_id)
+        self.id = id or DataNodeId(self.__ID_SEPARATOR.join([self.ID_PREFIX, self.config_id, str(uuid.uuid4())]))
         self.parent_id = parent_id
         self.scope = scope
 

--- a/taipy/core/data/data_repository.py
+++ b/taipy/core/data/data_repository.py
@@ -38,7 +38,7 @@ class DataRepository(FileSystemRepository[DataNodeModel, DataNode]):
 
         return DataNodeModel(
             data_node.id,
-            data_node.config_name,
+            data_node.config_id,
             data_node.scope,
             data_node.storage_type(),
             data_node._name,
@@ -79,7 +79,7 @@ class DataRepository(FileSystemRepository[DataNodeModel, DataNode]):
             validity_period = timedelta(days=model.validity_days, seconds=model.validity_seconds)
 
         return self.class_map[model.storage_type](
-            config_name=model.config_name,
+            config_id=model.config_id,
             scope=model.scope,
             id=model.id,
             name=model.name,

--- a/taipy/core/data/excel.py
+++ b/taipy/core/data/excel.py
@@ -21,7 +21,7 @@ class ExcelDataNode(DataNode):
     A Data Node stored as an Excel file (xlsx format).
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -51,7 +51,7 @@ class ExcelDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -76,7 +76,7 @@ class ExcelDataNode(DataNode):
             properties[self.__EXPOSED_TYPE_PROPERTY] = self.__exposed_types_to_dict(properties)
 
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/data/generic.py
+++ b/taipy/core/data/generic.py
@@ -12,7 +12,7 @@ class GenericDataNode(DataNode):
     A generic Data Node that accepts custom read function and custom write function.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -40,7 +40,7 @@ class GenericDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -59,7 +59,7 @@ class GenericDataNode(DataNode):
             )
 
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/data/in_memory.py
+++ b/taipy/core/data/in_memory.py
@@ -16,7 +16,7 @@ class InMemoryDataNode(DataNode):
     Synchronous task executor. The purpose of InMemoryDataNode is to be used for development or debug.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -42,7 +42,7 @@ class InMemoryDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -59,7 +59,7 @@ class InMemoryDataNode(DataNode):
             properties = {}
         default_value = properties.pop(self.__DEFAULT_DATA_VALUE, None)
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/data/pickle.py
+++ b/taipy/core/data/pickle.py
@@ -14,7 +14,7 @@ class PickleDataNode(DataNode):
     A Data Node stored as a pickle file.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -42,7 +42,7 @@ class PickleDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -57,7 +57,7 @@ class PickleDataNode(DataNode):
             properties = {}
         default_value = properties.pop(self.__DEFAULT_DATA_VALUE, None)
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/data/sql.py
+++ b/taipy/core/data/sql.py
@@ -19,7 +19,7 @@ class SQLDataNode(DataNode):
     A Data Node stored as a SQL database.
 
     Attributes:
-        config_name (str):  Name that identifies the data node.
+        config_id (str):  Identifier of the data node configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash character '-', or underscore character
             '_'. Note that other characters are replaced according the following rules :
             - Space characters are replaced by underscore characters ('_').
@@ -47,7 +47,7 @@ class SQLDataNode(DataNode):
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         scope: Scope,
         id: Optional[DataNodeId] = None,
         name: Optional[str] = None,
@@ -81,7 +81,7 @@ class SQLDataNode(DataNode):
         )
 
         super().__init__(
-            config_name,
+            config_id,
             scope,
             id,
             name,

--- a/taipy/core/exceptions/pipeline.py
+++ b/taipy/core/exceptions/pipeline.py
@@ -12,8 +12,8 @@ class NonExistingPipelineConfig(Exception):
     Raised if a requested Pipeline configuration is not known by the Pipeline Manager.
     """
 
-    def __init__(self, pipeline_config_name: str):
-        self.message = f"Pipeline config: {pipeline_config_name} does not exist."
+    def __init__(self, pipeline_config_id: str):
+        self.message = f"Pipeline config: {pipeline_config_id} does not exist."
 
 
 class MultiplePipelineFromSameConfigWithSameParent(Exception):

--- a/taipy/core/exceptions/scenario.py
+++ b/taipy/core/exceptions/scenario.py
@@ -12,8 +12,8 @@ class NonExistingScenarioConfig(Exception):
     Raised when a requested scenario configuration is not known by the Scenario Manager.
     """
 
-    def __init__(self, scenario_config_name: str):
-        self.message = f"Scenario config: {scenario_config_name} does not exist."
+    def __init__(self, scenario_config_id: str):
+        self.message = f"Scenario config: {scenario_config_id} does not exist."
 
 
 class DoesNotBelongToACycle(Exception):

--- a/taipy/core/pipeline/pipeline.py
+++ b/taipy/core/pipeline/pipeline.py
@@ -20,7 +20,7 @@ class Pipeline:
     connected in series.
 
     Attributes:
-        config_name (str):  Name that identifies the pipeline configuration.
+        config_id (str): Identifier of the pipeline configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash characters ('-'),
             or underscore characters ('_').
             Other characters are replaced according the following rules:
@@ -38,16 +38,16 @@ class Pipeline:
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         properties: Dict[str, Any],
         tasks: List[Task],
         pipeline_id: PipelineId = None,
         parent_id: Optional[str] = None,
         subscribers: Set[Callable] = None,
     ):
-        self.config_name = protect_name(config_name)
-        self.tasks = {task.config_name: task for task in tasks}
-        self.id: PipelineId = pipeline_id or self.new_id(self.config_name)
+        self.config_id = protect_name(config_id)
+        self.tasks = {task.config_id: task for task in tasks}
+        self.id: PipelineId = pipeline_id or self.new_id(self.config_id)
         self.parent_id = parent_id
         self.is_consistent = self.__is_consistent()
 
@@ -77,8 +77,8 @@ class Pipeline:
         return self.id == other.id
 
     @staticmethod
-    def new_id(config_name: str) -> PipelineId:
-        return PipelineId(Pipeline.__SEPARATOR.join([Pipeline.ID_PREFIX, protect_name(config_name), str(uuid.uuid4())]))
+    def new_id(config_id: str) -> PipelineId:
+        return PipelineId(Pipeline.__SEPARATOR.join([Pipeline.ID_PREFIX, protect_name(config_id), str(uuid.uuid4())]))
 
     def __getattr__(self, attribute_name):
         protected_attribute_name = protect_name(attribute_name)
@@ -132,7 +132,7 @@ class Pipeline:
         return PipelineModel(
             self.id,
             self.parent_id,
-            self.config_name,
+            self.config_id,
             self._properties.data,
             [task.id for task in self.tasks.values()],
             fcts_to_dict(list(self._subscribers)),

--- a/taipy/core/pipeline/pipeline_manager.py
+++ b/taipy/core/pipeline/pipeline_manager.py
@@ -84,8 +84,8 @@ class PipelineManager(Manager[Pipeline]):
         ]
         scope = min(task.scope for task in tasks) if len(tasks) != 0 else Scope.GLOBAL
         parent_id = scenario_id if scope == Scope.SCENARIO else pipeline_id if scope == Scope.PIPELINE else None
-        pipelines_from_config_name = cls._get_all_by_config_name(pipeline_config.name)
-        pipelines_from_parent = [pipeline for pipeline in pipelines_from_config_name if pipeline.parent_id == parent_id]
+        pipelines_from_config_id = cls._get_all_by_config_id(pipeline_config.name)
+        pipelines_from_parent = [pipeline for pipeline in pipelines_from_config_id if pipeline.parent_id == parent_id]
         if len(pipelines_from_parent) == 1:
             return pipelines_from_parent[0]
         elif len(pipelines_from_parent) > 1:
@@ -147,5 +147,5 @@ class PipelineManager(Manager[Pipeline]):
         cls.delete(pipeline_id)
 
     @classmethod
-    def _get_all_by_config_name(cls, config_name: str) -> List[Pipeline]:
-        return cls._repository.search_all("config_name", config_name)
+    def _get_all_by_config_id(cls, config_id: str) -> List[Pipeline]:
+        return cls._repository.search_all("config_id", config_id)

--- a/taipy/core/pipeline/pipeline_repository.py
+++ b/taipy/core/pipeline/pipeline_repository.py
@@ -27,7 +27,7 @@ class PipelineRepository(FileSystemRepository[PipelineModel, Pipeline]):
         return PipelineModel(
             pipeline.id,
             pipeline.parent_id,
-            pipeline.config_name,
+            pipeline.config_id,
             pipeline._properties.data,
             [task.id for task in pipeline.tasks.values()],
             utils.fcts_to_dict(pipeline._subscribers),

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -17,7 +17,7 @@ class Scenario:
     It holds a set of pipelines to submit for execution in order to solve the business case.
 
     Attributes:
-        config_name (str):  Name that identifies the scenario configuration.
+        config_id (str): Identifier of the scenario configuration.
             We strongly recommend to use lowercase alphanumeric characters, dash characters ('-'),
             or underscore characters ('_').
             Other characters are replaced according the following rules:
@@ -37,7 +37,7 @@ class Scenario:
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         pipelines: List[Pipeline],
         properties: Dict[str, Any],
         scenario_id: ScenarioId = None,
@@ -47,9 +47,9 @@ class Scenario:
         subscribers: Set[Callable] = None,
         tags: Set[str] = None,
     ):
-        self.config_name = protect_name(config_name)
-        self.id: ScenarioId = scenario_id or self.new_id(self.config_name)
-        self.pipelines = {p.config_name: p for p in pipelines}
+        self.config_id = protect_name(config_id)
+        self.id: ScenarioId = scenario_id or self.new_id(self.config_id)
+        self.pipelines = {p.config_id: p for p in pipelines}
         self.creation_date = creation_date or datetime.now()
         self.cycle = cycle
 
@@ -92,9 +92,9 @@ class Scenario:
         return self.id == other.id
 
     @staticmethod
-    def new_id(config_name: str) -> ScenarioId:
+    def new_id(config_id: str) -> ScenarioId:
         """Generates a unique scenario identifier."""
-        return ScenarioId(Scenario.__SEPARATOR.join([Scenario.ID_PREFIX, protect_name(config_name), str(uuid.uuid4())]))
+        return ScenarioId(Scenario.__SEPARATOR.join([Scenario.ID_PREFIX, protect_name(config_id), str(uuid.uuid4())]))
 
     def __getattr__(self, attribute_name):
         protected_attribute_name = protect_name(attribute_name)

--- a/taipy/core/scenario/scenario_repository.py
+++ b/taipy/core/scenario/scenario_repository.py
@@ -22,7 +22,7 @@ class ScenarioRepository(FileSystemRepository[ScenarioModel, Scenario]):
     def to_model(self, scenario: Scenario):
         return ScenarioModel(
             id=scenario.id,
-            name=scenario.config_name,
+            name=scenario.config_id,
             pipelines=self.__to_pipeline_ids(scenario.pipelines.values()),
             properties=scenario._properties.data,
             creation_date=scenario.creation_date.isoformat(),
@@ -35,7 +35,7 @@ class ScenarioRepository(FileSystemRepository[ScenarioModel, Scenario]):
     def from_model(self, model: ScenarioModel) -> Scenario:
         scenario = Scenario(
             scenario_id=model.id,
-            config_name=model.name,
+            config_id=model.name,
             pipelines=self.__to_pipelines(model.pipelines),
             properties=model.properties,
             creation_date=datetime.fromisoformat(model.creation_date),

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -216,14 +216,14 @@ def untag(scenario: Scenario, tag: str):
     return ScenarioManager.untag(scenario, tag)
 
 
-def compare_scenarios(*scenarios: Scenario, data_node_config_name: str = None):
+def compare_scenarios(*scenarios: Scenario, data_node_config_id: str = None):
     """
     Compares the data nodes of given scenarios with known datanode config name.
 
     Parameters:
         scenarios (Scenario) : Scenario objects to compare
-        data_node_config_name (Optional[str]) : config name of the DataNode to compare scenarios, if no
-            datanode_config_name is provided, the scenarios will be compared based on all the previously defined
+        data_node_config_id (Optional[str]) : config name of the DataNode to compare scenarios, if no
+            datanode_config_id is provided, the scenarios will be compared based on all the previously defined
             comparators.
     Raises:
         InsufficientScenarioToCompare: Provided only one or no scenario for comparison
@@ -231,7 +231,7 @@ def compare_scenarios(*scenarios: Scenario, data_node_config_name: str = None):
         DifferentScenarioConfigs: The provided scenarios do not share the same scenario_config
         NonExistingScenarioConfig: Cannot find the shared scenario config of the provided scenarios
     """
-    return ScenarioManager.compare(*scenarios, data_node_config_name=data_node_config_name)
+    return ScenarioManager.compare(*scenarios, data_node_config_id=data_node_config_id)
 
 
 def subscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):

--- a/taipy/core/task/task.py
+++ b/taipy/core/task/task.py
@@ -13,8 +13,8 @@ class Task:
     This element bring together the user code as function, parameters and outputs.
 
     Attributes:
-        config_name:
-            Name that identifies the task config. We strongly recommend to use lowercase alphanumeric characters,
+        config_id: Identifier of the task configuration.
+            We strongly recommend to use lowercase alphanumeric characters,
             dash character '-', or underscore character '_'.
             Note that other characters are replaced according the following rules :
             - Space character ' ' is replaced by '_'.
@@ -37,18 +37,18 @@ class Task:
 
     def __init__(
         self,
-        config_name: str,
+        config_id: str,
         function,
         input: Optional[Iterable[DataNode]] = None,
         output: Optional[Iterable[DataNode]] = None,
         id: TaskId = None,
         parent_id: Optional[str] = None,
     ):
-        self.config_name = protect_name(config_name)
-        self.id = id or TaskId(self.__ID_SEPARATOR.join([self.ID_PREFIX, self.config_name, str(uuid.uuid4())]))
+        self.config_id = protect_name(config_id)
+        self.id = id or TaskId(self.__ID_SEPARATOR.join([self.ID_PREFIX, self.config_id, str(uuid.uuid4())]))
         self.parent_id = parent_id
-        self.__input = {dn.config_name: dn for dn in input or []}
-        self.__output = {dn.config_name: dn for dn in output or []}
+        self.__input = {dn.config_id: dn for dn in input or []}
+        self.__output = {dn.config_id: dn for dn in output or []}
         self.function = function
 
     def __hash__(self):

--- a/taipy/core/task/task_manager.py
+++ b/taipy/core/task/task_manager.py
@@ -80,8 +80,8 @@ class TaskManager(Manager[Task]):
         }
         scope = min(dn.scope for dn in data_nodes.values()) if len(data_nodes) != 0 else Scope.GLOBAL
         parent_id = pipeline_id if scope == Scope.PIPELINE else scenario_id if scope == Scope.SCENARIO else None
-        tasks_from_config_name = cls._get_all_by_config_name(task_config.name)
-        tasks_from_parent = [task for task in tasks_from_config_name if task.parent_id == parent_id]
+        tasks_from_config_id = cls._get_all_by_config_id(task_config.name)
+        tasks_from_parent = [task for task in tasks_from_config_id if task.parent_id == parent_id]
         if len(tasks_from_parent) == 1:
             return tasks_from_parent[0]
         elif len(tasks_from_parent) > 1:
@@ -140,5 +140,5 @@ class TaskManager(Manager[Task]):
                 DataManager.delete(data_node.id)
 
     @classmethod
-    def _get_all_by_config_name(cls, config_name: str) -> List[Task]:
-        return cls._repository.search_all("config_name", config_name)
+    def _get_all_by_config_id(cls, config_id: str) -> List[Task]:
+        return cls._repository.search_all("config_id", config_id)

--- a/taipy/core/task/task_model.py
+++ b/taipy/core/task/task_model.py
@@ -8,12 +8,12 @@ class TaskModel:
     """Hold the model of a Task.
 
     A model refers to the structure of a Task stored in a database.
-    The tuple `(config_name, parent_id)` forms a unique key.
+    The tuple `(config_id, parent_id)` forms a unique key.
 
     Attributes:
         id: Identifier of a Data Node.
         parent_id: Identifier of the parent (pipeline_id, scenario_id, cycle_id) or `None`.
-        config_name: Name of the Data Node Config.
+        config_id: Name of the Data Node Config.
         input: Input data node of the Task, saved as its ID string representation.
         function_name: Name of the task function.
         function_module: Module name of the task function.
@@ -22,7 +22,7 @@ class TaskModel:
 
     id: str
     parent_id: Optional[str]
-    config_name: str
+    config_id: str
     input_ids: List[str]
     function_name: str
     function_module: str
@@ -36,7 +36,7 @@ class TaskModel:
         return TaskModel(
             id=data["id"],
             parent_id=data["parent_id"],
-            config_name=data["config_name"],
+            config_id=data["config_id"],
             input_ids=data["input_ids"],
             function_name=data["function_name"],
             function_module=data["function_module"],

--- a/taipy/core/task/task_repository.py
+++ b/taipy/core/task/task_repository.py
@@ -18,7 +18,7 @@ class TaskRepository(FileSystemRepository[TaskModel, Task]):
         return TaskModel(
             id=task.id,
             parent_id=task.parent_id,
-            config_name=task.config_name,
+            config_id=task.config_id,
             input_ids=self.__to_ids(task.input.values()),
             function_name=task.function.__name__,
             function_module=task.function.__module__,
@@ -29,7 +29,7 @@ class TaskRepository(FileSystemRepository[TaskModel, Task]):
         return Task(
             id=TaskId(model.id),
             parent_id=model.parent_id,
-            config_name=model.config_name,
+            config_id=model.config_id,
             function=load_fct(model.function_module, model.function_name),
             input=self.__to_data_nodes(model.input_ids),
             output=self.__to_data_nodes(model.output_ids),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,13 +102,13 @@ def scenario(cycle):
 
 @pytest.fixture(scope="function")
 def data_node():
-    return InMemoryDataNode("data_node_config_name", Scope.PIPELINE)
+    return InMemoryDataNode("data_node_config_id", Scope.PIPELINE)
 
 
 @pytest.fixture(scope="function")
 def task(data_node):
-    dn = InMemoryDataNode("dn_config_name", Scope.PIPELINE)
-    return Task("task_config_name", print, [data_node], [dn])
+    dn = InMemoryDataNode("dn_config_id", Scope.PIPELINE)
+    return Task("task_config_id", print, [data_node], [dn])
 
 
 @pytest.fixture(scope="function")

--- a/tests/core/config/checker/test_data_node_config_checker.py
+++ b/tests/core/config/checker/test_data_node_config_checker.py
@@ -7,7 +7,7 @@ from taipy.core.data.scope import Scope
 
 
 class TestDataNodeConfigChecker:
-    def test_check_config_name(self):
+    def test_check_config_id(self):
         collector = IssueCollector()
         config = _Config.default_config()
         DataNodeConfigChecker(config, collector).check()

--- a/tests/core/config/checker/test_pipeline_config_checker.py
+++ b/tests/core/config/checker/test_pipeline_config_checker.py
@@ -7,7 +7,7 @@ from taipy.core.config.task_config import TaskConfig
 
 
 class TestPipelineConfigChecker:
-    def test_check_config_name(self):
+    def test_check_config_id(self):
         collector = IssueCollector()
         config = _Config.default_config()
         PipelineConfigChecker(config, collector).check()

--- a/tests/core/config/checker/test_scenario_config_checker.py
+++ b/tests/core/config/checker/test_scenario_config_checker.py
@@ -8,7 +8,7 @@ from taipy.core.config.pipeline_config import PipelineConfig
 
 
 class TestScenarioConfigChecker:
-    def test_check_config_name(self):
+    def test_check_config_id(self):
         collector = IssueCollector()
         config = _Config.default_config()
         ScenarioConfigChecker(config, collector).check()

--- a/tests/core/config/checker/test_task_config_checker.py
+++ b/tests/core/config/checker/test_task_config_checker.py
@@ -7,7 +7,7 @@ from taipy.core.config.data_node_config import DataNodeConfig
 
 
 class TestTaskConfigChecker:
-    def test_check_config_name(self):
+    def test_check_config_id(self):
         config = _Config.default_config()
         collector = IssueCollector()
         TaskConfigChecker(config, collector).check()

--- a/tests/core/config/test_pipeline_config.py
+++ b/tests/core/config/test_pipeline_config.py
@@ -41,12 +41,12 @@ def test_pipeline_count():
 
 
 def test_pipeline_getitem():
-    pipeline_config_name = "pipelines1"
-    pipeline = Config.add_pipeline(pipeline_config_name, [task1_config, task2_config])
+    pipeline_config_id = "pipelines1"
+    pipeline = Config.add_pipeline(pipeline_config_id, [task1_config, task2_config])
 
-    assert Config.pipelines[pipeline_config_name].name == pipeline.name
-    assert Config.pipelines[pipeline_config_name].tasks == pipeline.tasks
-    assert Config.pipelines[pipeline_config_name].properties == pipeline.properties
+    assert Config.pipelines[pipeline_config_id].name == pipeline.name
+    assert Config.pipelines[pipeline_config_id].tasks == pipeline.tasks
+    assert Config.pipelines[pipeline_config_id].properties == pipeline.properties
 
 
 def test_pipeline_creation_no_duplication():

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -19,7 +19,7 @@ class TestCSVDataNode:
         dn = CSVDataNode("fOo BAr", Scope.PIPELINE, name="super name", properties={"path": path, "has_header": False})
         assert isinstance(dn, CSVDataNode)
         assert dn.storage_type() == "csv"
-        assert dn.config_name == "foo_bar"
+        assert dn.config_id == "foo_bar"
         assert dn.name == "super name"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None
@@ -31,12 +31,12 @@ class TestCSVDataNode:
         assert dn.has_header is False
 
     def test_new_csv_data_node_with_existing_file_is_ready_for_reading(self):
-        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_name", "csv", path="NOT_EXISTING.csv")
+        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_id", "csv", path="NOT_EXISTING.csv")
         not_ready_dn = DataManager.get_or_create(not_ready_dn_cfg)
         assert not not_ready_dn.is_ready_for_reading
 
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.csv")
-        ready_dn_cfg = Config.add_data_node("ready_data_node_config_name", "csv", path=path)
+        ready_dn_cfg = Config.add_data_node("ready_data_node_config_id", "csv", path=path)
         ready_dn = DataManager.get_or_create(ready_dn_cfg)
         assert ready_dn.is_ready_for_reading
 

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -42,8 +42,8 @@ class TestDataManager:
 
         assert DataManager.get(csv_dn.id) is not None
         assert DataManager.get(csv_dn.id).id == csv_dn.id
-        assert DataManager.get(csv_dn.id).config_name == "foo"
-        assert DataManager.get(csv_dn.id).config_name == csv_dn.config_name
+        assert DataManager.get(csv_dn.id).config_id == "foo"
+        assert DataManager.get(csv_dn.id).config_id == csv_dn.config_id
         assert DataManager.get(csv_dn.id).scope == Scope.SCENARIO
         assert DataManager.get(csv_dn.id).scope == csv_dn.scope
         assert DataManager.get(csv_dn.id).parent_id is None
@@ -62,8 +62,8 @@ class TestDataManager:
 
         assert DataManager.get(csv_dn) is not None
         assert DataManager.get(csv_dn).id == csv_dn.id
-        assert DataManager.get(csv_dn).config_name == "foo"
-        assert DataManager.get(csv_dn).config_name == csv_dn.config_name
+        assert DataManager.get(csv_dn).config_id == "foo"
+        assert DataManager.get(csv_dn).config_id == csv_dn.config_id
         assert DataManager.get(csv_dn).scope == Scope.SCENARIO
         assert DataManager.get(csv_dn).scope == csv_dn.scope
         assert DataManager.get(csv_dn).parent_id is None
@@ -101,8 +101,8 @@ class TestDataManager:
 
         assert DataManager.get(in_mem_dn.id) is not None
         assert DataManager.get(in_mem_dn.id).id == in_mem_dn.id
-        assert DataManager.get(in_mem_dn.id).config_name == "baz"
-        assert DataManager.get(in_mem_dn.id).config_name == in_mem_dn.config_name
+        assert DataManager.get(in_mem_dn.id).config_id == "baz"
+        assert DataManager.get(in_mem_dn.id).config_id == in_mem_dn.config_id
         assert DataManager.get(in_mem_dn.id).scope == Scope.SCENARIO
         assert DataManager.get(in_mem_dn.id).scope == in_mem_dn.scope
         assert DataManager.get(in_mem_dn.id).parent_id == "Scenario_id"
@@ -120,8 +120,8 @@ class TestDataManager:
 
         assert DataManager.get(in_mem_dn) is not None
         assert DataManager.get(in_mem_dn).id == in_mem_dn.id
-        assert DataManager.get(in_mem_dn).config_name == "baz"
-        assert DataManager.get(in_mem_dn).config_name == in_mem_dn.config_name
+        assert DataManager.get(in_mem_dn).config_id == "baz"
+        assert DataManager.get(in_mem_dn).config_id == in_mem_dn.config_id
         assert DataManager.get(in_mem_dn).scope == Scope.SCENARIO
         assert DataManager.get(in_mem_dn).scope == in_mem_dn.scope
         assert DataManager.get(in_mem_dn).parent_id == "Scenario_id"
@@ -151,8 +151,8 @@ class TestDataManager:
 
         assert DataManager.get(pickle_dn.id) is not None
         assert DataManager.get(pickle_dn.id).id == pickle_dn.id
-        assert DataManager.get(pickle_dn.id).config_name == "plop"
-        assert DataManager.get(pickle_dn.id).config_name == pickle_dn.config_name
+        assert DataManager.get(pickle_dn.id).config_id == "plop"
+        assert DataManager.get(pickle_dn.id).config_id == pickle_dn.config_id
         assert DataManager.get(pickle_dn.id).scope == Scope.CYCLE
         assert DataManager.get(pickle_dn.id).scope == pickle_dn.scope
         assert DataManager.get(pickle_dn.id).parent_id is None
@@ -169,8 +169,8 @@ class TestDataManager:
 
         assert DataManager.get(pickle_dn) is not None
         assert DataManager.get(pickle_dn).id == pickle_dn.id
-        assert DataManager.get(pickle_dn).config_name == "plop"
-        assert DataManager.get(pickle_dn).config_name == pickle_dn.config_name
+        assert DataManager.get(pickle_dn).config_id == "plop"
+        assert DataManager.get(pickle_dn).config_id == pickle_dn.config_id
         assert DataManager.get(pickle_dn).scope == Scope.CYCLE
         assert DataManager.get(pickle_dn).scope == pickle_dn.scope
         assert DataManager.get(pickle_dn).parent_id is None
@@ -201,14 +201,14 @@ class TestDataManager:
 
         csv_dn = Config.add_data_node(name="foo", storage_type="csv", path="bar", has_header=True)
         csv = DataManager._create_and_set(csv_dn, None)
-        assert csv.config_name == "foo"
+        assert csv.config_id == "foo"
         assert isinstance(csv, CSVDataNode)
         assert csv.path == "path_from_config_file"
         assert csv.has_header
 
         csv_dn = Config.add_data_node(name="baz", storage_type="csv", path="bar", has_header=True)
         csv = DataManager._create_and_set(csv_dn, None)
-        assert csv.config_name == "baz"
+        assert csv.config_id == "baz"
         assert isinstance(csv, CSVDataNode)
         assert csv.path == "bar"
         assert csv.has_header
@@ -226,26 +226,26 @@ class TestDataManager:
         DataManager._create_and_set(dn_config_2, None)
         DataManager._create_and_set(dn_config_2, None)
         assert len(DataManager.get_all()) == 3
-        assert len([dn for dn in DataManager.get_all() if dn.config_name == "foo"]) == 1
-        assert len([dn for dn in DataManager.get_all() if dn.config_name == "baz"]) == 2
+        assert len([dn for dn in DataManager.get_all() if dn.config_id == "foo"]) == 1
+        assert len([dn for dn in DataManager.get_all() if dn.config_id == "baz"]) == 2
 
-    def test_get_all_by_config_name(self):
-        assert len(DataManager._get_all_by_config_name("NOT_EXISTING_CONFIG_NAME")) == 0
+    def test_get_all_by_config_id(self):
+        assert len(DataManager._get_all_by_config_id("NOT_EXISTING_CONFIG_NAME")) == 0
         dn_config_1 = Config.add_data_node(name="foo", storage_type="in_memory")
-        assert len(DataManager._get_all_by_config_name("foo")) == 0
+        assert len(DataManager._get_all_by_config_id("foo")) == 0
         DataManager._create_and_set(dn_config_1, None)
-        assert len(DataManager._get_all_by_config_name("foo")) == 1
+        assert len(DataManager._get_all_by_config_id("foo")) == 1
         dn_config_2 = Config.add_data_node(name="baz", storage_type="in_memory")
         DataManager._create_and_set(dn_config_2, None)
-        assert len(DataManager._get_all_by_config_name("foo")) == 1
-        assert len(DataManager._get_all_by_config_name("baz")) == 1
+        assert len(DataManager._get_all_by_config_id("foo")) == 1
+        assert len(DataManager._get_all_by_config_id("baz")) == 1
         DataManager._create_and_set(dn_config_2, None)
-        assert len(DataManager._get_all_by_config_name("foo")) == 1
-        assert len(DataManager._get_all_by_config_name("baz")) == 2
+        assert len(DataManager._get_all_by_config_id("foo")) == 1
+        assert len(DataManager._get_all_by_config_id("baz")) == 2
 
     def test_set(self):
         dn = InMemoryDataNode(
-            "config_name",
+            "config_id",
             Scope.PIPELINE,
             id=DataNodeId("id"),
             parent_id=None,
@@ -259,18 +259,18 @@ class TestDataManager:
         assert len(DataManager.get_all()) == 1
 
         # changing data node attribute
-        dn.config_name = "foo"
-        assert dn.config_name == "foo"
-        assert DataManager.get(dn.id).config_name == "config_name"
+        dn.config_id = "foo"
+        assert dn.config_id == "foo"
+        assert DataManager.get(dn.id).config_id == "config_id"
         DataManager.set(dn)
         assert len(DataManager.get_all()) == 1
-        assert dn.config_name == "foo"
-        assert DataManager.get(dn.id).config_name == "foo"
+        assert dn.config_id == "foo"
+        assert DataManager.get(dn.id).config_id == "foo"
 
     def test_delete(self):
-        dn_1 = InMemoryDataNode("config_name", Scope.PIPELINE, id="id_1")
-        dn_2 = InMemoryDataNode("config_name", Scope.PIPELINE, id="id_2")
-        dn_3 = InMemoryDataNode("config_name", Scope.PIPELINE, id="id_3")
+        dn_1 = InMemoryDataNode("config_id", Scope.PIPELINE, id="id_1")
+        dn_2 = InMemoryDataNode("config_id", Scope.PIPELINE, id="id_2")
+        dn_3 = InMemoryDataNode("config_id", Scope.PIPELINE, id="id_3")
         assert len(DataManager.get_all()) == 0
         DataManager.set(dn_1)
         DataManager.set(dn_2)

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -17,8 +17,8 @@ class FakeDataNode(InMemoryDataNode):
     read_has_been_called = 0
     write_has_been_called = 0
 
-    def __init__(self, config_name, **kwargs):
-        super().__init__(config_name, Scope.PIPELINE, **kwargs)
+    def __init__(self, config_id, **kwargs):
+        super().__init__(config_id, Scope.PIPELINE, **kwargs)
 
     def _read(self, query=None):
         self.read_has_been_called += 1
@@ -33,8 +33,8 @@ class FakeDataframeDataNode(DataNode):
     COLUMN_NAME_1 = "a"
     COLUMN_NAME_2 = "b"
 
-    def __init__(self, config_name, default_data_frame, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, default_data_frame, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = default_data_frame
 
     def _read(self):
@@ -46,8 +46,8 @@ class FakeListDataNode(DataNode):
         def __init__(self, value):
             self.value = value
 
-    def __init__(self, config_name, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = [self.Row(i) for i in range(10)]
 
     def _read(self):
@@ -57,7 +57,7 @@ class FakeListDataNode(DataNode):
 class TestDataNode:
     def test_create_with_default_values(self):
         dn = DataNode("fOo BAr")
-        assert dn.config_name == "foo_bar"
+        assert dn.config_id == "foo_bar"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None
         assert dn.name == dn.id
@@ -80,7 +80,7 @@ class TestDataNode:
             edition_in_progress=False,
             prop="erty",
         )
-        assert dn.config_name == "foo_bar_e-"
+        assert dn.config_id == "foo_bar_e-"
         assert dn.scope == Scope.SCENARIO
         assert dn.id == "an_id"
         assert dn.name == "a name"

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -21,12 +21,12 @@ from taipy.core.exceptions.data_node import (
 
 class TestExcelDataNode:
     def test_new_excel_data_node_with_existing_file_is_ready_for_reading(self):
-        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_name", "excel", path="NOT_EXISTING.csv")
+        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_id", "excel", path="NOT_EXISTING.csv")
         not_ready_dn = DataManager.get_or_create(not_ready_dn_cfg)
         assert not not_ready_dn.is_ready_for_reading
 
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.xlsx")
-        ready_dn_cfg = Config.add_data_node("ready_data_node_config_name", "excel", path=path)
+        ready_dn_cfg = Config.add_data_node("ready_data_node_config_id", "excel", path=path)
         ready_dn = DataManager.get_or_create(ready_dn_cfg)
         assert ready_dn.is_ready_for_reading
 
@@ -41,7 +41,7 @@ class TestExcelDataNode:
         )
         assert isinstance(dn, ExcelDataNode)
         assert dn.storage_type() == "excel"
-        assert dn.config_name == "foo_bar"
+        assert dn.config_id == "foo_bar"
         assert dn.name == "super name"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None

--- a/tests/core/data/test_filter_data_node.py
+++ b/tests/core/data/test_filter_data_node.py
@@ -11,8 +11,8 @@ class FakeDataframeDataNode(DataNode):
     COLUMN_NAME_1 = "a"
     COLUMN_NAME_2 = "b"
 
-    def __init__(self, config_name, default_data_frame, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, default_data_frame, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = default_data_frame
 
     def _read(self):
@@ -26,8 +26,8 @@ class CustomClass:
 
 
 class FakeCustomDataNode(DataNode):
-    def __init__(self, config_name, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = [CustomClass(i, i * 2) for i in range(10)]
 
     def _read(self):
@@ -35,8 +35,8 @@ class FakeCustomDataNode(DataNode):
 
 
 class FakeMultiSheetExcelDataFrameDataNode(DataNode):
-    def __init__(self, config_name, default_data_frame, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, default_data_frame, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = {
             "Sheet1": default_data_frame,
             "Sheet2": default_data_frame,
@@ -47,8 +47,8 @@ class FakeMultiSheetExcelDataFrameDataNode(DataNode):
 
 
 class FakeMultiSheetExcelCustomDataNode(DataNode):
-    def __init__(self, config_name, **kwargs):
-        super().__init__(config_name, **kwargs)
+    def __init__(self, config_id, **kwargs):
+        super().__init__(config_id, **kwargs)
         self.data = {
             "Sheet1": [CustomClass(i, i * 2) for i in range(10)],
             "Sheet2": [CustomClass(i, i * 2) for i in range(10)],

--- a/tests/core/data/test_generic_data_node.py
+++ b/tests/core/data/test_generic_data_node.py
@@ -9,16 +9,19 @@ from taipy.core.exceptions.data_node import MissingReadFunction, MissingRequired
 def read_fct():
     return TestGenericDataNode.data
 
+
 def read_fct_with_params(inp):
-    return [i + inp for i in TestGenericDataNode.data] 
+    return [i + inp for i in TestGenericDataNode.data]
+
 
 def write_fct(data):
     data.append(data[-1] + 1)
 
+
 def write_fct_with_params(data, inp):
     for i in range(inp):
         data.append(data[-1] + 1)
-    
+
 
 class TestGenericDataNode:
     data = [i for i in range(10)]
@@ -30,7 +33,7 @@ class TestGenericDataNode:
         )
         assert isinstance(dn, GenericDataNode)
         assert dn.storage_type() == "generic"
-        assert dn.config_name == "foo_bar"
+        assert dn.config_id == "foo_bar"
         assert dn.name == "super name"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None
@@ -40,13 +43,11 @@ class TestGenericDataNode:
         assert dn.is_ready_for_reading
         assert dn.properties["read_fct"] == read_fct
         assert dn.properties["write_fct"] == write_fct
-        
-        dn_1 = GenericDataNode(
-            "fOo", Scope.PIPELINE, name="foo", properties={"read_fct": read_fct, "write_fct": None}
-        )
+
+        dn_1 = GenericDataNode("fOo", Scope.PIPELINE, name="foo", properties={"read_fct": read_fct, "write_fct": None})
         assert isinstance(dn, GenericDataNode)
         assert dn_1.storage_type() == "generic"
-        assert dn_1.config_name == "foo"
+        assert dn_1.config_id == "foo"
         assert dn_1.name == "foo"
         assert dn_1.scope == Scope.PIPELINE
         assert dn_1.id is not None
@@ -55,14 +56,12 @@ class TestGenericDataNode:
         assert dn_1.job_ids == []
         assert dn_1.is_ready_for_reading
         assert dn_1.properties["read_fct"] == read_fct
-        assert dn_1.properties["write_fct"] == None
-        
-        dn_2 = GenericDataNode(
-            "xyz", Scope.PIPELINE, name="xyz", properties={"read_fct": None, "write_fct": write_fct}
-        )
+        assert dn_1.properties["write_fct"] is None
+
+        dn_2 = GenericDataNode("xyz", Scope.PIPELINE, name="xyz", properties={"read_fct": None, "write_fct": write_fct})
         assert isinstance(dn, GenericDataNode)
         assert dn_2.storage_type() == "generic"
-        assert dn_2.config_name == "xyz"
+        assert dn_2.config_id == "xyz"
         assert dn_2.name == "xyz"
         assert dn_2.scope == Scope.PIPELINE
         assert dn_2.id is not None
@@ -70,7 +69,7 @@ class TestGenericDataNode:
         assert dn_2.last_edition_date is not None
         assert dn_2.job_ids == []
         assert dn_2.is_ready_for_reading
-        assert dn_2.properties["read_fct"] == None
+        assert dn_2.properties["read_fct"] is None
         assert dn_2.properties["write_fct"] == write_fct
 
     def test_create_with_missing_parameters(self):
@@ -93,33 +92,41 @@ class TestGenericDataNode:
         generic_dn.write(self.data)
         assert generic_dn.read() == self.data
         assert len(generic_dn.read()) == 11
-        
+
         generic_dn_1 = GenericDataNode("bar", Scope.PIPELINE, properties={"read_fct": read_fct, "write_fct": None})
-        
+
         assert generic_dn_1.read() == self.data
         assert len(generic_dn_1.read()) == 11
-        
+
         with pytest.raises(MissingWriteFunction):
             generic_dn_1.write(self.data)
-            
+
         generic_dn_2 = GenericDataNode("xyz", Scope.PIPELINE, properties={"read_fct": None, "write_fct": write_fct})
-        
+
         generic_dn_2.write(self.data)
         assert len(self.data) == 12
-        
+
         with pytest.raises(MissingReadFunction):
             generic_dn_2.read()
-        
+
         generic_dn_3 = GenericDataNode("bar", Scope.PIPELINE, properties={"read_fct": None, "write_fct": None})
-        
+
         with pytest.raises(MissingReadFunction):
             generic_dn_3.read()
         with pytest.raises(MissingWriteFunction):
             generic_dn_3.write(self.data)
-        
-        
+
     def test_read_write_generic_datanode_with_parameters(self):
-        generic_dn = GenericDataNode("foo", Scope.PIPELINE, properties={"read_fct": read_fct_with_params, "write_fct": write_fct_with_params, "read_fct_params": {"inp": 1}, "write_fct_params": {"inp": 2}})
+        generic_dn = GenericDataNode(
+            "foo",
+            Scope.PIPELINE,
+            properties={
+                "read_fct": read_fct_with_params,
+                "write_fct": write_fct_with_params,
+                "read_fct_params": {"inp": 1},
+                "write_fct_params": {"inp": 2},
+            },
+        )
 
         assert all([a + 1 == b for a, b in zip(self.data, generic_dn.read())])
         assert len(generic_dn.read()) == 12

--- a/tests/core/data/test_in_memory_data_node.py
+++ b/tests/core/data/test_in_memory_data_node.py
@@ -18,7 +18,7 @@ class TestInMemoryDataNodeEntity:
         )
         assert isinstance(dn, InMemoryDataNode)
         assert dn.storage_type() == "in_memory"
-        assert dn.config_name == "foobar_bazy"
+        assert dn.config_id == "foobar_bazy"
         assert dn.scope == Scope.SCENARIO
         assert dn.id == "id_uio"
         assert dn.name == "my name"

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -25,7 +25,7 @@ class TestPickleDataNodeEntity:
         assert os.path.isfile(Config.global_config.storage_folder + "pickles/" + dn.id + ".p")
         assert isinstance(dn, PickleDataNode)
         assert dn.storage_type() == "pickle"
-        assert dn.config_name == "foobar_bazxyxea"
+        assert dn.config_id == "foobar_bazxyxea"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None
         assert dn.name == dn.id
@@ -38,12 +38,12 @@ class TestPickleDataNodeEntity:
         assert dn.job_ids == []
 
     def test_new_pickle_data_node_with_existing_file_is_ready_for_reading(self):
-        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_name", "pickle", path="NOT_EXISTING.p")
+        not_ready_dn_cfg = Config.add_data_node("not_ready_data_node_config_id", "pickle", path="NOT_EXISTING.p")
         not_ready_dn = DataManager.get_or_create(not_ready_dn_cfg)
         assert not not_ready_dn.is_ready_for_reading
 
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.p")
-        ready_dn_cfg = Config.add_data_node("ready_data_node_config_name", "pickle", path=path)
+        ready_dn_cfg = Config.add_data_node("ready_data_node_config_id", "pickle", path=path)
         ready_dn = DataManager.get_or_create(ready_dn_cfg)
         assert ready_dn.is_ready_for_reading
 

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -40,7 +40,7 @@ class TestSQLDataNode:
         )
         assert isinstance(dn, SQLDataNode)
         assert dn.storage_type() == "sql"
-        assert dn.config_name == "foo_bar"
+        assert dn.config_id == "foo_bar"
         assert dn.scope == Scope.PIPELINE
         assert dn.id is not None
         assert dn.parent_id is None

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -22,7 +22,7 @@ def task_id():
 
 @pytest.fixture
 def task(task_id):
-    return Task(config_name="name", function=print, input=[], output=[], id=task_id)
+    return Task(config_id="name", function=print, input=[], output=[], id=task_id)
 
 
 @pytest.fixture
@@ -110,7 +110,7 @@ def test_notification_job(job):
 
 
 def test_handle_exception_in_user_function(task_id, job_id):
-    task = Task(config_name="name", input=[], function=_error, output=[], id=task_id)
+    task = Task(config_id="name", input=[], function=_error, output=[], id=task_id)
     job = Job(job_id, task)
 
     _dispatch(task, job)
@@ -124,7 +124,7 @@ def test_handle_exception_in_user_function(task_id, job_id):
 
 def test_handle_exception_in_input_data_node(task_id, job_id):
     data_node = InMemoryDataNode("data_node", scope=Scope.SCENARIO)
-    task = Task(config_name="name", input=[data_node], function=print, output=[], id=task_id)
+    task = Task(config_id="name", input=[data_node], function=print, output=[], id=task_id)
     job = Job(job_id, task)
 
     _dispatch(task, job)
@@ -137,7 +137,7 @@ def test_handle_exception_in_input_data_node(task_id, job_id):
 
 def test_handle_exception_in_ouptut_data_node(replace_in_memory_write_fct, task_id, job_id):
     data_node = InMemoryDataNode("data_node", scope=Scope.SCENARIO)
-    task = Task(config_name="name", input=[], function=_foo, output=[data_node], id=task_id)
+    task = Task(config_id="name", input=[], function=_foo, output=[data_node], id=task_id)
     job = Job(job_id, task)
 
     _dispatch(task, job)

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -114,17 +114,17 @@ def test_raise_when_trying_to_delete_unfinished_job():
 
 
 def _create_task(function, nb_outputs=1):
-    output_dn_config_name = str(uuid.uuid4())
+    output_dn_config_id = str(uuid.uuid4())
     input1_dn_config = Config.add_data_node("input1", "in_memory", Scope.PIPELINE, default_data=21)
     DataManager.get_or_create(input1_dn_config)
     input2_dn_config = Config.add_data_node("input2", "in_memory", Scope.PIPELINE, default_data=2)
     DataManager.get_or_create(input2_dn_config)
     output_dn_configs = [
-        Config.add_data_node(f"{output_dn_config_name}-output{i}", "pickle", Scope.PIPELINE, default_data=0)
+        Config.add_data_node(f"{output_dn_config_id}-output{i}", "pickle", Scope.PIPELINE, default_data=0)
         for i in range(nb_outputs)
     ]
     [DataManager.get_or_create(cfg) for cfg in output_dn_configs]
     task_config = Config.add_task(
-        output_dn_config_name, function, [input1_dn_config, input2_dn_config], output_dn_configs
+        output_dn_config_id, function, [input1_dn_config, input2_dn_config], output_dn_configs
     )
     return TaskManager.get_or_create(task_config)

--- a/tests/core/job/test_job_repository.py
+++ b/tests/core/job/test_job_repository.py
@@ -27,7 +27,7 @@ data_node = CSVDataNode(
     {"path": "/path", "has_header": True},
 )
 
-task = Task("config_name", print, [data_node], [], TaskId("task_id"), parent_id="parent_id")
+task = Task("config_id", print, [data_node], [], TaskId("task_id"), parent_id="parent_id")
 
 job = Job(JobId("id"), task)
 

--- a/tests/core/pipeline/test_pipeline.py
+++ b/tests/core/pipeline/test_pipeline.py
@@ -16,7 +16,7 @@ def test_create_pipeline():
     pipeline = Pipeline("nAmE 1 ", {"description": "description"}, [task])
     assert pipeline.id is not None
     assert pipeline.parent_id is None
-    assert pipeline.config_name == "name_1"
+    assert pipeline.config_id == "name_1"
     assert pipeline.description == "description"
     assert pipeline.foo == input
     assert pipeline.bar == output
@@ -31,7 +31,7 @@ def test_create_pipeline():
     pipeline_1 = Pipeline("nAmE 1 ", {"description": "description"}, [task_1], parent_id="parent_id")
     assert pipeline_1.id is not None
     assert pipeline_1.parent_id == "parent_id"
-    assert pipeline_1.config_name == "name_1"
+    assert pipeline_1.config_id == "name_1"
     assert pipeline_1.description == "description"
     assert pipeline_1.inx == input_1
     assert pipeline_1.outx == output_1
@@ -72,7 +72,7 @@ def test_check_consistency():
     assert not pipeline_4.is_consistent  # Not a Dag
 
     class FakeDataNode:
-        config_name = "config_name_of_a_fake_dn"
+        config_id = "config_id_of_a_fake_dn"
 
     input_5 = DataNode("foo", Scope.PIPELINE, "input_id_5")
     output_5 = DataNode("foo", Scope.PIPELINE, "output_id_5")

--- a/tests/core/pipeline/test_pipeline_manager.py
+++ b/tests/core/pipeline/test_pipeline_manager.py
@@ -52,10 +52,10 @@ def test_set_and_get_pipeline():
     # Save one pipeline. We expect to have only one pipeline stored
     PipelineManager.set(pipeline_1)
     assert PipelineManager.get(pipeline_id_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_id_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_id_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_id_1).tasks) == 0
     assert PipelineManager.get(pipeline_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_1).tasks) == 0
     assert PipelineManager.get(pipeline_id_2) is None
     assert PipelineManager.get(pipeline_2) is None
@@ -64,32 +64,32 @@ def test_set_and_get_pipeline():
     TaskManager.set(task_2)
     PipelineManager.set(pipeline_2)
     assert PipelineManager.get(pipeline_id_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_id_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_id_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_id_1).tasks) == 0
     assert PipelineManager.get(pipeline_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_1).tasks) == 0
     assert PipelineManager.get(pipeline_id_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_id_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_id_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_id_2).tasks) == 1
     assert PipelineManager.get(pipeline_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_2).tasks) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
 
     # We save the first pipeline again. We expect nothing to change
     PipelineManager.set(pipeline_1)
     assert PipelineManager.get(pipeline_id_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_id_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_id_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_id_1).tasks) == 0
     assert PipelineManager.get(pipeline_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_1).config_name == pipeline_1.config_name
+    assert PipelineManager.get(pipeline_1).config_id == pipeline_1.config_id
     assert len(PipelineManager.get(pipeline_1).tasks) == 0
     assert PipelineManager.get(pipeline_id_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_id_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_id_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_id_2).tasks) == 1
     assert PipelineManager.get(pipeline_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_2).tasks) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
 
@@ -97,16 +97,16 @@ def test_set_and_get_pipeline():
     # We expect the first pipeline to be updated
     PipelineManager.set(pipeline_3_with_same_id)
     assert PipelineManager.get(pipeline_id_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_id_1).config_name == pipeline_3_with_same_id.config_name
+    assert PipelineManager.get(pipeline_id_1).config_id == pipeline_3_with_same_id.config_id
     assert len(PipelineManager.get(pipeline_id_1).tasks) == 0
     assert PipelineManager.get(pipeline_1).id == pipeline_1.id
-    assert PipelineManager.get(pipeline_1).config_name == pipeline_3_with_same_id.config_name
+    assert PipelineManager.get(pipeline_1).config_id == pipeline_3_with_same_id.config_id
     assert len(PipelineManager.get(pipeline_1).tasks) == 0
     assert PipelineManager.get(pipeline_id_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_id_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_id_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_id_2).tasks) == 1
     assert PipelineManager.get(pipeline_2).id == pipeline_2.id
-    assert PipelineManager.get(pipeline_2).config_name == pipeline_2.config_name
+    assert PipelineManager.get(pipeline_2).config_id == pipeline_2.config_id
     assert len(PipelineManager.get(pipeline_2).tasks) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
 
@@ -268,8 +268,8 @@ def test_get_or_create_data():
     assert pipeline.foo.read() == 1
     assert pipeline.bar.read() == 0
     assert pipeline.baz.read() == 0
-    assert pipeline.get_sorted_tasks()[0][0].config_name == task_config_mult_by_2.name
-    assert pipeline.get_sorted_tasks()[1][0].config_name == task_config_mult_by_3.name
+    assert pipeline.get_sorted_tasks()[0][0].config_id == task_config_mult_by_2.name
+    assert pipeline.get_sorted_tasks()[1][0].config_id == task_config_mult_by_3.name
 
     PipelineManager.submit(pipeline.id)
     assert pipeline.foo.read() == 1
@@ -433,24 +433,24 @@ def test_pipeline_notification_subscribe_all():
     assert len(PipelineManager.get(other_pipeline.id).subscribers) == 1
 
 
-def test_get_all_by_config_name():
+def test_get_all_by_config_id():
     input_configs = [Config.add_data_node("my_input", "in_memory")]
     task_config_1 = Config.add_task("task_config_1", print, input_configs, [])
-    assert len(PipelineManager._get_all_by_config_name("NOT_EXISTING_CONFIG_NAME")) == 0
+    assert len(PipelineManager._get_all_by_config_id("NOT_EXISTING_CONFIG_NAME")) == 0
     pipeline_config_1 = Config.add_pipeline("foo", [task_config_1])
-    assert len(PipelineManager._get_all_by_config_name("foo")) == 0
+    assert len(PipelineManager._get_all_by_config_id("foo")) == 0
 
     PipelineManager.get_or_create(pipeline_config_1)
-    assert len(PipelineManager._get_all_by_config_name("foo")) == 1
+    assert len(PipelineManager._get_all_by_config_id("foo")) == 1
 
     pipeline_config_2 = Config.add_pipeline("baz", [task_config_1])
     PipelineManager.get_or_create(pipeline_config_2)
-    assert len(PipelineManager._get_all_by_config_name("foo")) == 1
-    assert len(PipelineManager._get_all_by_config_name("baz")) == 1
+    assert len(PipelineManager._get_all_by_config_id("foo")) == 1
+    assert len(PipelineManager._get_all_by_config_id("baz")) == 1
 
     PipelineManager.get_or_create(pipeline_config_2, "other_scenario")
-    assert len(PipelineManager._get_all_by_config_name("foo")) == 1
-    assert len(PipelineManager._get_all_by_config_name("baz")) == 2
+    assert len(PipelineManager._get_all_by_config_id("foo")) == 1
+    assert len(PipelineManager._get_all_by_config_id("baz")) == 2
 
 
 def test_do_not_recreate_existing_pipeline_except_same_config():

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -10,7 +10,7 @@ from taipy.core.task.task import Task
 def test_create_scenario(cycle, current_datetime):
     scenario_entity_1 = Scenario("fOo ", [], {"key": "value"}, is_master=True, cycle=cycle)
     assert scenario_entity_1.id is not None
-    assert scenario_entity_1.config_name == "foo"
+    assert scenario_entity_1.config_id == "foo"
     assert scenario_entity_1.pipelines == {}
     assert scenario_entity_1.properties == {"key": "value"}
     assert scenario_entity_1.key == "value"
@@ -21,7 +21,7 @@ def test_create_scenario(cycle, current_datetime):
 
     scenario_entity_2 = Scenario("   bar/ξéà   ", [], {}, ScenarioId("baz"), creation_date=current_datetime)
     assert scenario_entity_2.id == "baz"
-    assert scenario_entity_2.config_name == "bar-xea"
+    assert scenario_entity_2.config_id == "bar-xea"
     assert scenario_entity_2.pipelines == {}
     assert scenario_entity_2.properties == {}
     assert scenario_entity_2.creation_date == current_datetime
@@ -32,7 +32,7 @@ def test_create_scenario(cycle, current_datetime):
     pipeline_entity = Pipeline("qux", {}, [])
     scenario_entity_3 = Scenario("quux", [pipeline_entity], {})
     assert scenario_entity_3.id is not None
-    assert scenario_entity_3.config_name == "quux"
+    assert scenario_entity_3.config_id == "quux"
     assert len(scenario_entity_3.pipelines) == 1
     assert scenario_entity_3.qux == pipeline_entity
     assert scenario_entity_3.properties == {}
@@ -41,7 +41,7 @@ def test_create_scenario(cycle, current_datetime):
     pipeline_entity_1 = Pipeline("abcξyₓéà", {}, [])
     scenario_entity_4 = Scenario("abcx", [pipeline_entity_1], {})
     assert scenario_entity_4.id is not None
-    assert scenario_entity_4.config_name == "abcx"
+    assert scenario_entity_4.config_id == "abcx"
     assert len(scenario_entity_4.pipelines) == 1
     assert scenario_entity_4.abcxyxea == pipeline_entity_1
     assert scenario_entity_4.properties == {}

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -61,10 +61,10 @@ def test_set_and_get_scenario(cycle):
     ScenarioManager.set(scenario_1)
     assert len(ScenarioManager.get_all()) == 1
     assert ScenarioManager.get(scenario_id_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_id_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_id_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_id_1).pipelines) == 0
     assert ScenarioManager.get(scenario_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_1).pipelines) == 0
     assert ScenarioManager.get(scenario_id_2) is None
     assert ScenarioManager.get(scenario_2) is None
@@ -76,16 +76,16 @@ def test_set_and_get_scenario(cycle):
     ScenarioManager.set(scenario_2)
     assert len(ScenarioManager.get_all()) == 2
     assert ScenarioManager.get(scenario_id_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_id_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_id_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_id_1).pipelines) == 0
     assert ScenarioManager.get(scenario_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_1).pipelines) == 0
     assert ScenarioManager.get(scenario_id_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_id_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_id_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_id_2).pipelines) == 1
     assert ScenarioManager.get(scenario_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_2).pipelines) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
     assert ScenarioManager.get(scenario_id_2).cycle == cycle
@@ -96,16 +96,16 @@ def test_set_and_get_scenario(cycle):
     ScenarioManager.set(scenario_1)
     assert len(ScenarioManager.get_all()) == 2
     assert ScenarioManager.get(scenario_id_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_id_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_id_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_id_1).pipelines) == 0
     assert ScenarioManager.get(scenario_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_1).config_name == scenario_1.config_name
+    assert ScenarioManager.get(scenario_1).config_id == scenario_1.config_id
     assert len(ScenarioManager.get(scenario_1).pipelines) == 0
     assert ScenarioManager.get(scenario_id_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_id_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_id_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_id_2).pipelines) == 1
     assert ScenarioManager.get(scenario_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_2).pipelines) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
     assert CycleManager.get(cycle.id).id == cycle.id
@@ -117,18 +117,18 @@ def test_set_and_get_scenario(cycle):
     ScenarioManager.set(scenario_3_with_same_id)
     assert len(ScenarioManager.get_all()) == 2
     assert ScenarioManager.get(scenario_id_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_id_1).config_name == scenario_3_with_same_id.config_name
+    assert ScenarioManager.get(scenario_id_1).config_id == scenario_3_with_same_id.config_id
     assert len(ScenarioManager.get(scenario_id_1).pipelines) == 1
     assert ScenarioManager.get(scenario_id_1).cycle == cycle
     assert ScenarioManager.get(scenario_1).id == scenario_1.id
-    assert ScenarioManager.get(scenario_1).config_name == scenario_3_with_same_id.config_name
+    assert ScenarioManager.get(scenario_1).config_id == scenario_3_with_same_id.config_id
     assert len(ScenarioManager.get(scenario_1).pipelines) == 1
     assert ScenarioManager.get(scenario_1).cycle == cycle
     assert ScenarioManager.get(scenario_id_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_id_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_id_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_id_2).pipelines) == 1
     assert ScenarioManager.get(scenario_2).id == scenario_2.id
-    assert ScenarioManager.get(scenario_2).config_name == scenario_2.config_name
+    assert ScenarioManager.get(scenario_2).config_id == scenario_2.config_id
     assert len(ScenarioManager.get(scenario_2).pipelines) == 1
     assert TaskManager.get(task_2.id).id == task_2.id
 
@@ -165,7 +165,7 @@ def test_create_and_delete_scenario():
     scenario_config = Config.add_scenario("sc", [], Frequency.DAILY)
 
     scenario_1 = ScenarioManager.create(scenario_config, creation_date=creation_date_1, display_name=display_name_1)
-    assert scenario_1.config_name == "sc"
+    assert scenario_1.config_id == "sc"
     assert scenario_1.pipelines == {}
     assert scenario_1.cycle.frequency == Frequency.DAILY
     assert scenario_1.is_master
@@ -181,7 +181,7 @@ def test_create_and_delete_scenario():
         ScenarioManager.delete(scenario_1.id)
 
     scenario_2 = ScenarioManager.create(scenario_config, creation_date=creation_date_2)
-    assert scenario_2.config_name == "sc"
+    assert scenario_2.config_id == "sc"
     assert scenario_2.pipelines == {}
     assert scenario_2.cycle.frequency == Frequency.DAILY
     assert not scenario_2.is_master
@@ -245,9 +245,9 @@ def test_scenario_manager_only_creates_data_node_once():
     assert scenario.bar.read() == 0
     assert scenario.baz.read() == 0
     assert scenario.qux.read() == 0
-    assert scenario.by_6.get_sorted_tasks()[0][0].config_name == task_mult_by_2_config.name
-    assert scenario.by_6.get_sorted_tasks()[1][0].config_name == task_mult_by_3_config.name
-    assert scenario.by_4.get_sorted_tasks()[0][0].config_name == task_mult_by_4_config.name
+    assert scenario.by_6.get_sorted_tasks()[0][0].config_id == task_mult_by_2_config.name
+    assert scenario.by_6.get_sorted_tasks()[1][0].config_id == task_mult_by_3_config.name
+    assert scenario.by_4.get_sorted_tasks()[0][0].config_id == task_mult_by_4_config.name
     assert scenario.cycle.frequency == Frequency.DAILY
 
 
@@ -658,19 +658,19 @@ def test_scenarios_comparison():
     scenario_2 = ScenarioManager.create(scenario_config)
 
     with pytest.raises(InsufficientScenarioToCompare):
-        ScenarioManager.compare(scenario_1, data_node_config_name="bar")
+        ScenarioManager.compare(scenario_1, data_node_config_id="bar")
 
     scenario_3 = Scenario("awesome_scenario_config", [], {})
     with pytest.raises(DifferentScenarioConfigs):
-        ScenarioManager.compare(scenario_1, scenario_3, data_node_config_name="bar")
+        ScenarioManager.compare(scenario_1, scenario_3, data_node_config_id="bar")
 
     ScenarioManager.submit(scenario_1.id)
     ScenarioManager.submit(scenario_2.id)
 
-    bar_comparison = ScenarioManager.compare(scenario_1, scenario_2, data_node_config_name="bar")["bar"]
+    bar_comparison = ScenarioManager.compare(scenario_1, scenario_2, data_node_config_id="bar")["bar"]
     assert bar_comparison["subtraction"] == 0
 
-    foo_comparison = ScenarioManager.compare(scenario_1, scenario_2, data_node_config_name="foo")["foo"]
+    foo_comparison = ScenarioManager.compare(scenario_1, scenario_2, data_node_config_id="foo")["foo"]
     assert len(foo_comparison.keys()) == 2
     assert foo_comparison["addition"] == 2
     assert foo_comparison["subtraction"] == 0
@@ -681,7 +681,7 @@ def test_scenarios_comparison():
         ScenarioManager.compare(scenario_3, scenario_3)
 
     with pytest.raises(NonExistingComparator):
-        ScenarioManager.compare(scenario_1, scenario_2, data_node_config_name="abc")
+        ScenarioManager.compare(scenario_1, scenario_2, data_node_config_id="abc")
 
 
 def test_automatic_reload():

--- a/tests/core/scheduler/test_job_dispatcher.py
+++ b/tests/core/scheduler/test_job_dispatcher.py
@@ -40,7 +40,7 @@ def test_can_execute_synchronous():
 
     task_id = TaskId("task_id1")
     task = Task(
-        config_name="name",
+        config_id="name",
         input=[],
         function=partial(execute, lock),
         output=[DataManager.get_or_create(Config.add_data_node("input1", default_data=21))],
@@ -66,7 +66,7 @@ def test_can_execute_parallel_multiple_submit():
     lock = m.Lock()
 
     task_id = TaskId("task_id1")
-    task = Task(config_name="name", input=[], function=partial(execute, lock), output=[], id=task_id)
+    task = Task(config_id="name", input=[], function=partial(execute, lock), output=[], id=task_id)
     job_id = JobId("id1")
     job = Job(job_id, task)
 
@@ -80,7 +80,7 @@ def test_can_execute_parallel_multiple_submit():
 
 def test_can_execute_synchronous_2():
     task_id = TaskId("task_id1")
-    task = Task(config_name="name", input=[], function=print, output=[], id=task_id)
+    task = Task(config_id="name", input=[], function=print, output=[], id=task_id)
     job_id = JobId("id1")
     job = Job(job_id, task)
 
@@ -94,7 +94,7 @@ def test_can_execute_synchronous_2():
 def test_handle_exception_in_user_function():
     task_id = TaskId("task_id1")
     job_id = JobId("id1")
-    task = Task(config_name="name", input=[], function=_error, output=[], id=task_id)
+    task = Task(config_id="name", input=[], function=_error, output=[], id=task_id)
     job = Job(job_id, task)
 
     executor = JobDispatcher(None)
@@ -108,10 +108,10 @@ def test_handle_exception_when_writing_datanode():
     job_id = JobId("id1")
     output = MagicMock()
     output.id = DataNodeId("output_id")
-    output.config_name = "my_raising_datanode"
+    output.config_id = "my_raising_datanode"
     output.is_in_cache = False
     output.write.side_effect = ValueError()
-    task = Task(config_name="name", input=[], function=print, output=[output], id=task_id)
+    task = Task(config_id="name", input=[], function=print, output=[output], id=task_id)
     job = Job(job_id, task)
 
     dispatcher = JobDispatcher(None)

--- a/tests/core/scheduler/test_scheduler.py
+++ b/tests/core/scheduler/test_scheduler.py
@@ -48,7 +48,7 @@ def test_submit_task():
     before_creation = datetime.now()
     sleep(0.1)
     task = _create_task(multiply)
-    output_dn_id = task.output[f"{task.config_name}-output0"].id
+    output_dn_id = task.output[f"{task.config_id}-output0"].id
 
     assert DataManager.get(output_dn_id).last_edition_date > before_creation
     assert DataManager.get(output_dn_id).job_ids == []
@@ -83,13 +83,13 @@ def test_submit_task_that_return_multiple_outputs():
     scheduler.submit_task(with_list)
 
     assert (
-        with_tuple.output[f"{with_tuple.config_name}-output0"].read()
-        == with_list.output[f"{with_list.config_name}-output0"].read()
+        with_tuple.output[f"{with_tuple.config_id}-output0"].read()
+        == with_list.output[f"{with_list.config_id}-output0"].read()
         == 42
     )
     assert (
-        with_tuple.output[f"{with_tuple.config_name}-output1"].read()
-        == with_list.output[f"{with_list.config_name}-output1"].read()
+        with_tuple.output[f"{with_tuple.config_id}-output1"].read()
+        == with_list.output[f"{with_list.config_id}-output1"].read()
         == 21
     )
 
@@ -106,9 +106,9 @@ def test_submit_task_returns_single_iterable_output():
     task_with_list = _create_task(return_list, 1)
 
     scheduler.submit_task(task_with_tuple)
-    assert task_with_tuple.output[f"{task_with_tuple.config_name}-output0"].read() == (42, 21)
+    assert task_with_tuple.output[f"{task_with_tuple.config_id}-output0"].read() == (42, 21)
     scheduler.submit_task(task_with_list)
-    assert task_with_list.output[f"{task_with_list.config_name}-output0"].read() == [42, 21]
+    assert task_with_list.output[f"{task_with_list.config_id}-output0"].read() == [42, 21]
 
 
 def test_data_node_not_written_due_to_wrong_result_nb():
@@ -119,7 +119,7 @@ def test_data_node_not_written_due_to_wrong_result_nb():
     task = _create_task(return_2tuple(), 3)
 
     job = scheduler.submit_task(task)
-    assert task.output[f"{task.config_name}-output0"].read() == 0
+    assert task.output[f"{task.config_id}-output0"].read() == 0
     assert job.is_failed()
 
 
@@ -132,7 +132,7 @@ def test_submit_task_in_parallel():
 
     with lock:
         job = scheduler.submit_task(task)
-        assert task.output[f"{task.config_name}-output0"].read() == 0
+        assert task.output[f"{task.config_id}-output0"].read() == 0
         assert job.is_running()
 
     assert_true_after_20_second_max(job.is_completed)
@@ -153,19 +153,19 @@ def test_submit_task_multithreading_multiple_task():
             job_1 = scheduler.submit_task(task_1)
             job_2 = scheduler.submit_task(task_2)
 
-            assert task_1.output[f"{task_1.config_name}-output0"].read() == 0
-            assert task_2.output[f"{task_2.config_name}-output0"].read() == 0
+            assert task_1.output[f"{task_1.config_id}-output0"].read() == 0
+            assert task_2.output[f"{task_2.config_id}-output0"].read() == 0
             assert job_1.is_running()
             assert job_2.is_running()
 
-        assert_true_after_20_second_max(lambda: task_2.output[f"{task_2.config_name}-output0"].read() == 42)
-        assert task_1.output[f"{task_1.config_name}-output0"].read() == 0
+        assert_true_after_20_second_max(lambda: task_2.output[f"{task_2.config_id}-output0"].read() == 42)
+        assert task_1.output[f"{task_1.config_id}-output0"].read() == 0
         assert_true_after_20_second_max(job_2.is_completed)
         assert job_1.is_running()
         assert job_2.is_completed()
 
-    assert_true_after_20_second_max(lambda: task_1.output[f"{task_1.config_name}-output0"].read() == 42)
-    assert task_2.output[f"{task_2.config_name}-output0"].read() == 42
+    assert_true_after_20_second_max(lambda: task_1.output[f"{task_1.config_id}-output0"].read() == 42)
+    assert task_2.output[f"{task_2.config_id}-output0"].read() == 42
     assert_true_after_20_second_max(job_1.is_completed)
     assert job_2.is_completed()
 
@@ -189,18 +189,18 @@ def test_submit_task_multithreading_multiple_task_in_sync_way_to_check_job_statu
                 job_1 = scheduler.submit_task(task_2)
                 job_2 = scheduler.submit_task(task_1)
 
-                assert task_1.output[f"{task_1.config_name}-output0"].read() == 0
-                assert task_2.output[f"{task_2.config_name}-output0"].read() == 0
+                assert task_1.output[f"{task_1.config_id}-output0"].read() == 0
+                assert task_2.output[f"{task_2.config_id}-output0"].read() == 0
                 assert job_1.is_running()
                 assert job_2.is_pending()
 
-            assert_true_after_20_second_max(lambda: task_2.output[f"{task_2.config_name}-output0"].read() == 42)
-            assert task_1.output[f"{task_1.config_name}-output0"].read() == 0
+            assert_true_after_20_second_max(lambda: task_2.output[f"{task_2.config_id}-output0"].read() == 42)
+            assert task_1.output[f"{task_1.config_id}-output0"].read() == 0
             assert_true_after_20_second_max(job_1.is_completed)
             assert job_2.is_running()
 
-    assert_true_after_20_second_max(lambda: task_1.output[f"{task_1.config_name}-output0"].read() == 42)
-    assert task_2.output[f"{task_2.config_name}-output0"].read() == 42
+    assert_true_after_20_second_max(lambda: task_1.output[f"{task_1.config_id}-output0"].read() == 42)
+    assert task_2.output[f"{task_2.config_id}-output0"].read() == 42
     assert job_1.is_completed()
     assert_true_after_20_second_max(job_2.is_completed)
 
@@ -263,20 +263,20 @@ def test_task_scheduler_create_parallel_dispatcher():
 
 
 def _create_task(function, nb_outputs=1):
-    output_dn_config_name = str(uuid.uuid4())
+    output_dn_config_id = str(uuid.uuid4())
     input_dn = [
         DataManager.get_or_create(Config.add_data_node("input1", "pickle", Scope.PIPELINE, default_data=21)),
         DataManager.get_or_create(Config.add_data_node("input2", "pickle", Scope.PIPELINE, default_data=2)),
     ]
     output_dn = [
         DataManager.get_or_create(
-            Config.add_data_node(f"{output_dn_config_name}-output{i}", "pickle", Scope.PIPELINE, default_data=0)
+            Config.add_data_node(f"{output_dn_config_id}-output{i}", "pickle", Scope.PIPELINE, default_data=0)
         )
         for i in range(nb_outputs)
     ]
 
     return Task(
-        output_dn_config_name,
+        output_dn_config_id,
         function=function,
         input=input_dn,
         output=output_dn,

--- a/tests/core/task/test_task.py
+++ b/tests/core/task/test_task.py
@@ -33,16 +33,16 @@ def test_create_task():
     name = "name_1"
     task = Task(name, print, [], [])
     assert f"TASK_{name}_" in task.id
-    assert task.config_name == "name_1"
+    assert task.config_id == "name_1"
 
     name_1 = "name_1//ξ"
     task_1 = Task(name_1, print, [], [])
-    assert task_1.config_name == "name_1-x"
+    assert task_1.config_id == "name_1-x"
 
     path = "my/csv/path"
     foo_dn = CSVDataNode("foo", Scope.PIPELINE, properties={"path": path, "has_header": True})
     task = Task("namE 1", print, [foo_dn], [])
-    assert task.config_name == "name_1"
+    assert task.config_id == "name_1"
     assert task.id is not None
     assert task.parent_id is None
     assert task.foo == foo_dn
@@ -53,7 +53,7 @@ def test_create_task():
     path = "my/csv/path"
     abc_dn = InMemoryDataNode("abc_dsξyₓéà", Scope.SCENARIO, properties={"path": path})
     task = Task("namE 1éà", print, [abc_dn], [], parent_id="parent_id")
-    assert task.config_name == "name_1ea"
+    assert task.config_id == "name_1ea"
     assert task.id is not None
     assert task.parent_id == "parent_id"
     assert task.abc_dsxyxea == abc_dn

--- a/tests/core/task/test_task_manager.py
+++ b/tests/core/task/test_task_manager.py
@@ -16,23 +16,23 @@ def test_create_and_save():
     task_config = Config.add_task("foo", print, input_configs, output_configs)
     task = TaskManager.get_or_create(task_config)
     assert task.id is not None
-    assert task.config_name == "foo"
+    assert task.config_id == "foo"
     assert len(task.input) == 1
     assert len(DataManager.get_all()) == 2
     assert task.my_input.id is not None
-    assert task.my_input.config_name == "my_input"
+    assert task.my_input.config_id == "my_input"
     assert task.my_output.id is not None
-    assert task.my_output.config_name == "my_output"
+    assert task.my_output.config_id == "my_output"
     assert task.function == print
 
     task_retrieved_from_manager = TaskManager.get(task.id)
     assert task_retrieved_from_manager.id == task.id
-    assert task_retrieved_from_manager.config_name == task.config_name
+    assert task_retrieved_from_manager.config_id == task.config_id
     assert len(task_retrieved_from_manager.input) == len(task.input)
     assert task_retrieved_from_manager.my_input.id is not None
-    assert task_retrieved_from_manager.my_input.config_name == task.my_input.config_name
+    assert task_retrieved_from_manager.my_input.config_id == task.my_input.config_id
     assert task_retrieved_from_manager.my_output.id is not None
-    assert task_retrieved_from_manager.my_output.config_name == task.my_output.config_name
+    assert task_retrieved_from_manager.my_output.config_id == task.my_output.config_id
     assert task_retrieved_from_manager.function == task.function
 
 
@@ -160,9 +160,9 @@ def test_set_and_get_task():
     TaskManager.set(third_task_with_same_id_as_first_task)
     assert len(TaskManager.get_all()) == 2
     assert TaskManager.get(task_id_1).id == third_task_with_same_id_as_first_task.id
-    assert TaskManager.get(task_id_1).config_name != first_task.config_name
+    assert TaskManager.get(task_id_1).config_id != first_task.config_id
     assert TaskManager.get(first_task).id == third_task_with_same_id_as_first_task.id
-    assert TaskManager.get(first_task).config_name != first_task.config_name
+    assert TaskManager.get(first_task).config_id != first_task.config_id
     assert TaskManager.get(task_id_2).id == second_task.id
     assert TaskManager.get(second_task).id == second_task.id
 
@@ -180,8 +180,8 @@ def test_ensure_conservation_of_order_of_data_nodes_on_task_creation():
     task_config = Config.add_task("name_1", print, input, output)
     task = TaskManager.get_or_create(task_config)
 
-    assert [i.config_name for i in task.input.values()] == [embedded_1.name, embedded_2.name, embedded_3.name]
-    assert [o.config_name for o in task.output.values()] == [embedded_4.name, embedded_5.name]
+    assert [i.config_id for i in task.input.values()] == [embedded_1.name, embedded_2.name, embedded_3.name]
+    assert [o.config_id for o in task.output.values()] == [embedded_4.name, embedded_5.name]
 
     data_nodes = {
         embedded_1: InMemoryDataNode(embedded_1.name, Scope.PIPELINE),
@@ -194,27 +194,27 @@ def test_ensure_conservation_of_order_of_data_nodes_on_task_creation():
     task_config = Config.add_task("name_2", print, input, output)
     task = TaskManager.get_or_create(task_config, data_nodes)
 
-    assert [i.config_name for i in task.input.values()] == [embedded_1.name, embedded_2.name, embedded_3.name]
-    assert [o.config_name for o in task.output.values()] == [embedded_4.name, embedded_5.name]
+    assert [i.config_id for i in task.input.values()] == [embedded_1.name, embedded_2.name, embedded_3.name]
+    assert [o.config_id for o in task.output.values()] == [embedded_4.name, embedded_5.name]
 
 
-def test_get_all_by_config_name():
+def test_get_all_by_config_id():
     input_configs = [Config.add_data_node("my_input", "in_memory", scope=Scope.PIPELINE)]
-    assert len(TaskManager._get_all_by_config_name("NOT_EXISTING_CONFIG_NAME")) == 0
+    assert len(TaskManager._get_all_by_config_id("NOT_EXISTING_CONFIG_NAME")) == 0
     task_config_1 = Config.add_task("foo", print, input_configs, [])
-    assert len(TaskManager._get_all_by_config_name("foo")) == 0
+    assert len(TaskManager._get_all_by_config_id("foo")) == 0
 
     TaskManager.get_or_create(task_config_1)
-    assert len(TaskManager._get_all_by_config_name("foo")) == 1
+    assert len(TaskManager._get_all_by_config_id("foo")) == 1
 
     task_config_2 = Config.add_task("baz", print, input_configs, [])
     TaskManager.get_or_create(task_config_2)
-    assert len(TaskManager._get_all_by_config_name("foo")) == 1
-    assert len(TaskManager._get_all_by_config_name("baz")) == 1
+    assert len(TaskManager._get_all_by_config_id("foo")) == 1
+    assert len(TaskManager._get_all_by_config_id("baz")) == 1
 
     TaskManager.get_or_create(task_config_2, "other_scenario", "other_pipeline")
-    assert len(TaskManager._get_all_by_config_name("foo")) == 1
-    assert len(TaskManager._get_all_by_config_name("baz")) == 2
+    assert len(TaskManager._get_all_by_config_id("foo")) == 1
+    assert len(TaskManager._get_all_by_config_id("baz")) == 2
 
 
 def test_delete_raise_exception():

--- a/tests/core/task/test_task_repository.py
+++ b/tests/core/task/test_task_repository.py
@@ -24,12 +24,12 @@ data_node = CSVDataNode(
     {"path": "/path", "has_header": True},
 )
 
-task = Task("config_name", print, [data_node], [], TaskId("id"), parent_id="parent_id")
+task = Task("config_id", print, [data_node], [], TaskId("id"), parent_id="parent_id")
 
 task_model = TaskModel(
     id="id",
     parent_id="parent_id",
-    config_name="config_name",
+    config_id="config_id",
     input_ids=["dn_id"],
     function_name=print.__name__,
     function_module=print.__module__,

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -275,8 +275,8 @@ class TestTaipy:
 
     def test_compare_scenarios(self, scenario):
         with mock.patch("taipy.core.scenario.scenario_manager.ScenarioManager.compare") as mck:
-            tp.compare_scenarios(scenario, scenario, data_node_config_name="dn")
-            mck.assert_called_once_with(scenario, scenario, data_node_config_name="dn")
+            tp.compare_scenarios(scenario, scenario, data_node_config_id="dn")
+            mck.assert_called_once_with(scenario, scenario, data_node_config_id="dn")
 
     def test_subscribe_scenario(self, scenario):
         with mock.patch("taipy.core.scenario.scenario_manager.ScenarioManager.subscribe") as mck:
@@ -447,9 +447,9 @@ class TestTaipy:
 
     def test_clean_all_entities_with_user_pickle_files(self, pickle_file_path):
         user_pickle = PickleDataNode(
-            config_name="d1", properties={"default_data": "foo", "path": pickle_file_path}, scope=Scope.SCENARIO
+            config_id="d1", properties={"default_data": "foo", "path": pickle_file_path}, scope=Scope.SCENARIO
         )
-        generated_pickle = PickleDataNode(config_name="d2", properties={"default_data": "foo"}, scope=Scope.SCENARIO)
+        generated_pickle = PickleDataNode(config_id="d2", properties={"default_data": "foo"}, scope=Scope.SCENARIO)
 
         # File already exists so it does not write any
         assert len(DataManager.get_all()) == 1


### PR DESCRIPTION
This is the first part of the refactor, renaming all the "config_name" in entity classes to "config_id"

TODO: rename "name" inside config classes into "id"