### PR TITLE
Fix/#175 do not save secrets in entities

### DIFF
--- a/taipy/core/_scheduler/_scheduler_factory.py
+++ b/taipy/core/_scheduler/_scheduler_factory.py
@@ -35,5 +35,5 @@ class _SchedulerFactory:
                 scheduler = _Scheduler
         else:
             raise ModeNotAvailable
-        scheduler.initialize()
-        return scheduler
+        scheduler.initialize()  # type: ignore
+        return scheduler  # type: ignore

--- a/taipy/core/common/_properties.py
+++ b/taipy/core/common/_properties.py
@@ -23,3 +23,8 @@ class _Properties(UserDict):
 
         if hasattr(self, "parent"):
             tp.set(self.parent)
+
+    def __getitem__(self, key):
+        from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
+
+        return _tpl._replace_templates(super(_Properties, self).__getitem__(key))

--- a/taipy/core/config/_config_template_handler.py
+++ b/taipy/core/config/_config_template_handler.py
@@ -12,6 +12,7 @@
 import os
 import re
 
+from taipy.core.common._properties import _Properties
 from taipy.core.common.frequency import Frequency
 from taipy.core.common.scope import Scope
 from taipy.core.exceptions.exceptions import InconsistentEnvVariableError, MissingEnvVariableError
@@ -29,6 +30,8 @@ class _ConfigTemplateHandler:
         if isinstance(template, list):
             return [cls._replace_template(item, type, required, default) for item in template]
         if isinstance(template, dict):
+            return {str(k): cls._replace_template(v, type, required, default) for k, v in template.items()}
+        if isinstance(template, _Properties):
             return {str(k): cls._replace_template(v, type, required, default) for k, v in template.items()}
         return cls._replace_template(template, type, required, default)
 

--- a/taipy/core/config/checker/_checkers/_gLobal_config_checker.py
+++ b/taipy/core/config/checker/_checkers/_gLobal_config_checker.py
@@ -27,12 +27,12 @@ class _GlobalConfigChecker(_ConfigChecker):
         return self._collector
 
     def _check_clean_entities_enabled_type(self, global_config: GlobalAppConfig):
-        value = global_config.clean_entities_enabled
+        value = global_config._clean_entities_enabled
 
-        if isinstance(global_config.clean_entities_enabled, str):
+        if isinstance(global_config._clean_entities_enabled, str):
             try:
                 value = tpl._replace_templates(
-                    global_config.clean_entities_enabled,
+                    global_config._clean_entities_enabled,
                     type=bool,
                     required=False,
                     default=GlobalAppConfig._DEFAULT_CLEAN_ENTITIES_ENABLED,

--- a/taipy/core/config/data_node_config.py
+++ b/taipy/core/config/data_node_config.py
@@ -73,10 +73,7 @@ class DataNodeConfig:
 
     @property
     def properties(self):
-        res = {}
-        for k, v in self._properties.items():
-            res[k] = _tpl._replace_templates(v)
-        return res
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/data_node_config.py
+++ b/taipy/core/config/data_node_config.py
@@ -53,15 +53,15 @@ class DataNodeConfig:
         self.id = _validate_id(id)
         self._storage_type = storage_type
         self._scope = scope
-        self.properties = properties
-        if self.properties.get(self._IS_CACHEABLE_KEY) is None:
-            self.properties[self._IS_CACHEABLE_KEY] = self._DEFAULT_IS_CACHEABLE_VALUE
+        self._properties = properties
+        if self._properties.get(self._IS_CACHEABLE_KEY) is None:
+            self._properties[self._IS_CACHEABLE_KEY] = self._DEFAULT_IS_CACHEABLE_VALUE
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return _tpl._replace_templates(self.properties.get(item))
+        return _tpl._replace_templates(self._properties.get(item))
 
     def __copy__(self):
-        return DataNodeConfig(self.id, self._storage_type, self._scope, **copy(self.properties))
+        return DataNodeConfig(self.id, self._storage_type, self._scope, **copy(self._properties))
 
     @property
     def storage_type(self):
@@ -70,6 +70,17 @@ class DataNodeConfig:
     @storage_type.setter  # type: ignore
     def storage_type(self, val):
         self._storage_type = val
+
+    @property
+    def properties(self):
+        res = {}
+        for k, v in self._properties.items():
+            res[k] = _tpl._replace_templates(v)
+        return res
+
+    @properties.setter  # type: ignore
+    def properties(self, val):
+        self._properties = val
 
     @property
     def scope(self):
@@ -89,7 +100,7 @@ class DataNodeConfig:
             as_dict[self._STORAGE_TYPE_KEY] = self._storage_type
         if self._scope is not None:
             as_dict[self._SCOPE_KEY] = self._scope
-        as_dict.update(self.properties)
+        as_dict.update(self._properties)
         return as_dict
 
     @classmethod
@@ -98,7 +109,7 @@ class DataNodeConfig:
         config.id = _validate_id(id)
         config._storage_type = config_as_dict.pop(cls._STORAGE_TYPE_KEY, None)
         config._scope = config_as_dict.pop(cls._SCOPE_KEY, None)
-        config.properties = config_as_dict
+        config._properties = config_as_dict
         return config
 
     def _update(self, config_as_dict, default_dn_cfg=None):
@@ -106,6 +117,6 @@ class DataNodeConfig:
             config_as_dict.pop(self._STORAGE_TYPE_KEY, self._storage_type) or default_dn_cfg.storage_type
         )
         self._scope = config_as_dict.pop(self._SCOPE_KEY, self._scope) or default_dn_cfg.scope
-        self.properties.update(config_as_dict)
+        self._properties.update(config_as_dict)
         if default_dn_cfg:
-            self.properties = {**default_dn_cfg.properties, **self.properties}
+            self._properties = {**default_dn_cfg.properties, **self._properties}

--- a/taipy/core/config/global_app_config.py
+++ b/taipy/core/config/global_app_config.py
@@ -47,51 +47,72 @@ class GlobalAppConfig:
         clean_entities_enabled: Union[bool, str] = None,
         **properties,
     ):
-        self.root_folder = root_folder
-        self.storage_folder = storage_folder
-        self.clean_entities_enabled = clean_entities_enabled
+        self._root_folder = root_folder
+        self._storage_folder = storage_folder
+        self._clean_entities_enabled = clean_entities_enabled
         self.properties = properties
 
+    @property
+    def storage_folder(self):
+        return _tpl._replace_templates(self._storage_folder)
+
+    @storage_folder.setter  # type: ignore
+    def storage_folder(self, val):
+        self._storage_folder = val
+
+    @property
+    def root_folder(self):
+        return _tpl._replace_templates(self._root_folder)
+
+    @root_folder.setter  # type: ignore
+    def root_folder(self, val):
+        self._root_folder = val
+
+    @property
+    def clean_entities_enabled(self):
+        return _tpl._replace_templates(
+            self._clean_entities_enabled, type=bool, required=False, default=self._DEFAULT_CLEAN_ENTITIES_ENABLED
+        )
+
+    @clean_entities_enabled.setter  # type: ignore
+    def clean_entities_enabled(self, val):
+        self._clean_entities_enabled = val
+
     def __getattr__(self, item: str) -> Optional[Any]:
-        return self.properties.get(item)
+        return _tpl._replace_templates(self.properties.get(item))
 
     @classmethod
     def default_config(cls) -> GlobalAppConfig:
         config = GlobalAppConfig()
-        config.root_folder = cls._DEFAULT_ROOT_FOLDER
-        config.storage_folder = cls._DEFAULT_STORAGE_FOLDER
-        config.clean_entities_enabled = cls._CLEAN_ENTITIES_ENABLED_TEMPLATE
+        config._root_folder = cls._DEFAULT_ROOT_FOLDER
+        config._storage_folder = cls._DEFAULT_STORAGE_FOLDER
+        config._clean_entities_enabled = cls._CLEAN_ENTITIES_ENABLED_TEMPLATE
         return config
 
     def _to_dict(self):
         as_dict = {}
-        if self.root_folder:
-            as_dict[self._ROOT_FOLDER_KEY] = self.root_folder
-        if self.storage_folder:
-            as_dict[self._STORAGE_FOLDER_KEY] = self.storage_folder
-        if self.clean_entities_enabled is not None:
-            as_dict[self._CLEAN_ENTITIES_ENABLED_KEY] = self.clean_entities_enabled
+        if self._root_folder:
+            as_dict[self._ROOT_FOLDER_KEY] = self._root_folder
+        if self._storage_folder:
+            as_dict[self._STORAGE_FOLDER_KEY] = self._storage_folder
+        if self._clean_entities_enabled is not None:
+            as_dict[self._CLEAN_ENTITIES_ENABLED_KEY] = self._clean_entities_enabled
         as_dict.update(self.properties)
         return as_dict
 
     @classmethod
     def _from_dict(cls, config_as_dict: Dict[str, Any]):
         config = GlobalAppConfig()
-        config.root_folder = config_as_dict.pop(cls._ROOT_FOLDER_KEY, None)
-        config.storage_folder = config_as_dict.pop(cls._STORAGE_FOLDER_KEY, None)
-        config.clean_entities_enabled = config_as_dict.pop(cls._CLEAN_ENTITIES_ENABLED_KEY, None)
+        config._root_folder = config_as_dict.pop(cls._ROOT_FOLDER_KEY, None)
+        config._storage_folder = config_as_dict.pop(cls._STORAGE_FOLDER_KEY, None)
+        config._clean_entities_enabled = config_as_dict.pop(cls._CLEAN_ENTITIES_ENABLED_KEY, None)
         config.properties = config_as_dict
         return config
 
     def _update(self, config_as_dict):
-        self.root_folder = _tpl._replace_templates(config_as_dict.pop(self._ROOT_FOLDER_KEY, self.root_folder))
-        self.storage_folder = _tpl._replace_templates(config_as_dict.pop(self._STORAGE_FOLDER_KEY, self.storage_folder))
-        self.clean_entities_enabled = _tpl._replace_templates(
-            config_as_dict.pop(self._CLEAN_ENTITIES_ENABLED_KEY, self.clean_entities_enabled),
-            type=bool,
-            required=False,
-            default=self._DEFAULT_CLEAN_ENTITIES_ENABLED,
+        self._root_folder = config_as_dict.pop(self._ROOT_FOLDER_KEY, self._root_folder)
+        self._storage_folder = config_as_dict.pop(self._STORAGE_FOLDER_KEY, self._storage_folder)
+        self._clean_entities_enabled = config_as_dict.pop(
+            self._CLEAN_ENTITIES_ENABLED_KEY, self._clean_entities_enabled
         )
         self.properties.update(config_as_dict)
-        for k, v in self.properties.items():
-            self.properties[k] = _tpl._replace_templates(v)

--- a/taipy/core/config/global_app_config.py
+++ b/taipy/core/config/global_app_config.py
@@ -80,10 +80,7 @@ class GlobalAppConfig:
 
     @property
     def properties(self):
-        res = {}
-        for k, v in self._properties.items():
-            res[k] = _tpl._replace_templates(v)
-        return res
+return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/global_app_config.py
+++ b/taipy/core/config/global_app_config.py
@@ -50,7 +50,7 @@ class GlobalAppConfig:
         self._root_folder = root_folder
         self._storage_folder = storage_folder
         self._clean_entities_enabled = clean_entities_enabled
-        self.properties = properties
+        self._properties = properties
 
     @property
     def storage_folder(self):
@@ -78,8 +78,19 @@ class GlobalAppConfig:
     def clean_entities_enabled(self, val):
         self._clean_entities_enabled = val
 
+    @property
+    def properties(self):
+        res = {}
+        for k, v in self._properties.items():
+            res[k] = _tpl._replace_templates(v)
+        return res
+
+    @properties.setter  # type: ignore
+    def properties(self, val):
+        self._properties = val
+
     def __getattr__(self, item: str) -> Optional[Any]:
-        return _tpl._replace_templates(self.properties.get(item))
+        return _tpl._replace_templates(self._properties.get(item))
 
     @classmethod
     def default_config(cls) -> GlobalAppConfig:
@@ -97,7 +108,7 @@ class GlobalAppConfig:
             as_dict[self._STORAGE_FOLDER_KEY] = self._storage_folder
         if self._clean_entities_enabled is not None:
             as_dict[self._CLEAN_ENTITIES_ENABLED_KEY] = self._clean_entities_enabled
-        as_dict.update(self.properties)
+        as_dict.update(self._properties)
         return as_dict
 
     @classmethod
@@ -106,7 +117,7 @@ class GlobalAppConfig:
         config._root_folder = config_as_dict.pop(cls._ROOT_FOLDER_KEY, None)
         config._storage_folder = config_as_dict.pop(cls._STORAGE_FOLDER_KEY, None)
         config._clean_entities_enabled = config_as_dict.pop(cls._CLEAN_ENTITIES_ENABLED_KEY, None)
-        config.properties = config_as_dict
+        config._properties = config_as_dict
         return config
 
     def _update(self, config_as_dict):
@@ -115,4 +126,4 @@ class GlobalAppConfig:
         self._clean_entities_enabled = config_as_dict.pop(
             self._CLEAN_ENTITIES_ENABLED_KEY, self._clean_entities_enabled
         )
-        self.properties.update(config_as_dict)
+        self._properties.update(config_as_dict)

--- a/taipy/core/config/global_app_config.py
+++ b/taipy/core/config/global_app_config.py
@@ -80,7 +80,7 @@ class GlobalAppConfig:
 
     @property
     def properties(self):
-return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/pipeline_config.py
+++ b/taipy/core/config/pipeline_config.py
@@ -45,10 +45,7 @@ class PipelineConfig:
 
     @property
     def properties(self):
-        res = {}
-        for k, v in self._properties.items():
-            res[k] = _tpl._replace_templates(v)
-        return res
+return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/pipeline_config.py
+++ b/taipy/core/config/pipeline_config.py
@@ -45,7 +45,7 @@ class PipelineConfig:
 
     @property
     def properties(self):
-return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/pipeline_config.py
+++ b/taipy/core/config/pipeline_config.py
@@ -38,7 +38,7 @@ class PipelineConfig:
             self._tasks = []
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return self.properties.get(item)
+        return _tpl._replace_templates(self.properties.get(item))
 
     def __copy__(self):
         return PipelineConfig(self.id, copy(self._tasks), **copy(self.properties))
@@ -72,5 +72,3 @@ class PipelineConfig:
         if self._tasks is None and default_pipeline_cfg:
             self._tasks = default_pipeline_cfg._tasks
         self.properties.update(config_as_dict)
-        for k, v in self.properties.items():
-            self.properties[k] = _tpl._replace_templates(v)

--- a/taipy/core/config/pipeline_config.py
+++ b/taipy/core/config/pipeline_config.py
@@ -31,17 +31,28 @@ class PipelineConfig:
 
     def __init__(self, id: str, tasks: Union[TaskConfig, List[TaskConfig]] = None, **properties):
         self.id = _validate_id(id)
-        self.properties = properties
+        self._properties = properties
         if tasks:
             self._tasks = [tasks] if isinstance(tasks, TaskConfig) else copy(tasks)
         else:
             self._tasks = []
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return _tpl._replace_templates(self.properties.get(item))
+        return _tpl._replace_templates(self._properties.get(item))
 
     def __copy__(self):
-        return PipelineConfig(self.id, copy(self._tasks), **copy(self.properties))
+        return PipelineConfig(self.id, copy(self._tasks), **copy(self._properties))
+
+    @property
+    def properties(self):
+        res = {}
+        for k, v in self._properties.items():
+            res[k] = _tpl._replace_templates(v)
+        return res
+
+    @properties.setter  # type: ignore
+    def properties(self, val):
+        self._properties = val
 
     @classmethod
     def default_config(cls, id):
@@ -52,7 +63,7 @@ class PipelineConfig:
         return self._tasks
 
     def _to_dict(self):
-        return {self._TASK_KEY: self._tasks, **self.properties}
+        return {self._TASK_KEY: self._tasks, **self._properties}
 
     @classmethod
     def _from_dict(cls, id: str, config_as_dict: Dict[str, Any], task_configs: Dict[str, TaskConfig]):
@@ -60,7 +71,7 @@ class PipelineConfig:
         config.id = _validate_id(id)
         if tasks := config_as_dict.pop(cls._TASK_KEY, None):
             config._tasks = [task_configs[task_id] for task_id in tasks if task_id in task_configs]
-        config.properties = config_as_dict
+        config._properties = config_as_dict
         return config
 
     def _update(self, config_as_dict, default_pipeline_cfg=None):
@@ -71,4 +82,4 @@ class PipelineConfig:
         )
         if self._tasks is None and default_pipeline_cfg:
             self._tasks = default_pipeline_cfg._tasks
-        self.properties.update(config_as_dict)
+        self._properties.update(config_as_dict)

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -59,7 +59,7 @@ class ScenarioConfig:
                     self.comparators[_validate_id(k)].append(v)
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return self.properties.get(item)
+        return _tpl._replace_templates(self.properties.get(item))
 
     def __copy__(self):
         comp = None if self.comparators is None else self.comparators
@@ -100,8 +100,6 @@ class ScenarioConfig:
         if self.comparators is None and default_scenario_cfg:
             self.comparators = default_scenario_cfg.comparators
         self.properties.update(config_as_dict)
-        for k, v in self.properties.items():
-            self.properties[k] = _tpl._replace_templates(v)
 
     def add_comparator(self, dn_config_id: str, comparator: Callable):
         self.comparators[dn_config_id].append(comparator)

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -67,7 +67,7 @@ class ScenarioConfig:
 
     @property
     def properties(self):
-return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -67,10 +67,7 @@ class ScenarioConfig:
 
     @property
     def properties(self):
-        res = {}
-        for k, v in self._properties.items():
-            res[k] = _tpl._replace_templates(v)
-        return res
+return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/config/scenario_config.py
+++ b/taipy/core/config/scenario_config.py
@@ -44,7 +44,7 @@ class ScenarioConfig:
         **properties,
     ):
         self.id = _validate_id(id)
-        self.properties = properties
+        self._properties = properties
         if pipelines:
             self._pipelines = [pipelines] if isinstance(pipelines, PipelineConfig) else copy(pipelines)
         else:
@@ -59,11 +59,22 @@ class ScenarioConfig:
                     self.comparators[_validate_id(k)].append(v)
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return _tpl._replace_templates(self.properties.get(item))
+        return _tpl._replace_templates(self._properties.get(item))
 
     def __copy__(self):
         comp = None if self.comparators is None else self.comparators
-        return ScenarioConfig(self.id, copy(self._pipelines), self.frequency, copy(comp), **copy(self.properties))
+        return ScenarioConfig(self.id, copy(self._pipelines), self.frequency, copy(comp), **copy(self._properties))
+
+    @property
+    def properties(self):
+        res = {}
+        for k, v in self._properties.items():
+            res[k] = _tpl._replace_templates(v)
+        return res
+
+    @properties.setter  # type: ignore
+    def properties(self, val):
+        self._properties = val
 
     @classmethod
     def default_config(cls, id):
@@ -74,7 +85,7 @@ class ScenarioConfig:
         return self._pipelines
 
     def _to_dict(self):
-        return {self._PIPELINE_KEY: self._pipelines, self._FREQUENCY_KEY: self.frequency, **self.properties}
+        return {self._PIPELINE_KEY: self._pipelines, self._FREQUENCY_KEY: self.frequency, **self._properties}
 
     @classmethod
     def _from_dict(cls, id: str, config_as_dict: Dict[str, Any], pipeline_configs: Dict[str, PipelineConfig]):
@@ -84,7 +95,7 @@ class ScenarioConfig:
             config._pipelines = [pipeline_configs[p_id] for p_id in pipeline_ids if p_id in pipeline_configs]
         config.frequency = config_as_dict.pop(cls._FREQUENCY_KEY, None)
         config.comparators = config_as_dict.pop(cls._COMPARATOR_KEY, dict())
-        config.properties = config_as_dict
+        config._properties = config_as_dict
         return config
 
     def _update(self, config_as_dict, default_scenario_cfg=None):
@@ -99,7 +110,7 @@ class ScenarioConfig:
         self.comparators = config_as_dict.pop(self._COMPARATOR_KEY, self.comparators)
         if self.comparators is None and default_scenario_cfg:
             self.comparators = default_scenario_cfg.comparators
-        self.properties.update(config_as_dict)
+        self._properties.update(config_as_dict)
 
     def add_comparator(self, dn_config_id: str, comparator: Callable):
         self.comparators[dn_config_id].append(comparator)

--- a/taipy/core/config/task_config.py
+++ b/taipy/core/config/task_config.py
@@ -58,7 +58,7 @@ class TaskConfig:
         self.function = function
 
     def __getattr__(self, item: str) -> Optional[Any]:
-        return self.properties.get(item)
+        return _tpl._replace_templates(self.properties.get(item))
 
     def __copy__(self):
         return TaskConfig(self.id, copy(self._inputs), self.function, copy(self._outputs), **copy(self.properties))
@@ -111,5 +111,3 @@ class TaskConfig:
         self.properties.update(config_as_dict)
         if default_task_cfg:
             self.properties = {**default_task_cfg.properties, **self.properties}
-        for k, v in self.properties.items():
-            self.properties[k] = _tpl._replace_templates(v)

--- a/taipy/core/config/task_config.py
+++ b/taipy/core/config/task_config.py
@@ -65,10 +65,7 @@ class TaskConfig:
 
     @property
     def properties(self):
-        res = {}
-        for k, v in self._properties.items():
-            res[k] = _tpl._replace_templates(v)
-        return res
+        return {k: _tpl._replace_templates(v) for k, v in self._properties.items()}
 
     @properties.setter  # type: ignore
     def properties(self, val):

--- a/taipy/core/data/_data_manager.py
+++ b/taipy/core/data/_data_manager.py
@@ -52,7 +52,7 @@ class _DataManager(_Manager[DataNode]):
     @classmethod
     def __create(cls, data_node_config: DataNodeConfig, parent_id: Optional[str]) -> DataNode:
         try:
-            props = data_node_config.properties.copy()
+            props = data_node_config._properties.copy()
             validity_period = props.pop("validity_period", None)
             return cls.__DATA_NODE_CLASS_MAP[data_node_config.storage_type](  # type: ignore
                 config_id=data_node_config.id,

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -27,6 +27,7 @@ from taipy.core.common._validate_id import _validate_id
 from taipy.core.common._warnings import _warn_deprecated
 from taipy.core.common.alias import DataNodeId, JobId
 from taipy.core.common.scope import Scope
+from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.data._filter import _FilterDataNode
 from taipy.core.data.operator import JoinOperator, Operator
@@ -214,7 +215,7 @@ class DataNode(_Entity):
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
         if protected_attribute_name in self.properties:
-            return self.properties[protected_attribute_name]
+            return _tpl._replace_templates(self.properties[protected_attribute_name])
         raise AttributeError(f"{attribute_name} is not an attribute of data node {self.id}")
 
     @classmethod

--- a/taipy/core/data/data_node.py
+++ b/taipy/core/data/data_node.py
@@ -27,7 +27,6 @@ from taipy.core.common._validate_id import _validate_id
 from taipy.core.common._warnings import _warn_deprecated
 from taipy.core.common.alias import DataNodeId, JobId
 from taipy.core.common.scope import Scope
-from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.data._filter import _FilterDataNode
 from taipy.core.data.operator import JoinOperator, Operator
@@ -214,8 +213,8 @@ class DataNode(_Entity):
 
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
-        if protected_attribute_name in self.properties:
-            return _tpl._replace_templates(self.properties[protected_attribute_name])
+        if protected_attribute_name in self._properties:
+            return self._properties[protected_attribute_name]
         raise AttributeError(f"{attribute_name} is not an attribute of data node {self.id}")
 
     @classmethod

--- a/taipy/core/pipeline/_pipeline_manager.py
+++ b/taipy/core/pipeline/_pipeline_manager.py
@@ -73,7 +73,7 @@ class _PipelineManager(_Manager[Pipeline]):
         if pipelines_from_parent := cls._repository._get_by_config_and_parent_ids(pipeline_config.id, parent_id):
             return pipelines_from_parent
 
-        pipeline = Pipeline(pipeline_config.id, dict(**pipeline_config.properties), tasks, pipeline_id, parent_id)
+        pipeline = Pipeline(pipeline_config.id, dict(**pipeline_config._properties), tasks, pipeline_id, parent_id)
         cls._set(pipeline)
         return pipeline
 

--- a/taipy/core/pipeline/pipeline.py
+++ b/taipy/core/pipeline/pipeline.py
@@ -105,8 +105,8 @@ class Pipeline(_Entity):
 
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
-        if protected_attribute_name in self.properties:
-            return _tpl._replace_templates(self.properties[protected_attribute_name])
+        if protected_attribute_name in self._properties:
+            return _tpl._replace_templates(self._properties[protected_attribute_name])
         if protected_attribute_name in self._tasks:
             return self._tasks[protected_attribute_name]
         for task in self._tasks.values():

--- a/taipy/core/pipeline/pipeline.py
+++ b/taipy/core/pipeline/pipeline.py
@@ -22,6 +22,7 @@ from taipy.core.common._properties import _Properties
 from taipy.core.common._reload import _reload, _self_reload, _self_setter
 from taipy.core.common._validate_id import _validate_id
 from taipy.core.common.alias import PipelineId
+from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.data.data_node import DataNode
 from taipy.core.job.job import Job
 from taipy.core.task.task import Task
@@ -105,7 +106,7 @@ class Pipeline(_Entity):
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
         if protected_attribute_name in self.properties:
-            return self.properties[protected_attribute_name]
+            return _tpl._replace_templates(self.properties[protected_attribute_name])
         if protected_attribute_name in self._tasks:
             return self._tasks[protected_attribute_name]
         for task in self._tasks.values():

--- a/taipy/core/scenario/_scenario_manager.py
+++ b/taipy/core/scenario/_scenario_manager.py
@@ -91,7 +91,7 @@ class _ScenarioManager(_Manager[Scenario]):
             else None
         )
         is_primary_scenario = len(cls._get_all_by_cycle(cycle)) == 0 if cycle else False
-        props = config.properties.copy()
+        props = config._properties.copy()
         if name:
             props["name"] = name
         scenario = Scenario(

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -166,8 +166,8 @@ class Scenario(_Entity):
 
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
-        if protected_attribute_name in self.properties:
-            return _tpl._replace_templates(self.properties[protected_attribute_name])
+        if protected_attribute_name in self._properties:
+            return _tpl._replace_templates(self._properties[protected_attribute_name])
         if protected_attribute_name in self.pipelines:
             return self.pipelines[protected_attribute_name]
         for pipeline in self.pipelines.values():

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -21,6 +21,7 @@ from taipy.core.common._properties import _Properties
 from taipy.core.common._reload import _reload, _self_reload, _self_setter
 from taipy.core.common._validate_id import _validate_id
 from taipy.core.common.alias import ScenarioId
+from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.cycle.cycle import Cycle
 from taipy.core.job.job import Job
 from taipy.core.pipeline.pipeline import Pipeline
@@ -166,7 +167,7 @@ class Scenario(_Entity):
     def __getattr__(self, attribute_name):
         protected_attribute_name = _validate_id(attribute_name)
         if protected_attribute_name in self.properties:
-            return self.properties[protected_attribute_name]
+            return _tpl._replace_templates(self.properties[protected_attribute_name])
         if protected_attribute_name in self.pipelines:
             return self.pipelines[protected_attribute_name]
         for pipeline in self.pipelines.values():

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -118,9 +118,12 @@ def test_date_node_create_with_datetime():
 
 
 def test_data_node_with_env_variable_value():
-    with mock.patch.dict(os.environ, {"BAR": "baz"}):
-        Config.configure_data_node("data_node", prop="ENV[BAR]")
+    with mock.patch.dict(os.environ, {"FOO": "pickle", "BAR": "baz"}):
+        Config.configure_data_node("data_node", storage_type="ENV[FOO]", prop="ENV[BAR]")
         assert Config.data_nodes["data_node"].prop == "baz"
+        assert Config.data_nodes["data_node"].properties["prop"] == "ENV[BAR]"
+        assert Config.data_nodes["data_node"].storage_type == "pickle"
+        assert Config.data_nodes["data_node"]._storage_type == "ENV[FOO]"
 
 
 def test_data_node_with_env_variable_in_write_fct_params():

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -121,7 +121,8 @@ def test_data_node_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "pickle", "BAR": "baz"}):
         Config.configure_data_node("data_node", storage_type="ENV[FOO]", prop="ENV[BAR]")
         assert Config.data_nodes["data_node"].prop == "baz"
-        assert Config.data_nodes["data_node"].properties["prop"] == "ENV[BAR]"
+        assert Config.data_nodes["data_node"].properties["prop"] == "baz"
+        assert Config.data_nodes["data_node"]._properties["prop"] == "ENV[BAR]"
         assert Config.data_nodes["data_node"].storage_type == "pickle"
         assert Config.data_nodes["data_node"]._storage_type == "ENV[FOO]"
 

--- a/tests/core/config/test_default_config.py
+++ b/tests/core/config/test_default_config.py
@@ -17,7 +17,6 @@ from taipy.core.config.global_app_config import GlobalAppConfig
 from taipy.core.config.job_config import JobConfig
 from taipy.core.config.pipeline_config import PipelineConfig
 from taipy.core.config.scenario_config import ScenarioConfig
-from taipy.core.config.standalone_config import StandaloneConfig
 from taipy.core.config.task_config import TaskConfig
 
 
@@ -27,7 +26,8 @@ def _test_default_global_app_config(global_config: GlobalAppConfig):
     assert global_config.root_folder == "./taipy/"
     assert global_config.storage_folder == ".data/"
     assert global_config.broker_endpoint is None
-    assert global_config.clean_entities_enabled is GlobalAppConfig._CLEAN_ENTITIES_ENABLED_TEMPLATE
+    assert global_config._clean_entities_enabled is GlobalAppConfig._CLEAN_ENTITIES_ENABLED_TEMPLATE
+    assert global_config.clean_entities_enabled is False
     assert len(global_config.properties) == 0
 
 

--- a/tests/core/config/test_file_config.py
+++ b/tests/core/config/test_file_config.py
@@ -75,15 +75,15 @@ custom = "custom property"
 default_data = "dn1"
 
 [DATA_NODE.dn2]
-storage_type = "in_memory"
+storage_type = "ENV[FOO]"
 scope = "SCENARIO"
 cacheable = "False:bool"
 custom = "default_custom_prop"
 foo = "bar"
 default_data = "dn2"
-baz = "qux"
-quux = "True:bool"
-corge = [ "grault", "garply", "17:int", "3.0:float",]
+baz = "ENV[QUX]"
+quux = "ENV[QUUZ]:bool"
+corge = [ "grault", "ENV[GARPLY]", "ENV[WALDO]:int", "3.0:float",]
 
 [TASK.default]
 inputs = []
@@ -113,7 +113,9 @@ frequency = "QUARTERLY"
 owner = "Raymond Kopa"
     """.strip()
     tf = NamedTemporaryFile()
-    with mock.patch.dict(os.environ, {"QUX": "qux", "QUUZ": "true", "GARPLY": "garply", "WALDO": "17"}):
+    with mock.patch.dict(
+        os.environ, {"FOO": "in_memory", "QUX": "qux", "QUUZ": "true", "GARPLY": "garply", "WALDO": "17"}
+    ):
         Config.configure_global_app(clean_entities_enabled=True)
         Config.configure_job_executions(mode="standalone")
         Config.configure_default_data_node(storage_type="in_memory", custom="default_custom_prop")
@@ -122,7 +124,7 @@ owner = "Raymond Kopa"
         )
         dn2_cfg_v2 = Config.configure_data_node(
             "dn2",
-            storage_type="in_memory",
+            storage_type="ENV[FOO]",
             foo="bar",
             default_data="dn2",
             baz="ENV[QUX]",

--- a/tests/core/config/test_global_app_config.py
+++ b/tests/core/config/test_global_app_config.py
@@ -19,6 +19,15 @@ from taipy.core.config.global_app_config import GlobalAppConfig
 from taipy.core.exceptions.exceptions import InconsistentEnvVariableError
 
 
+def test_scenario_config_with_env_variable_value():
+    with mock.patch.dict(os.environ, {"FOO": "bar", "BAZ": "qux"}):
+        Config.configure_global_app(root_folder="ENV[FOO]", storage_folder="ENV[BAZ]")
+        assert Config.global_config.root_folder == "bar"
+        assert Config.global_config._root_folder == "ENV[FOO]"
+        assert Config.global_config.storage_folder == "qux"
+        assert Config.global_config._storage_folder == "ENV[BAZ]"
+
+
 def test_clean_entities_enabled_default():
     Config.configure_global_app()
     assert Config.global_config.clean_entities_enabled is GlobalAppConfig._DEFAULT_CLEAN_ENTITIES_ENABLED

--- a/tests/core/config/test_override_config.py
+++ b/tests/core/config/test_override_config.py
@@ -76,6 +76,7 @@ def test_override_default_config_with_code_config_including_env_variable_values(
     with mock.patch.dict(os.environ, {"ENV_VAR": "foo"}):
         with pytest.raises(InconsistentEnvVariableError):
             Config.configure_global_app(clean_entities_enabled="ENV[ENV_VAR]")
+            Config.global_config.clean_entities_enabled
 
 
 def test_override_default_configuration_with_file_configuration():

--- a/tests/core/config/test_pipeline_config.py
+++ b/tests/core/config/test_pipeline_config.py
@@ -73,4 +73,5 @@ def test_pipeline_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "bar"}):
         Config.configure_pipeline("pipeline_name", [task1_config, task2_config], prop="ENV[FOO]")
         assert Config.pipelines["pipeline_name"].prop == "bar"
-        assert Config.pipelines["pipeline_name"].properties["prop"] == "ENV[FOO]"
+        assert Config.pipelines["pipeline_name"].properties["prop"] == "bar"
+        assert Config.pipelines["pipeline_name"]._properties["prop"] == "ENV[FOO]"

--- a/tests/core/config/test_pipeline_config.py
+++ b/tests/core/config/test_pipeline_config.py
@@ -73,3 +73,4 @@ def test_pipeline_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "bar"}):
         Config.configure_pipeline("pipeline_name", [task1_config, task2_config], prop="ENV[FOO]")
         assert Config.pipelines["pipeline_name"].prop == "bar"
+        assert Config.pipelines["pipeline_name"].properties["prop"] == "ENV[FOO]"

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -118,6 +118,7 @@ def test_scenario_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "bar"}):
         Config.configure_scenario("scenario_name", [pipeline1_config, pipeline2_config], prop="ENV[FOO]")
         assert Config.scenarios["scenario_name"].prop == "bar"
+        assert Config.scenarios["scenario_name"].properties["prop"] == "ENV[FOO]"
 
 
 def test_scenario_create_from_tasks():

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -118,7 +118,8 @@ def test_scenario_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "bar"}):
         Config.configure_scenario("scenario_name", [pipeline1_config, pipeline2_config], prop="ENV[FOO]")
         assert Config.scenarios["scenario_name"].prop == "bar"
-        assert Config.scenarios["scenario_name"].properties["prop"] == "ENV[FOO]"
+        assert Config.scenarios["scenario_name"].properties["prop"] == "bar"
+        assert Config.scenarios["scenario_name"]._properties["prop"] == "ENV[FOO]"
 
 
 def test_scenario_create_from_tasks():

--- a/tests/core/config/test_task_config.py
+++ b/tests/core/config/test_task_config.py
@@ -82,3 +82,4 @@ def test_task_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "plop", "BAR": "baz"}):
         Config.configure_task("task_name", print, input_config, output_config, prop="ENV[BAR]")
         assert Config.tasks["task_name"].prop == "baz"
+        assert Config.tasks["task_name"].properties["prop"] == "ENV[BAR]"

--- a/tests/core/config/test_task_config.py
+++ b/tests/core/config/test_task_config.py
@@ -82,4 +82,5 @@ def test_task_config_with_env_variable_value():
     with mock.patch.dict(os.environ, {"FOO": "plop", "BAR": "baz"}):
         Config.configure_task("task_name", print, input_config, output_config, prop="ENV[BAR]")
         assert Config.tasks["task_name"].prop == "baz"
-        assert Config.tasks["task_name"].properties["prop"] == "ENV[BAR]"
+        assert Config.tasks["task_name"].properties["prop"] == "baz"
+        assert Config.tasks["task_name"]._properties["prop"] == "ENV[BAR]"

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -36,7 +36,6 @@ class TestDataManager:
         assert dn_config.properties.get("foo") == "bar"
         assert dn_config.properties.get("baz") is None
 
-        # dn._properties["baz"] = "qux"
         dn.properties["baz"] = "qux"
         _DataManager._set(dn)
         assert dn_config.properties.get("foo") == "bar"

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -36,6 +36,7 @@ class TestDataManager:
         assert dn_config.properties.get("foo") == "bar"
         assert dn_config.properties.get("baz") is None
 
+        # dn._properties["baz"] = "qux"
         dn.properties["baz"] = "qux"
         _DataManager._set(dn)
         assert dn_config.properties.get("foo") == "bar"

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
+import os
 from datetime import datetime, timedelta
 from time import sleep
 from unittest import mock
@@ -587,3 +587,11 @@ class TestDataNode:
         assert dn.last_edit_date == dn.last_edition_date
         dn.last_edition_date = datetime.now()
         assert dn.last_edit_date == dn.last_edition_date
+
+    def test_data_node_with_env_variable_value_not_stored(self):
+        dn_config = Config.configure_data_node("A", prop="ENV[FOO]")
+        with mock.patch.dict(os.environ, {"FOO": "bar"}):
+            dn = _DataManager._get_or_create(dn_config)
+            assert dn._properties.data["prop"] == "ENV[FOO]"
+            assert dn.properties["prop"] == "bar"
+            assert dn.prop == "bar"

--- a/tests/core/data/test_data_repository.py
+++ b/tests/core/data/test_data_repository.py
@@ -69,5 +69,6 @@ class TestDataRepository:
         with mock.patch.dict(os.environ, {"FOO": "bar"}):
             repository = _DataManager._repository
             assert repository._to_model(self.data_node).data_node_properties["prop"] == "ENV[FOO]"
-            assert self.data_node.properties["prop"] == "ENV[FOO]"
+            assert self.data_node._properties.data["prop"] == "ENV[FOO]"
+            assert self.data_node.properties["prop"] == "bar"
             assert self.data_node.prop == "bar"

--- a/tests/core/data/test_data_repository.py
+++ b/tests/core/data/test_data_repository.py
@@ -10,6 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 import datetime
+import os
+from unittest import mock
 
 from taipy.core.common.alias import DataNodeId, JobId
 from taipy.core.common.scope import Scope
@@ -18,46 +20,54 @@ from taipy.core.data._data_model import _DataNodeModel
 from taipy.core.data.csv import CSVDataNode
 from taipy.core.data.data_node import DataNode
 
-data_node = CSVDataNode(
-    "test_data_node",
-    Scope.PIPELINE,
-    DataNodeId("dn_id"),
-    "name",
-    "parent_id",
-    datetime.datetime(1985, 10, 14, 2, 30, 0),
-    [JobId("job_id")],
-    None,
-    False,
-    {"path": "/path", "has_header": True},
-)
-
-data_node_model = _DataNodeModel(
-    "dn_id",
-    "test_data_node",
-    Scope.PIPELINE,
-    "csv",
-    "name",
-    "parent_id",
-    datetime.datetime(1985, 10, 14, 2, 30, 0).isoformat(),
-    [JobId("job_id")],
-    None,
-    None,
-    False,
-    {"path": "/path", "has_header": True},
-)
-
 
 class TestDataRepository:
+
+    data_node = CSVDataNode(
+        "test_data_node",
+        Scope.PIPELINE,
+        DataNodeId("my_dn_id"),
+        "name",
+        "parent_id",
+        datetime.datetime(1985, 10, 14, 2, 30, 0),
+        [JobId("job_id")],
+        None,
+        False,
+        {"path": "/path", "has_header": True, "prop": "ENV[FOO]"},
+    )
+
+    data_node_model = _DataNodeModel(
+        "my_dn_id",
+        "test_data_node",
+        Scope.PIPELINE,
+        "csv",
+        "name",
+        "parent_id",
+        datetime.datetime(1985, 10, 14, 2, 30, 0).isoformat(),
+        [JobId("job_id")],
+        None,
+        None,
+        False,
+        {"path": "/path", "has_header": True, "prop": "ENV[FOO]"},
+    )
+
     def test_save_and_load(self, tmpdir):
         repository = _DataManager._repository
         repository.base_path = tmpdir
-        repository._save(data_node)
-        dn = repository.load("dn_id")
+        repository._save(self.data_node)
+        dn = repository.load("my_dn_id")
 
         assert isinstance(dn, CSVDataNode)
         assert isinstance(dn, DataNode)
 
     def test_from_and_to_model(self):
         repository = _DataManager._repository
-        assert repository._to_model(data_node) == data_node_model
-        assert repository._from_model(data_node_model) == data_node
+        assert repository._to_model(self.data_node) == self.data_node_model
+        assert repository._from_model(self.data_node_model) == self.data_node
+
+    def test_data_node_with_env_variable_value_not_serialized(self):
+
+        with mock.patch.dict(os.environ, {"FOO": "bar"}):
+            repository = _DataManager._repository
+            assert repository._to_model(self.data_node).data_node_properties["prop"] == "ENV[FOO]"
+            assert self.data_node.prop == "bar"

--- a/tests/core/data/test_data_repository.py
+++ b/tests/core/data/test_data_repository.py
@@ -66,8 +66,8 @@ class TestDataRepository:
         assert repository._from_model(self.data_node_model) == self.data_node
 
     def test_data_node_with_env_variable_value_not_serialized(self):
-
         with mock.patch.dict(os.environ, {"FOO": "bar"}):
             repository = _DataManager._repository
             assert repository._to_model(self.data_node).data_node_properties["prop"] == "ENV[FOO]"
+            assert self.data_node.properties["prop"] == "ENV[FOO]"
             assert self.data_node.prop == "bar"


### PR DESCRIPTION
I implemented a fix for taipy-core #175.

From now, the Config._applied_config object still does contain the compiled config, but the environment values are not interpreted. For instance, the config field contains values like 'ENV[NAME]' (before, the value was interpreted and replaced by the value of the corresponding environment variable).
I then needed to ensure that every time a config field is accessed, it is interpreted on the fly through the method: _tpl._replace_templates. I created getters/setters properties for that purpose.

Here is the expected behavior of the usage of a config object:
```
def test_data_node_with_env_variable_value():
    with mock.patch.dict(os.environ, {"FOO": "pickle", "BAR": "baz"}):
        Config.configure_data_node("data_node", storage_type="ENV[FOO]", prop="ENV[BAR]")
        assert Config.data_nodes["data_node"].prop == "baz"
        assert Config.data_nodes["data_node"].properties["prop"] == "baz"
        assert Config.data_nodes["data_node"]._properties["prop"] == "ENV[BAR]"
        assert Config.data_nodes["data_node"].storage_type == "pickle"
        assert Config.data_nodes["data_node"]._storage_type == "ENV[FOO]"
```

First consequence: When exporting the applied config, we do not export the env variable values, but the templates. And so secrets are not serialized.

Second consequence: When creating an entity, the properties of the config are copied before they got interpreted and replaced. When serializing the entity through a repository, we do not serialize interpreted values. And so secrets are not serialized.
I then needed to ensure that every time an entity field is accessed, it is interpreted on the fly through the method: _tpl._replace_templates. I created getters/setters properties for that purpose.

Here is the behavior of the usage of an entity object:
```
def test_data_node_with_env_variable_value_not_serialized(self):
    with mock.patch.dict(os.environ, {"FOO": "bar"}):
        assert self.data_node._properties["prop"] == "ENV[FOO]"
        assert self.data_node.properties["prop"] == "bar"
        assert self.data_node.prop == "bar"
```