### PR TITLE
Feature/#105 exception serialization

### DIFF
--- a/taipy/core/job/_job_model.py
+++ b/taipy/core/job/_job_model.py
@@ -14,7 +14,6 @@ class _JobModel:
     force: bool
     creation_date: str
     subscribers: List[Dict]
-    exceptions: List[Dict]
     stacktrace: List[str]
 
     def to_dict(self) -> Dict[str, Any]:
@@ -29,6 +28,5 @@ class _JobModel:
             force=data["force"],
             creation_date=data["creation_date"],
             subscribers=data["subscribers"],
-            exceptions=data["exceptions"],
             stacktrace=data["stacktrace"],
         )

--- a/taipy/core/job/_job_repository.py
+++ b/taipy/core/job/_job_repository.py
@@ -1,11 +1,10 @@
 import pathlib
-import traceback
 from datetime import datetime
 from typing import List
 
 from taipy.core._repository import _FileSystemRepository
 from taipy.core.common._taipy_logger import _TaipyLogger
-from taipy.core.common._utils import _fct_to_dict, _fcts_to_dict, _load_fct
+from taipy.core.common._utils import _fcts_to_dict, _load_fct
 from taipy.core.config.config import Config
 from taipy.core.exceptions.exceptions import InvalidSubscriber
 from taipy.core.job._job_model import _JobModel
@@ -27,8 +26,7 @@ class _JobRepository(_FileSystemRepository[_JobModel, Job]):
             job._force,
             job._creation_date.isoformat(),
             self._serialize_subscribers(job._subscribers),
-            self._serialize_exceptions(job._exceptions),
-            self._get_exceptions_stacktrace(job._exceptions),
+            job._stacktrace,
         )
 
     def _from_model(self, model: _JobModel):
@@ -42,27 +40,13 @@ class _JobRepository(_FileSystemRepository[_JobModel, Job]):
                 job._subscribers.append(_load_fct(it.get("fct_module"), it.get("fct_name")))  # type:ignore
             except AttributeError:
                 raise InvalidSubscriber(f"The subscriber function {it.get('fct_name')} cannot be loaded.")
-        job._exceptions = []
         job._stacktrace = model.stacktrace
-        for e in model.exceptions:
-            try:
-                job._exceptions.append(_load_fct(e["fct_module"], e["fct_name"])(*e["args"]))  # type:ignore
-            except Exception:
-                self.__logger.error(e)
 
         return job
 
     @property
     def _storage_folder(self) -> pathlib.Path:
         return pathlib.Path(Config.global_config.storage_folder)  # type: ignore
-
-    @staticmethod
-    def _serialize_exceptions(exceptions: List) -> List:
-        return [{**_fct_to_dict(type(e)), "args": e.args} for e in exceptions]
-
-    @staticmethod
-    def _get_exceptions_stacktrace(exceptions: List) -> List:
-        return ["".join(traceback.TracebackException.from_exception(e).format()) for e in exceptions]
 
     @staticmethod
     def _serialize_subscribers(subscribers: List) -> List:

--- a/tests/core/job/test_job.py
+++ b/tests/core/job/test_job.py
@@ -118,9 +118,6 @@ def test_handle_exception_in_user_function(task_id, job_id):
 
     job = _JobManager._get(job_id)
     assert job.is_failed()
-    with pytest.raises(RuntimeError):
-        raise job.exceptions[0]
-    assert "Something bad has happened" == str(job.exceptions[0])
     assert 'raise RuntimeError("Something bad has happened")' in str(job.stacktrace[0])
 
 
@@ -133,8 +130,7 @@ def test_handle_exception_in_input_data_node(task_id, job_id):
 
     job = _JobManager._get(job_id)
     assert job.is_failed()
-    with pytest.raises(NoData):
-        raise job.exceptions[0]
+    assert 'taipy.core.exceptions.exceptions.NoData' in str(job.stacktrace[0])
 
 
 def test_handle_exception_in_ouptut_data_node(replace_in_memory_write_fct, task_id, job_id):
@@ -147,9 +143,7 @@ def test_handle_exception_in_ouptut_data_node(replace_in_memory_write_fct, task_
     job = _JobManager._get(job_id)
 
     assert job.is_failed()
-    with pytest.raises(DataNodeWritingError):
-        raise job.exceptions[0]
-    assert "Error writing in datanode" in str(job.exceptions[0])
+    assert "taipy.core.exceptions.exceptions.DataNodeWritingError" in str(job.stacktrace[0])
 
 
 def test_auto_set_and_reload(current_datetime, job_id):
@@ -209,25 +203,8 @@ def test_auto_set_and_reload(current_datetime, job_id):
     assert not job_1._is_in_context
 
 
-def test_serialize_exception_with_multiple_params(task_id, job_id):
-    task = Task(config_id="name", input=[], function=_error_multi_param, output=[], id=task_id)
-    job = Job(job_id, task)
-
-    _dispatch(task, job)
-
-    job = _JobManager._get(job_id)
-    assert job.is_failed()
-    with pytest.raises(ExceptionTest):
-        raise job.exceptions[0]
-    assert "Something bad has happened a b 3" == str(job.exceptions[0].message)
-
-
 def _error():
     raise RuntimeError("Something bad has happened")
-
-
-def _error_multi_param():
-    raise ExceptionTest("Something bad has happened", "a", "b", 3)
 
 
 def _dispatch(task: Task, job: Job):
@@ -239,8 +216,3 @@ def _dispatch(task: Task, job: Job):
 
 def _foo():
     return 42
-
-
-class ExceptionTest(Exception):
-    def __init__(self, message, arg1, arg2, arg3):
-        self.message = f"{message} {arg1} {arg2} {arg3}"

--- a/tests/core/job/test_job_repository.py
+++ b/tests/core/job/test_job_repository.py
@@ -1,4 +1,5 @@
 import datetime
+import traceback
 
 import pytest
 
@@ -54,7 +55,7 @@ class A:
 
 job = Job(JobId("id"), task)
 job._subscribers = [f, A.f, A.g, A.h, A.B.f]
-job._exceptions = [Exception()]
+job._exceptions = [traceback.TracebackException.from_exception(Exception())]
 
 job_model = _JobModel(
     id=JobId("id"),
@@ -63,8 +64,7 @@ job_model = _JobModel(
     force=False,
     creation_date=job._creation_date.isoformat(),
     subscribers=_JobRepository._serialize_subscribers(job._subscribers),
-    exceptions=_JobRepository._serialize_exceptions(job._exceptions),
-    stacktrace=_JobRepository._get_exceptions_stacktrace(job._exceptions),
+    stacktrace=job._stacktrace,
 )
 
 

--- a/tests/core/scheduler/test_job_dispatcher.py
+++ b/tests/core/scheduler/test_job_dispatcher.py
@@ -100,7 +100,7 @@ def test_handle_exception_in_user_function():
     executor = _JobDispatcher(None)
     executor._dispatch(job)
     assert job.is_failed()
-    assert "Something bad has happened" == str(job.exceptions[0])
+    assert 'RuntimeError("Something bad has happened")' in str(job.stacktrace[0])
 
 
 def test_handle_exception_when_writing_datanode():
@@ -120,8 +120,7 @@ def test_handle_exception_when_writing_datanode():
         get.return_value = output
         dispatcher._dispatch(job)
         assert job.is_failed()
-        stack_trace = str(job.exceptions[0])
-        assert "node" in stack_trace
+        assert "node" in job.stacktrace[0]
 
 
 def test_need_to_run_no_output():


### PR DESCRIPTION
This PR adds the exception stacktrace to the Job entity and Job Model. The idea is to move from reinstantiating each exception when loading a Job from the repository and instead show the user the stacktrace of the exception.

This PR does not remove the old code yet, since we talked about discussing it further after the implementation.

