### PR TITLE
Feature/#148 allow taipy enterprise scheduler

### DIFF
--- a/taipy/core/_scheduler/_abstract_scheduler.py
+++ b/taipy/core/_scheduler/_abstract_scheduler.py
@@ -19,22 +19,27 @@ from taipy.core.task.task import Task
 class _AbstractScheduler:
     """Creates, Enqueues and schedules jobs as instances of `Job^` class."""
 
+    @classmethod
     @abstractmethod
-    def submit(self, pipeline, callbacks: Optional[Iterable[Callable]], force: bool = False) -> List[Job]:
+    def submit(cls, pipeline, callbacks: Optional[Iterable[Callable]], force: bool = False) -> List[Job]:
         return NotImplemented
 
+    @classmethod
     @abstractmethod
-    def submit_task(self, task: Task, callbacks: Optional[Iterable[Callable]] = None, force: bool = False) -> Job:
+    def submit_task(cls, task: Task, callbacks: Optional[Iterable[Callable]] = None, force: bool = False) -> Job:
         return NotImplemented
 
+    @classmethod
     @abstractmethod
-    def is_running(self) -> bool:
+    def is_running(cls) -> bool:
         return NotImplemented
 
+    @classmethod
     @abstractmethod
-    def start(self):
+    def start(cls):
         return NotImplemented
 
+    @classmethod
     @abstractmethod
-    def stop(self):
+    def stop(cls):
         return NotImplemented

--- a/taipy/core/_scheduler/_scheduler_factory.py
+++ b/taipy/core/_scheduler/_scheduler_factory.py
@@ -8,6 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+from importlib import util
 
 from taipy.core._scheduler._abstract_scheduler import _AbstractScheduler
 from taipy.core._scheduler._scheduler import _Scheduler
@@ -17,10 +18,16 @@ from taipy.core.config.config import Config
 
 class _SchedulerFactory:
     @classmethod
-    def _build_scheduler(cls):
+    def _build_scheduler(cls) -> _AbstractScheduler:
         if Config.job_config._is_default_mode():
-            _Scheduler._recover_jobs()
-            return _Scheduler
-
-        package = f"taipy.{Config.job_config.mode}.scheduler"
-        return _load_fct(package, "Scheduler")
+            if util.find_spec("taipy.enterprise"):
+                # Mode standalone with enterprise version
+                package = "taipy.enterprise.core.scheduler"
+                return _load_fct(package, "Scheduler")()
+            else:
+                # Mode standalone with community version
+                return _Scheduler()
+        else:
+            # Mode airflow with enterprise version
+            package = f"taipy.{Config.job_config.mode}.scheduler"
+            return _load_fct(package, "Scheduler")()


### PR DESCRIPTION
@toan-quach this is just a draft PR. The tests are failing, and the code is not reviewed. But the purpose is just to share my ideas.

Based on your code and your PR, I propose to change the scheduler factory so it is able to instantiate a Scheduler from taipy-enterprise. This new taipy-enterprise.scheduler should inherit from taipy-core._Scheduler and should contain the job recovery code. 

What do you think?
