### PR TITLE
Fix/#87 - Fix SQL Server connection string and add db_host to tp.configure_sql_data_node

### DIFF
--- a/taipy/core/data/sql.py
+++ b/taipy/core/data/sql.py
@@ -1,4 +1,5 @@
 import os
+import re
 import urllib.parse
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
@@ -79,6 +80,7 @@ class SQLDataNode(DataNode):
             properties.get("db_password"),
             properties.get("db_name"),
             properties.get("db_port", 1433),
+            properties.get("db_driver", "ODBC Driver 17 for SQL Server"),
             properties.get("path", ""),
         )
 
@@ -98,16 +100,17 @@ class SQLDataNode(DataNode):
             self.unlock_edition()
 
     @staticmethod
-    def __build_conn_string(engine, username, host, password, database, port, path) -> str:
+    def __build_conn_string(engine, username, host, password, database, port, driver, path) -> str:
         # TODO: Add support to other SQL engines, the engine value should be checked.
         if engine == "mssql":
-            return f"mssql+pyodbc://{username}:{password}@{host}:{port}/{database}?driver=ODBC+Driver+17+for+SQL+Server"
+            driver = re.sub(r"\s+", "+", driver)
+            return f"mssql+pyodbc://{username}:{password}@{host}:{port}/{database}?driver={driver}"
         elif engine == "sqlite":
             return os.path.join("sqlite:///", path, f"{database}.sqlite3")
         raise UnknownDatabaseEngine(f"Unknown engine: {engine}")
 
-    def __create_engine(self, engine, username, host, password, database, port=1433, path=""):
-        conn_str = self.__build_conn_string(engine, username, host, password, database, port, path)
+    def __create_engine(self, engine, username, host, password, database, port, driver, path):
+        conn_str = self.__build_conn_string(engine, username, host, password, database, port, driver, path)
         return create_engine(conn_str)
 
     @classmethod

--- a/taipy/core/job/_job_repository.py
+++ b/taipy/core/job/_job_repository.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List
 
 from taipy.core._repository import _FileSystemRepository
+from taipy.core.common._taipy_logger import _TaipyLogger
 from taipy.core.common._utils import _fct_to_dict, _fcts_to_dict, _load_fct
 from taipy.core.config.config import Config
 from taipy.core.exceptions.exceptions import InvalidSubscriber
@@ -12,6 +13,8 @@ from taipy.core.task._task_repository import _TaskRepository
 
 
 class _JobRepository(_FileSystemRepository[_JobModel, Job]):
+    __logger = _TaipyLogger._get_logger()
+
     def __init__(self):
         super().__init__(model=_JobModel, dir_name="jobs")
 
@@ -41,10 +44,8 @@ class _JobRepository(_FileSystemRepository[_JobModel, Job]):
         for e in model.exceptions:
             try:
                 job._exceptions.append(_load_fct(e["fct_module"], e["fct_name"])(*e["args"]))  # type:ignore
-            except Exception as ex:
-                print(f"Error while loading exception: {ex}")
-                print(e)
-                pass
+            except Exception:
+                self.__logger.error(e)
 
         return job
 

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -647,6 +647,7 @@ def configure_sql_data_node(
     write_table: str = None,
     db_port: int = 1433,
     db_host: str = "localhost",
+    db_driver: str = "ODBC Driver 17 for SQL Server",
     scope: Scope = DataNodeConfig._DEFAULT_SCOPE,
     **properties,
 ):
@@ -663,6 +664,7 @@ def configure_sql_data_node(
         write_table (str): The name of the table in the database to write the data to.
         db_port (int): The database port. The default value is 1433.
         db_host (str): The database host. The default value is 'localhost'.
+        db_driver (str): The database driver. The default value is 'ODBC Driver 17 for SQL Server'.
         scope (`Scope`): The scope of the SQL data node configuration. The default value is Scope.SCENARIO.
         **properties (Dict[str, Any]): The variable length keyword arguments.
     Returns:
@@ -677,6 +679,7 @@ def configure_sql_data_node(
         db_name=db_name,
         db_host=db_host,
         db_engine=db_engine,
+        db_driver=db_driver,
         read_query=read_query,
         write_table=write_table,
         db_port=db_port,

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -100,7 +100,7 @@ class TestTaipy:
             mck.assert_called_once_with(a, "pickle", scope=c, default_data=b, path=d)
 
     def test_configure_sql_data_node(self):
-        a, b, c, d, e, f, g, h, i, j, k = (
+        a, b, c, d, e, f, g, h, i, j, scope, k = (
             "foo",
             "user",
             "pwd",
@@ -110,15 +110,16 @@ class TestTaipy:
             "write",
             "port",
             "host",
+            "driver",
             Scope.PIPELINE,
             "qux",
         )
         with mock.patch("taipy.core.config.config.Config._add_data_node") as mck:
-            tp.configure_sql_data_node(a, b, c, d, e, f, g, h, i, j, property=k)
+            tp.configure_sql_data_node(a, b, c, d, e, f, g, h, i, j, scope=scope, property=k)
             mck.assert_called_once_with(
                 a,
                 "sql",
-                scope=j,
+                scope=scope,
                 db_username=b,
                 db_password=c,
                 db_name=d,
@@ -127,6 +128,7 @@ class TestTaipy:
                 write_table=g,
                 db_port=h,
                 db_host=i,
+                db_driver=j,
                 property=k,
             )
 


### PR DESCRIPTION
## 1. Fix database connection string for SQL Server
Changes: 
- Add default driver when configuring mssql data node.
- Exposing db_host in tp.configure_sql_data_node

I haven't expose default driver in the above function yet in this PR. The problem is, we are having too many parameters which is not needed by some databases (e.g: we don't need port, user, password for sqlite but it is available in the param). Additionally, we can only have one default value for each parameter, for example, current default port is 1433, which is only the default for mssql. It is inconvenient for user to configure the values if they use other database such as MySQL where the default port is 3306.

Another issue is that we have to pass in all the database configuration for every SQL data node, even if we use 1 database only.

Suggested change: (need a ticket for this)

- Create classes to hold database configuration with only the needed parameters and have the default values specific to each database. For example: SQLServerConfig, MySQLConfig, SQLiteConfig, etc.

- In the tp.configure_sql_data_node, remove all the database config related parameters and add a parameter called "db_config", which takes in the database configuration object.

- The build connection string method in SQL data node should check the instance of database configuration, then build the appropriate string.

## 2. Exception deserialization
Changes:
- Skip if the exception cannot be deserialized.

The problem is that when we serialize an exception "e", e.args can return less arguments than how much it takes to build an exception from the constructor. When I debug the problem in this ticket, I found out the sqlalchemy.exc.InterfaceError exception object only return 1 argument but the constructor requires 3 arguments so it raises an error. 

We need to discuss a way to deserialize the exception, if it is not possible, then I would suggest that saving the exception message is enough. (need a ticket for this)
