### PR TITLE
Feature/subscribe with args

### DIFF
--- a/taipy/core/common/_utils.py
+++ b/taipy/core/common/_utils.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import functools
+from collections import namedtuple
 from importlib import import_module
 from operator import attrgetter
 from typing import Callable, Optional
@@ -30,7 +31,7 @@ def _get_fct_name(f) -> Optional[str]:
 
 
 def _fct_to_dict(obj):
-    fct_name = _get_fct_name(obj)
+    fct_name = _get_fct_name(obj.callable)
     if not fct_name:
         return None
     return {"fct_name": fct_name, "fct_module": obj.__module__}
@@ -38,3 +39,6 @@ def _fct_to_dict(obj):
 
 def _fcts_to_dict(objs):
     return [d for obj in objs if (d := _fct_to_dict(obj)) is not None]
+
+
+Subscriber = namedtuple("Subscriber", "callable params")

--- a/taipy/core/common/_utils.py
+++ b/taipy/core/common/_utils.py
@@ -31,13 +31,13 @@ def _get_fct_name(f) -> Optional[str]:
 
 
 def _fct_to_dict(obj):
-    fct_name = _get_fct_name(obj.callable)
+    fct_name = _get_fct_name(obj.callback)
     if not fct_name:
         return None
     return {
         "fct_name": fct_name,
         "fct_params": obj.params,
-        "fct_module": obj.__module__,
+        "fct_module": obj.callback.__module__,
     }
 
 
@@ -45,4 +45,4 @@ def _fcts_to_dict(objs):
     return [d for obj in objs if (d := _fct_to_dict(obj)) is not None]
 
 
-Subscriber = namedtuple("Subscriber", "callable params")
+Subscriber = namedtuple("Subscriber", "callback params")

--- a/taipy/core/common/_utils.py
+++ b/taipy/core/common/_utils.py
@@ -31,13 +31,20 @@ def _get_fct_name(f) -> Optional[str]:
 
 
 def _fct_to_dict(obj):
-    fct_name = _get_fct_name(obj.callback)
+    params = []
+    callback = obj
+
+    if isinstance(obj, Subscriber):
+        callback = obj.callback
+        params = obj.params
+
+    fct_name = _get_fct_name(callback)
     if not fct_name:
         return None
     return {
         "fct_name": fct_name,
-        "fct_params": obj.params,
-        "fct_module": obj.callback.__module__,
+        "fct_params": params,
+        "fct_module": callback.__module__,
     }
 
 

--- a/taipy/core/common/_utils.py
+++ b/taipy/core/common/_utils.py
@@ -34,7 +34,11 @@ def _fct_to_dict(obj):
     fct_name = _get_fct_name(obj.callable)
     if not fct_name:
         return None
-    return {"fct_name": fct_name, "fct_module": obj.__module__}
+    return {
+        "fct_name": fct_name,
+        "fct_params": obj.params,
+        "fct_module": obj.__module__,
+    }
 
 
 def _fcts_to_dict(objs):

--- a/taipy/core/pipeline/_pipeline_manager.py
+++ b/taipy/core/pipeline/_pipeline_manager.py
@@ -12,18 +12,17 @@
 from functools import partial
 from typing import Callable, List, Optional, Union
 
+from taipy.core._manager._manager import _Manager
 from taipy.core.common._entity_ids import _EntityIds
 from taipy.core.common.alias import PipelineId, ScenarioId
 from taipy.core.common.scope import Scope
 from taipy.core.config.pipeline_config import PipelineConfig
-from taipy.core.job._job_manager_factory import _JobManagerFactory
-from taipy.core.pipeline._pipeline_repository import _PipelineRepository
-from taipy.core.task._task_manager_factory import _TaskManagerFactory
-
-from taipy.core._manager._manager import _Manager
 from taipy.core.exceptions.exceptions import NonExistingPipeline
+from taipy.core.job._job_manager_factory import _JobManagerFactory
 from taipy.core.job.job import Job
+from taipy.core.pipeline._pipeline_repository import _PipelineRepository
 from taipy.core.pipeline.pipeline import Pipeline
+from taipy.core.task._task_manager_factory import _TaskManagerFactory
 
 
 class _PipelineManager(_Manager[Pipeline]):
@@ -31,14 +30,19 @@ class _PipelineManager(_Manager[Pipeline]):
     _ENTITY_NAME = Pipeline.__name__
 
     @classmethod
-    def _subscribe(cls, callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None):
+    def _subscribe(
+        cls,
+        callback: Callable[[Pipeline, Job], None],
+        params: Optional[List[str]] = None,
+        pipeline: Optional[Pipeline] = None,
+    ):
         if pipeline is None:
             pipelines = cls._get_all()
             for pln in pipelines:
-                cls.__add_subscriber(callback, pln)
+                cls.__add_subscriber(callback, params, pln)
             return
 
-        cls.__add_subscriber(callback, pipeline)
+        cls.__add_subscriber(callback, params, pipeline)
 
     @classmethod
     def _unsubscribe(cls, callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None):
@@ -52,8 +56,8 @@ class _PipelineManager(_Manager[Pipeline]):
         cls.__remove_subscriber(callback, pipeline)
 
     @classmethod
-    def __add_subscriber(cls, callback, pipeline):
-        pipeline._add_subscriber(callback)
+    def __add_subscriber(cls, callback, params, pipeline):
+        pipeline._add_subscriber(callback, params)
         cls._set(pipeline)
 
     @classmethod

--- a/taipy/core/pipeline/pipeline.py
+++ b/taipy/core/pipeline/pipeline.py
@@ -15,15 +15,16 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import networkx as nx
+
 from taipy.core.common._entity import _Entity
 from taipy.core.common._listattributes import _ListAttributes
 from taipy.core.common._properties import _Properties
 from taipy.core.common._reload import _reload, _self_reload, _self_setter
+from taipy.core.common._utils import Subscriber
 from taipy.core.common._validate_id import _validate_id
 from taipy.core.common.alias import PipelineId, TaskId
 from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.data.data_node import DataNode
-
 from taipy.core.exceptions.exceptions import NonExistingTask
 from taipy.core.job.job import Job
 from taipy.core.task.task import Task
@@ -52,7 +53,7 @@ class Pipeline(_Entity):
         tasks: Union[List[TaskId], List[Task], List[Union[TaskId, Task]]],
         pipeline_id: PipelineId = None,
         parent_id: Optional[str] = None,
-        subscribers: List[Callable] = None,
+        subscribers: List[Subscriber] = None,
     ):
         self.config_id = _validate_id(config_id)
         self.id: PipelineId = pipeline_id or self._new_id(self.config_id)
@@ -169,11 +170,15 @@ class Pipeline(_Entity):
     def subscribers(self, val):
         self._subscribers = _ListAttributes(self, val)
 
-    def _add_subscriber(self, callback: Callable):
-        self._subscribers.append(callback)
+    def _add_subscriber(self, callback: Callable, params: Optional[List[str]] = None):
+        params = [] if params is None else params
+        self._subscribers.append(Subscriber(callback=callback, params=params))
 
     def _remove_subscriber(self, callback: Callable):
-        self._subscribers.remove(callback)
+        elem = [x for x in self._subscribers if x.callback == callback]
+        if not elem:
+            raise ValueError
+        self._subscribers.remove(elem[0])
 
     def _get_sorted_tasks(self) -> List[List[Task]]:
         dag = self.__build_dag()
@@ -181,19 +186,24 @@ class Pipeline(_Entity):
         dag.remove_nodes_from(remove)
         return list(nodes for nodes in nx.topological_generations(dag) if (Task in (type(node) for node in nodes)))
 
-    def subscribe(self, callback: Callable[[Pipeline, Job], None]):
+    def subscribe(
+        self,
+        callback: Callable[[Pipeline, Job], None],
+        params: Optional[List[str]] = None,
+    ):
         """Subscribe a function to be called on `Job^` status change.
         The subscription is applied to all jobs created from the pipeline's execution.
 
         Parameters:
             callback (Callable[[Pipeline^, Job^], None]): The callable function to be called on
                 status change.
+            params (Optional[List[str]]): The parameters to be passed to the _callback_.
         Note:
             Notification will be available only for jobs created after this subscription.
         """
         import taipy.core as tp
 
-        return tp.subscribe_pipeline(callback, self)
+        return tp.subscribe_pipeline(callback, params, self)
 
     def unsubscribe(self, callback: Callable[[Pipeline, Job], None]):
         """Unsubscribe a function that is called when the status of a `Job^` changes.

--- a/taipy/core/scenario/_scenario_manager.py
+++ b/taipy/core/scenario/_scenario_manager.py
@@ -134,7 +134,7 @@ class _ScenarioManager(_Manager[Scenario]):
 
     @classmethod
     def __get_status_notifier_callbacks(cls, scenario: Scenario) -> List:
-        return [partial(c, scenario) for c in scenario.subscribers]
+        return [partial(c.callback, scenario) for c in scenario.subscribers]
 
     @classmethod
     def _get_primary(cls, cycle: Cycle) -> Optional[Scenario]:

--- a/taipy/core/scenario/_scenario_manager.py
+++ b/taipy/core/scenario/_scenario_manager.py
@@ -45,17 +45,26 @@ class _ScenarioManager(_Manager[Scenario]):
     _ENTITY_NAME = Scenario.__name__
 
     @classmethod
-    def _subscribe(cls, callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):
+    def _subscribe(
+        cls,
+        callback: Callable[[Scenario, Job], None],
+        params: Optional[List[str]] = None,
+        scenario: Optional[Scenario] = None,
+    ):
         if scenario is None:
             scenarios = cls._get_all()
             for scn in scenarios:
-                cls.__add_subscriber(callback, scn)
+                cls.__add_subscriber(callback, params, scn)
             return
 
-        cls.__add_subscriber(callback, scenario)
+        cls.__add_subscriber(callback, params, scenario)
 
     @classmethod
-    def _unsubscribe(cls, callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):
+    def _unsubscribe(
+        cls,
+        callback: Callable[[Scenario, Job], None],
+        scenario: Optional[Scenario] = None,
+    ):
         if scenario is None:
             scenarios = cls._get_all()
             for scn in scenarios:
@@ -65,8 +74,8 @@ class _ScenarioManager(_Manager[Scenario]):
         cls.__remove_subscriber(callback, scenario)
 
     @classmethod
-    def __add_subscriber(cls, callback, scenario):
-        scenario._add_subscriber(callback)
+    def __add_subscriber(cls, callback, params, scenario):
+        scenario._add_subscriber(callback, params)
         cls._set(scenario)
 
     @classmethod
@@ -83,11 +92,15 @@ class _ScenarioManager(_Manager[Scenario]):
     ) -> Scenario:
         scenario_id = Scenario._new_id(config.id)
         pipelines = [
-            _PipelineManagerFactory._build_manager()._get_or_create(p_config, scenario_id)
+            _PipelineManagerFactory._build_manager()._get_or_create(
+                p_config, scenario_id
+            )
             for p_config in config.pipeline_configs
         ]
         cycle = (
-            _CycleManagerFactory._build_manager()._get_or_create(config.frequency, creation_date)
+            _CycleManagerFactory._build_manager()._get_or_create(
+                config.frequency, creation_date
+            )
             if config.frequency
             else None
         )
@@ -115,7 +128,9 @@ class _ScenarioManager(_Manager[Scenario]):
             raise NonExistingScenario(scenario_id)
         callbacks = cls.__get_status_notifier_callbacks(scenario)
         for pipeline in scenario.pipelines.values():
-            _PipelineManagerFactory._build_manager()._submit(pipeline, callbacks=callbacks, force=force)
+            _PipelineManagerFactory._build_manager()._submit(
+                pipeline, callbacks=callbacks, force=force
+            )
 
     @classmethod
     def __get_status_notifier_callbacks(cls, scenario: Scenario) -> List:
@@ -177,7 +192,9 @@ class _ScenarioManager(_Manager[Scenario]):
     def _tag(cls, scenario: Scenario, tag: str):
         tags = scenario.properties.get(cls._AUTHORIZED_TAGS_KEY, set())
         if len(tags) > 0 and tag not in tags:
-            raise UnauthorizedTagError(f"Tag `{tag}` not authorized by scenario configuration `{scenario.config_id}`")
+            raise UnauthorizedTagError(
+                f"Tag `{tag}` not authorized by scenario configuration `{scenario.config_id}`"
+            )
         if scenario.cycle:
             old_tagged_scenario = cls._get_by_tag(scenario.cycle, tag)
             if old_tagged_scenario:
@@ -202,23 +219,33 @@ class _ScenarioManager(_Manager[Scenario]):
         if len(scenarios) < 2:
             raise InsufficientScenarioToCompare
 
-        if not all([scenarios[0].config_id == scenario.config_id for scenario in scenarios]):
+        if not all(
+            [scenarios[0].config_id == scenario.config_id for scenario in scenarios]
+        ):
             raise DifferentScenarioConfigs
 
         if scenario_config := _ScenarioManager.__get_config(scenarios[0]):
             results = {}
             if data_node_config_id:
                 if data_node_config_id in scenario_config.comparators.keys():
-                    dn_comparators = {data_node_config_id: scenario_config.comparators[data_node_config_id]}
+                    dn_comparators = {
+                        data_node_config_id: scenario_config.comparators[
+                            data_node_config_id
+                        ]
+                    }
                 else:
                     raise NonExistingComparator
             else:
                 dn_comparators = scenario_config.comparators
 
             for data_node_config_id, comparators in dn_comparators.items():
-                data_nodes = [scenario.__getattr__(data_node_config_id).read() for scenario in scenarios]
+                data_nodes = [
+                    scenario.__getattr__(data_node_config_id).read()
+                    for scenario in scenarios
+                ]
                 results[data_node_config_id] = {
-                    comparator.__name__: comparator(*data_nodes) for comparator in comparators
+                    comparator.__name__: comparator(*data_nodes)
+                    for comparator in comparators
                 }
 
             return results

--- a/taipy/core/scenario/_scenario_repository.py
+++ b/taipy/core/scenario/_scenario_repository.py
@@ -15,6 +15,7 @@ from typing import List, Optional
 
 from taipy.core._repository import _FileSystemRepository
 from taipy.core.common import _utils
+from taipy.core.common._utils import Subscriber
 from taipy.core.common.alias import CycleId, PipelineId
 from taipy.core.config.config import Config
 from taipy.core.cycle._cycle_manager_factory import _CycleManagerFactory
@@ -53,9 +54,12 @@ class _ScenarioRepository(_FileSystemRepository[_ScenarioModel, Scenario]):
             is_primary=model.primary_scenario,
             tags=set(model.tags),
             cycle=self.__to_cycle(model.cycle),
-            subscribers={
-                _utils._load_fct(it["fct_module"], it["fct_name"]) for it in model.subscribers
-            },  # type: ignore
+            subscribers=[
+                Subscriber(
+                    _utils._load_fct(it["fct_module"], it["fct_name"]), it["fct_params"]
+                )
+                for it in model.subscribers
+            ],
         )
         return scenario
 
@@ -69,7 +73,9 @@ class _ScenarioRepository(_FileSystemRepository[_ScenarioModel, Scenario]):
 
     @staticmethod
     def __to_cycle(cycle_id: CycleId = None) -> Optional[Cycle]:
-        return _CycleManagerFactory._build_manager()._get(cycle_id) if cycle_id else None
+        return (
+            _CycleManagerFactory._build_manager()._get(cycle_id) if cycle_id else None
+        )
 
     @staticmethod
     def __to_cycle_id(cycle: Cycle = None) -> Optional[CycleId]:

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -186,7 +186,7 @@ class Scenario(_Entity):
 
     def _add_subscriber(self, callback: Callable, params: Optional[List[str]] = None):
         params = [] if params is None else params
-        self._subscribers.append(Subscriber(callable=callback, params=params))
+        self._subscribers.append(Subscriber(callback=callback, params=params))
 
     def _add_tag(self, tag: str):
         self._tags = _reload("scenario", self)._tags
@@ -203,7 +203,9 @@ class Scenario(_Entity):
         return tag in self.tags
 
     def _remove_subscriber(self, callback: Callable):
-        self._subscribers = [x for x in self._subscribers if x.callable != callback]
+        elem = [x for x in self._subscribers if x.callback == callback]
+        if elem:
+            self._subscribers.remove(elem[0])
 
     def _remove_tag(self, tag: str):
         self._tags = _reload("scenario", self)._tags

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union, Tuple
 
 from taipy.core.common._entity import _Entity
 from taipy.core.common._listattributes import _ListAttributes
@@ -21,6 +21,7 @@ from taipy.core.common._properties import _Properties
 from taipy.core.common._reload import _reload, _self_reload, _self_setter
 from taipy.core.common._validate_id import _validate_id
 from taipy.core.common.alias import PipelineId, ScenarioId
+from taipy.core.common._utils import Subscriber
 from taipy.core.config._config_template_handler import _ConfigTemplateHandler as _tpl
 from taipy.core.cycle.cycle import Cycle
 from taipy.core.exceptions.exceptions import NonExistingPipeline
@@ -60,7 +61,7 @@ class Scenario(_Entity):
         creation_date=None,
         is_primary: bool = False,
         cycle: Cycle = None,
-        subscribers: List[Callable] = None,
+        subscribers: List[Subscriber] = None,
         tags: Set[str] = None,
     ):
         self.config_id = _validate_id(config_id)
@@ -183,8 +184,9 @@ class Scenario(_Entity):
                     return task.output[protected_attribute_name]
         raise AttributeError(f"{attribute_name} is not an attribute of scenario {self.id}")
 
-    def _add_subscriber(self, callback: Callable):
-        self._subscribers.append(callback)
+    def _add_subscriber(self, callback: Callable, params: Optional[List[str]] = None):
+        params = [] if params is None else params
+        self._subscribers.append(Subscriber(callable=callback, params=params))
 
     def _add_tag(self, tag: str):
         self._tags = _reload("scenario", self)._tags
@@ -201,14 +203,18 @@ class Scenario(_Entity):
         return tag in self.tags
 
     def _remove_subscriber(self, callback: Callable):
-        self._subscribers.remove(callback)
+        self._subscribers = [x for x in self._subscribers if x.callable != callback]
 
     def _remove_tag(self, tag: str):
         self._tags = _reload("scenario", self)._tags
         if self.has_tag(tag):
             self._tags.remove(tag)
 
-    def subscribe(self, callback: Callable[[Scenario, Job], None]):
+    def subscribe(
+        self,
+        callback: Callable[[Scenario, Job], None],
+        params: Optional[List[str]] = None,
+    ):
         """Subscribe a function to be called on `Job^` status change.
 
         The subscription is applied to all jobs created from the scenario's execution.
@@ -216,13 +222,14 @@ class Scenario(_Entity):
         Parameters:
             callback (Callable[[Scenario^, Job^], None]): The callable function to be called
                 on status change.
+            params (Optional[List[str]]): The parameters to be passed to the _callback_.
 
         Note:
             Notification will be available only for jobs created after this subscription.
         """
         import taipy.core as tp
 
-        return tp.subscribe_scenario(callback, self)
+        return tp.subscribe_scenario(callback, params, self)
 
     def unsubscribe(self, callback: Callable[[Scenario, Job], None]):
         """Unsubscribe a function that is called when the status of a `Job^` changes.

--- a/taipy/core/scenario/scenario.py
+++ b/taipy/core/scenario/scenario.py
@@ -204,8 +204,9 @@ class Scenario(_Entity):
 
     def _remove_subscriber(self, callback: Callable):
         elem = [x for x in self._subscribers if x.callback == callback]
-        if elem:
-            self._subscribers.remove(elem[0])
+        if not elem:
+            raise ValueError
+        self._subscribers.remove(elem[0])
 
     def _remove_tag(self, tag: str):
         self._tags = _reload("scenario", self)._tags

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -13,7 +13,14 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional, Union
 
 from taipy.core.common._taipy_logger import _TaipyLogger
-from taipy.core.common.alias import CycleId, DataNodeId, JobId, PipelineId, ScenarioId, TaskId
+from taipy.core.common.alias import (
+    CycleId,
+    DataNodeId,
+    JobId,
+    PipelineId,
+    ScenarioId,
+    TaskId,
+)
 from taipy.core.config.config import Config
 from taipy.core.config.pipeline_config import PipelineConfig
 from taipy.core.config.scenario_config import ScenarioConfig
@@ -111,7 +118,9 @@ def get_tasks() -> List[Task]:
     return _TaskManagerFactory._build_manager()._get_all()
 
 
-def delete(entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]):
+def delete(
+    entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]
+):
     """Delete an entity and its nested entities.
 
     The given entity is deleted. The deletion is propagated to all nested entities that are
@@ -134,9 +143,13 @@ def delete(entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, C
     if entity_id.startswith(Cycle._ID_PREFIX):
         return _CycleManagerFactory._build_manager()._hard_delete(CycleId(entity_id))
     if entity_id.startswith(Scenario._ID_PREFIX):
-        return _ScenarioManagerFactory._build_manager()._hard_delete(ScenarioId(entity_id))
+        return _ScenarioManagerFactory._build_manager()._hard_delete(
+            ScenarioId(entity_id)
+        )
     if entity_id.startswith(Pipeline._ID_PREFIX):
-        return _PipelineManagerFactory._build_manager()._hard_delete(PipelineId(entity_id))
+        return _PipelineManagerFactory._build_manager()._hard_delete(
+            PipelineId(entity_id)
+        )
     if entity_id.startswith(Task._ID_PREFIX):
         return _TaskManagerFactory._build_manager()._hard_delete(TaskId(entity_id))
     if entity_id.startswith(DataNode._ID_PREFIX):
@@ -144,7 +157,9 @@ def delete(entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, C
     raise ModelNotFound("NOT_DETERMINED", entity_id)
 
 
-def get_scenarios(cycle: Optional[Cycle] = None, tag: Optional[str] = None) -> List[Scenario]:
+def get_scenarios(
+    cycle: Optional[Cycle] = None, tag: Optional[str] = None
+) -> List[Scenario]:
     """Return the list of all existing scenarios filtered by a cycle or a tag.
 
     If both _cycle_ and _tag_ are provided, the returned list contains scenarios
@@ -163,7 +178,9 @@ def get_scenarios(cycle: Optional[Cycle] = None, tag: Optional[str] = None) -> L
     if not cycle and tag:
         return _ScenarioManagerFactory._build_manager()._get_all_by_tag(tag)
     if cycle and tag:
-        cycles_scenarios = _ScenarioManagerFactory._build_manager()()._get_all_by_cycle(cycle)
+        cycles_scenarios = _ScenarioManagerFactory._build_manager()()._get_all_by_cycle(
+            cycle
+        )
         return [scenario for scenario in cycles_scenarios if scenario.has_tag(tag)]
     return []
 
@@ -246,10 +263,16 @@ def compare_scenarios(*scenarios: Scenario, data_node_config_id: Optional[str] =
         NonExistingScenarioConfig^: The scenario config of the provided scenarios could not
             be found.
     """
-    return _ScenarioManagerFactory._build_manager()._compare(*scenarios, data_node_config_id=data_node_config_id)
+    return _ScenarioManagerFactory._build_manager()._compare(
+        *scenarios, data_node_config_id=data_node_config_id
+    )
 
 
-def subscribe_scenario(callback: Callable[[Scenario, Job], None], params: Optional[List[str]] = None, scenario: Optional[Scenario] = None):
+def subscribe_scenario(
+    callback: Callable[[Scenario, Job], None],
+    params: Optional[List[str]] = None,
+    scenario: Optional[Scenario] = None,
+):
     """Subscribe a function to be called on job status change.
 
     The subscription is applied to all jobs created for the execution of _scenario_.
@@ -264,10 +287,15 @@ def subscribe_scenario(callback: Callable[[Scenario, Job], None], params: Option
     Note:
         Notifications are applied only for jobs created **after** this subscription.
     """
-    return _ScenarioManagerFactory._build_manager()._subscribe(callback, params, scenario)
+    params = [] if params is None else params
+    return _ScenarioManagerFactory._build_manager()._subscribe(
+        callback, params, scenario
+    )
 
 
-def unsubscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):
+def unsubscribe_scenario(
+    callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None
+):
     """Unsubscribe a function that is called when the status of a `Job^` changes.
 
     If _scenario_ is not provided, the subscription is removed for all scenarios.
@@ -282,7 +310,9 @@ def unsubscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Op
     return _ScenarioManagerFactory._build_manager()._unsubscribe(callback, scenario)
 
 
-def subscribe_pipeline(callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None):
+def subscribe_pipeline(
+    callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None
+):
     """Subscribe a function to be called on job status change.
 
     The subscription is applied to all jobs created for the execution of _pipeline_.
@@ -298,7 +328,9 @@ def subscribe_pipeline(callback: Callable[[Pipeline, Job], None], pipeline: Opti
     return _PipelineManagerFactory._build_manager()._subscribe(callback, pipeline)
 
 
-def unsubscribe_pipeline(callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None):
+def unsubscribe_pipeline(
+    callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None
+):
     """Unsubscribe a function that is called when the status of a Job changes.
 
     Parameters:
@@ -379,7 +411,9 @@ def get_cycles() -> List[Cycle]:
 
 
 def create_scenario(
-    config: ScenarioConfig, creation_date: Optional[datetime] = None, name: Optional[str] = None
+    config: ScenarioConfig,
+    creation_date: Optional[datetime] = None,
+    name: Optional[str] = None,
 ) -> Scenario:
     """Create and return a new scenario from a scenario configuration.
 
@@ -418,7 +452,9 @@ def clean_all_entities() -> bool:
         bool: True if the operation succeeded, False otherwise.
     """
     if not Config.global_config.clean_entities_enabled:
-        __logger.warning("Please set 'clean_entities_enabled' to True to clean all entities.")
+        __logger.warning(
+            "Please set 'clean_entities_enabled' to True to clean all entities."
+        )
         return False
 
     _DataManagerFactory._build_manager()._delete_all()

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -249,7 +249,7 @@ def compare_scenarios(*scenarios: Scenario, data_node_config_id: Optional[str] =
     return _ScenarioManagerFactory._build_manager()._compare(*scenarios, data_node_config_id=data_node_config_id)
 
 
-def subscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):
+def subscribe_scenario(callback: Callable[[Scenario, Job], None], params: Optional[List[str]] = None, scenario: Optional[Scenario] = None):
     """Subscribe a function to be called on job status change.
 
     The subscription is applied to all jobs created for the execution of _scenario_.
@@ -258,12 +258,13 @@ def subscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Opti
     Parameters:
         callback (Callable[[Scenario^, Job^], None]): The function to be called on
             status change.
+        params (Optional[List[str]]): The parameters to be passed to the _callback_.
         scenario (Optional[Scenario^]): The scenario that subscribes to _callback_.
             If None, the subscription is registered for all scenarios.
     Note:
         Notifications are applied only for jobs created **after** this subscription.
     """
-    return _ScenarioManagerFactory._build_manager()._subscribe(callback, scenario)
+    return _ScenarioManagerFactory._build_manager()._subscribe(callback, params, scenario)
 
 
 def unsubscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):

--- a/taipy/core/taipy.py
+++ b/taipy/core/taipy.py
@@ -13,14 +13,7 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional, Union
 
 from taipy.core.common._taipy_logger import _TaipyLogger
-from taipy.core.common.alias import (
-    CycleId,
-    DataNodeId,
-    JobId,
-    PipelineId,
-    ScenarioId,
-    TaskId,
-)
+from taipy.core.common.alias import CycleId, DataNodeId, JobId, PipelineId, ScenarioId, TaskId
 from taipy.core.config.config import Config
 from taipy.core.config.pipeline_config import PipelineConfig
 from taipy.core.config.scenario_config import ScenarioConfig
@@ -118,9 +111,7 @@ def get_tasks() -> List[Task]:
     return _TaskManagerFactory._build_manager()._get_all()
 
 
-def delete(
-    entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]
-):
+def delete(entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]):
     """Delete an entity and its nested entities.
 
     The given entity is deleted. The deletion is propagated to all nested entities that are
@@ -143,13 +134,9 @@ def delete(
     if entity_id.startswith(Cycle._ID_PREFIX):
         return _CycleManagerFactory._build_manager()._hard_delete(CycleId(entity_id))
     if entity_id.startswith(Scenario._ID_PREFIX):
-        return _ScenarioManagerFactory._build_manager()._hard_delete(
-            ScenarioId(entity_id)
-        )
+        return _ScenarioManagerFactory._build_manager()._hard_delete(ScenarioId(entity_id))
     if entity_id.startswith(Pipeline._ID_PREFIX):
-        return _PipelineManagerFactory._build_manager()._hard_delete(
-            PipelineId(entity_id)
-        )
+        return _PipelineManagerFactory._build_manager()._hard_delete(PipelineId(entity_id))
     if entity_id.startswith(Task._ID_PREFIX):
         return _TaskManagerFactory._build_manager()._hard_delete(TaskId(entity_id))
     if entity_id.startswith(DataNode._ID_PREFIX):
@@ -157,9 +144,7 @@ def delete(
     raise ModelNotFound("NOT_DETERMINED", entity_id)
 
 
-def get_scenarios(
-    cycle: Optional[Cycle] = None, tag: Optional[str] = None
-) -> List[Scenario]:
+def get_scenarios(cycle: Optional[Cycle] = None, tag: Optional[str] = None) -> List[Scenario]:
     """Return the list of all existing scenarios filtered by a cycle or a tag.
 
     If both _cycle_ and _tag_ are provided, the returned list contains scenarios
@@ -178,9 +163,7 @@ def get_scenarios(
     if not cycle and tag:
         return _ScenarioManagerFactory._build_manager()._get_all_by_tag(tag)
     if cycle and tag:
-        cycles_scenarios = _ScenarioManagerFactory._build_manager()()._get_all_by_cycle(
-            cycle
-        )
+        cycles_scenarios = _ScenarioManagerFactory._build_manager()()._get_all_by_cycle(cycle)
         return [scenario for scenario in cycles_scenarios if scenario.has_tag(tag)]
     return []
 
@@ -263,9 +246,7 @@ def compare_scenarios(*scenarios: Scenario, data_node_config_id: Optional[str] =
         NonExistingScenarioConfig^: The scenario config of the provided scenarios could not
             be found.
     """
-    return _ScenarioManagerFactory._build_manager()._compare(
-        *scenarios, data_node_config_id=data_node_config_id
-    )
+    return _ScenarioManagerFactory._build_manager()._compare(*scenarios, data_node_config_id=data_node_config_id)
 
 
 def subscribe_scenario(
@@ -288,14 +269,10 @@ def subscribe_scenario(
         Notifications are applied only for jobs created **after** this subscription.
     """
     params = [] if params is None else params
-    return _ScenarioManagerFactory._build_manager()._subscribe(
-        callback, params, scenario
-    )
+    return _ScenarioManagerFactory._build_manager()._subscribe(callback, params, scenario)
 
 
-def unsubscribe_scenario(
-    callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None
-):
+def unsubscribe_scenario(callback: Callable[[Scenario, Job], None], scenario: Optional[Scenario] = None):
     """Unsubscribe a function that is called when the status of a `Job^` changes.
 
     If _scenario_ is not provided, the subscription is removed for all scenarios.
@@ -311,7 +288,7 @@ def unsubscribe_scenario(
 
 
 def subscribe_pipeline(
-    callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None
+    callback: Callable[[Pipeline, Job], None], params: Optional[List[str]] = None, pipeline: Optional[Pipeline] = None
 ):
     """Subscribe a function to be called on job status change.
 
@@ -320,17 +297,16 @@ def subscribe_pipeline(
     Parameters:
         callback (Callable[[Pipeline^, Job^], None]): The callable function to be called on
             status change.
+        params (Optional[List[str]]): The parameters to be passed to the _callback_.
         pipeline (Optional[Pipeline^]): The pipeline to subscribe on. If None, the subscription
             is actived for all pipelines.
     Note:
         Notifications are applied only for jobs created **after** this subscription.
     """
-    return _PipelineManagerFactory._build_manager()._subscribe(callback, pipeline)
+    return _PipelineManagerFactory._build_manager()._subscribe(callback, params, pipeline)
 
 
-def unsubscribe_pipeline(
-    callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None
-):
+def unsubscribe_pipeline(callback: Callable[[Pipeline, Job], None], pipeline: Optional[Pipeline] = None):
     """Unsubscribe a function that is called when the status of a Job changes.
 
     Parameters:
@@ -452,9 +428,7 @@ def clean_all_entities() -> bool:
         bool: True if the operation succeeded, False otherwise.
     """
     if not Config.global_config.clean_entities_enabled:
-        __logger.warning(
-            "Please set 'clean_entities_enabled' to True to clean all entities."
-        )
+        __logger.warning("Please set 'clean_entities_enabled' to True to clean all entities.")
         return False
 
     _DataManagerFactory._build_manager()._delete_all()

--- a/tests/core/pipeline/test_pipeline.py
+++ b/tests/core/pipeline/test_pipeline.py
@@ -299,7 +299,7 @@ def test_subscribe_pipeline():
     with mock.patch("taipy.core.subscribe_pipeline") as mck:
         pipeline = Pipeline("id", {}, [])
         pipeline.subscribe(None)
-        mck.assert_called_once_with(None, pipeline)
+        mck.assert_called_once_with(None, None, pipeline)
 
 
 def test_unsubscribe_pipeline():

--- a/tests/core/pipeline/test_pipeline_manager.py
+++ b/tests/core/pipeline/test_pipeline_manager.py
@@ -377,7 +377,7 @@ def test_pipeline_notification_subscribe(mocker):
     callback.assert_called()
 
     # test pipeline subscribe notification
-    _PipelineManager._subscribe(notify_1, pipeline)
+    _PipelineManager._subscribe(callback=notify_1, pipeline=pipeline)
     _PipelineManager._submit(pipeline.id)
 
     notify_1.assert_called_3_times()
@@ -387,7 +387,7 @@ def test_pipeline_notification_subscribe(mocker):
     # test pipeline unsubscribe notification
     # test subscribe notification only on new job
     _PipelineManager._unsubscribe(notify_1, pipeline)
-    _PipelineManager._subscribe(notify_2, pipeline)
+    _PipelineManager._subscribe(callback=notify_2, pipeline=pipeline)
     _PipelineManager._submit(pipeline.id)
 
     notify_1.assert_not_called()
@@ -417,9 +417,9 @@ def test_pipeline_notification_unsubscribe(mocker):
     notify_1 = notify1
     notify_2 = notify2
 
-    _PipelineManager._subscribe(notify_1, pipeline)
+    _PipelineManager._subscribe(callback=notify_1, pipeline=pipeline)
     _PipelineManager._unsubscribe(notify_1, pipeline)
-    _PipelineManager._subscribe(notify_2, pipeline)
+    _PipelineManager._subscribe(callback=notify_2, pipeline=pipeline)
     _PipelineManager._submit(pipeline.id)
 
     with pytest.raises(ValueError):

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -14,6 +14,7 @@ from unittest import mock
 
 import pytest
 
+from taipy.core.common._utils import Subscriber
 from taipy.core.common.alias import ScenarioId
 from taipy.core.cycle._cycle_manager import _CycleManager
 from taipy.core.exceptions.exceptions import InvalidConfigurationId
@@ -110,7 +111,14 @@ def test_add_and_remove_tag():
 
 
 def test_auto_set_and_reload(cycle, current_datetime, pipeline):
-    scenario_1 = Scenario("foo", [], {"name": "bar"}, creation_date=current_datetime, is_primary=False, cycle=None)
+    scenario_1 = Scenario(
+        "foo",
+        [],
+        {"name": "bar"},
+        creation_date=current_datetime,
+        is_primary=False,
+        cycle=None,
+    )
     _ScenarioManager._set(scenario_1)
     _PipelineManager._set(pipeline)
     _CycleManager._set(cycle)
@@ -149,7 +157,7 @@ def test_auto_set_and_reload(cycle, current_datetime, pipeline):
     assert scenario_2.is_primary
 
     assert len(scenario_1.subscribers) == 0
-    scenario_1.subscribers.append(print)
+    scenario_1.subscribers.append(Subscriber(print, []))
     assert len(scenario_1.subscribers) == 1
     assert len(scenario_2.subscribers) == 1
 
@@ -157,15 +165,15 @@ def test_auto_set_and_reload(cycle, current_datetime, pipeline):
     assert len(scenario_1.subscribers) == 0
     assert len(scenario_2.subscribers) == 0
 
-    scenario_1.subscribers.extend([print, map])
+    scenario_1.subscribers.extend([Subscriber(print, []), Subscriber(map, [])])
     assert len(scenario_1.subscribers) == 2
     assert len(scenario_2.subscribers) == 2
 
-    scenario_1.subscribers.remove(print)
+    scenario_1.subscribers.remove(Subscriber(print, []))
     assert len(scenario_1.subscribers) == 1
     assert len(scenario_2.subscribers) == 1
 
-    scenario_1.subscribers + print + len
+    scenario_1.subscribers + [Subscriber(print, [])] + [Subscriber(len, [])]
     assert len(scenario_1.subscribers) == 3
     assert len(scenario_2.subscribers) == 3
 
@@ -238,7 +246,7 @@ def test_subscribe_scenario():
     with mock.patch("taipy.core.subscribe_scenario") as mock_subscribe:
         scenario = Scenario("foo", [], {})
         scenario.subscribe(None)
-        mock_subscribe.assert_called_once_with(None, scenario)
+        mock_subscribe.assert_called_once_with(None, None, scenario)
 
 
 def test_unsubscribe_scenario():

--- a/tests/core/scenario/test_scenario.py
+++ b/tests/core/scenario/test_scenario.py
@@ -173,7 +173,7 @@ def test_auto_set_and_reload(cycle, current_datetime, pipeline):
     assert len(scenario_1.subscribers) == 1
     assert len(scenario_2.subscribers) == 1
 
-    scenario_1.subscribers + [Subscriber(print, [])] + [Subscriber(len, [])]
+    scenario_1.subscribers + print + len
     assert len(scenario_1.subscribers) == 3
     assert len(scenario_2.subscribers) == 3
 

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -317,7 +317,7 @@ def test_notification_subscribe(mocker):
     mocker.patch.object(_utils, "_load_fct", side_effect=[notify_1, notify_2])
 
     # test subscribing notification
-    _ScenarioManager._subscribe(notify_1, scenario)
+    _ScenarioManager._subscribe(callback=notify_1, scenario=scenario)
     _ScenarioManager._submit(scenario)
     notify_1.assert_called_3_times()
 
@@ -327,7 +327,7 @@ def test_notification_subscribe(mocker):
     # test notis subscribe only on new jobs
     # _ScenarioManager._get(scenario)
     _ScenarioManager._unsubscribe(notify_1, scenario)
-    _ScenarioManager._subscribe(notify_2, scenario)
+    _ScenarioManager._subscribe(callback=notify_2, scenario=scenario)
     _ScenarioManager._submit(scenario)
 
     notify_1.assert_not_called()
@@ -371,9 +371,9 @@ def test_notification_unsubscribe(mocker):
     notify_2 = notify2
 
     # test subscribing notification
-    _ScenarioManager._subscribe(notify_1, scenario)
+    _ScenarioManager._subscribe(callback=notify_1, scenario=scenario)
     _ScenarioManager._unsubscribe(notify_1, scenario)
-    _ScenarioManager._subscribe(notify_2, scenario)
+    _ScenarioManager._subscribe(callback=notify_2, scenario=scenario)
     _ScenarioManager._submit(scenario.id)
 
     with pytest.raises(ValueError):
@@ -849,15 +849,33 @@ def test_tags():
     _Scheduler._update_job_config()
 
     cycle_1 = _CycleManager._create(Frequency.DAILY, name="today", creation_date=datetime.now())
-    cycle_2 = _CycleManager._create(Frequency.DAILY, name="tomorrow", creation_date=datetime.now() + timedelta(days=1))
+    cycle_2 = _CycleManager._create(
+        Frequency.DAILY,
+        name="tomorrow",
+        creation_date=datetime.now() + timedelta(days=1),
+    )
     cycle_3 = _CycleManager._create(
-        Frequency.DAILY, name="yesterday", creation_date=datetime.now() + timedelta(days=-1)
+        Frequency.DAILY,
+        name="yesterday",
+        creation_date=datetime.now() + timedelta(days=-1),
     )
 
     scenario_no_tag = Scenario("SCENARIO_no_tag", [], {}, ScenarioId("SCENARIO_no_tag"), cycle=cycle_1)
-    scenario_1_tag = Scenario("SCENARIO_1_tag", [], {}, ScenarioId("SCENARIO_1_tag"), cycle=cycle_1, tags={"fst"})
+    scenario_1_tag = Scenario(
+        "SCENARIO_1_tag",
+        [],
+        {},
+        ScenarioId("SCENARIO_1_tag"),
+        cycle=cycle_1,
+        tags={"fst"},
+    )
     scenario_2_tags = Scenario(
-        "SCENARIO_2_tags", [], {}, ScenarioId("SCENARIO_2_tags"), cycle=cycle_2, tags={"fst", "scd"}
+        "SCENARIO_2_tags",
+        [],
+        {},
+        ScenarioId("SCENARIO_2_tags"),
+        cycle=cycle_2,
+        tags={"fst", "scd"},
     )
 
     # Test has_tag

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -161,10 +161,10 @@ class TestTaipy:
     def test_subscribe_pipeline(self, pipeline):
         with mock.patch("taipy.core.pipeline._pipeline_manager._PipelineManager._subscribe") as mck:
             tp.subscribe_pipeline(print)
-            mck.assert_called_once_with(print, None)
+            mck.assert_called_once_with(print, None, None)
         with mock.patch("taipy.core.pipeline._pipeline_manager._PipelineManager._subscribe") as mck:
             tp.subscribe_pipeline(print, pipeline=pipeline)
-            mck.assert_called_once_with(print, pipeline)
+            mck.assert_called_once_with(print, None, pipeline)
 
     def test_unsubscribe_pipeline(self, pipeline):
         with mock.patch("taipy.core.pipeline._pipeline_manager._PipelineManager._unsubscribe") as mck:

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -145,10 +145,10 @@ class TestTaipy:
     def test_subscribe_scenario(self, scenario):
         with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._subscribe") as mck:
             tp.subscribe_scenario(print)
-            mck.assert_called_once_with(print, None)
+            mck.assert_called_once_with(print, [], None)
         with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._subscribe") as mck:
             tp.subscribe_scenario(print, scenario=scenario)
-            mck.assert_called_once_with(print, scenario)
+            mck.assert_called_once_with(print, [], scenario)
 
     def test_unsubscribe_scenario(self, scenario):
         with mock.patch("taipy.core.scenario._scenario_manager._ScenarioManager._unsubscribe") as mck:


### PR DESCRIPTION
This PR adds an option to create subscribers with parameters. This functionality is implemented in both `Scenario` and `Pipeline`. The main idea is that the list of subscribers of an entity is no longer just a list of callbacks but a list of a `Subscriber` object, which is a named tuple with two attributes: callback and params.

Please challenge this implementation and let me know if there are any other ideas.