### PR TITLE
Fix/#90 - Fix sql data node writing error

### DIFF
--- a/taipy/core/data/sql.py
+++ b/taipy/core/data/sql.py
@@ -126,7 +126,7 @@ class SQLDataNode(DataNode):
 
     def _read_as(self, query, custom_class):
         with self.__engine.connect() as connection:
-            query_result = connection.dispatch(text(query))
+            query_result = connection.execute(text(query))
         return list(map(lambda row: custom_class(**row), query_result))
 
     def _read_as_numpy(self):
@@ -179,7 +179,7 @@ class SQLDataNode(DataNode):
                 markers = markers
                 ins = "INSERT INTO {tablename} VALUES {markers}"
                 ins = ins.format(tablename=write_table.name, markers=markers)
-                connection.dispatch(ins, list(data))
+                connection.execute(ins, list(data))
             except:
                 transaction.rollback()
                 raise
@@ -204,7 +204,7 @@ class SQLDataNode(DataNode):
                 ins = "INSERT INTO {tablename} VALUES ({markers})"
                 ins = ins.format(tablename=write_table.name, markers=markers)
 
-                connection.dispatch(ins, data)
+                connection.execute(ins, data)
             except:
                 transaction.rollback()
                 raise
@@ -223,7 +223,7 @@ class SQLDataNode(DataNode):
         """
         with connection.begin() as transaction:
             try:
-                connection.dispatch(write_table.insert(), data)
+                connection.execute(write_table.insert(), data)
             except:
                 transaction.rollback()
                 raise

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -135,7 +135,7 @@ class TestSQLDataNode:
 
         with mock.patch("sqlalchemy.engine.Engine.connect") as engine_mock:
             cursor_mock = engine_mock.return_value.__enter__.return_value
-            cursor_mock.dispatch.return_value = [
+            cursor_mock.execute.return_value = [
                 {"foo": "baz", "bar": "qux"},
                 {"foo": "quux", "bar": "quuz"},
                 {"foo": "corge"},
@@ -171,7 +171,7 @@ class TestSQLDataNode:
 
         with mock.patch("sqlalchemy.engine.Engine.connect") as engine_mock:
             cursor_mock = engine_mock.return_value.__enter__.return_value
-            cursor_mock.dispatch.return_value = []
+            cursor_mock.execute.return_value = []
             data_2 = sql_data_node._read_as("fake query", MyCustomObject)
         assert isinstance(data_2, list)
         assert len(data_2) == 0
@@ -216,6 +216,6 @@ class TestSQLDataNode:
 
         with mock.patch("sqlalchemy.engine.Engine.connect") as engine_mock:
             cursor_mock = engine_mock.return_value.__enter__.return_value
-            cursor_mock.dispatch.side_effect = None
+            cursor_mock.execute.side_effect = None
             dn._write(data)
             dn2._write(data)


### PR DESCRIPTION
Use connection.execute instead of connection.dispatch. The error does not occur in the piece of code that @FlorianJacta sent anymore.

I cannot find any documentation about the dispatch method. Maybe it is deprecated?

https://stackoverflow.com/questions/26141183/insert-a-list-of-dictionary-using-sqlalchemy-efficiently