### PR TITLE
Feature #184 - rename path to default_path and make path settable (#209)

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,7 +7,7 @@ pip install taipy-core
 
 ## Development version
 
-You can install the development version of _taipy_ with _pip_ and _git_:
+You can install the development version of _taipy-core_ with _pip_ and _git_:
 ```
 pip install git+https://git@github.com/Avaiga/taipy-core
 ```

--- a/taipy/core/config/config.py
+++ b/taipy/core/config/config.py
@@ -487,13 +487,13 @@ class Config:
 
     @classmethod
     def configure_csv_data_node(
-        cls, id: str, path: str, has_header: bool = True, scope=DataNodeConfig._DEFAULT_SCOPE, **properties
+        cls, id: str, default_path: str, has_header: bool = True, scope=DataNodeConfig._DEFAULT_SCOPE, **properties
     ):
         """Configure a new CSV data node configuration.
 
         Parameters:
             id (str): The unique identifier of the new CSV data node configuration.
-            path (str): The path of the CSV file.
+            default_path (str): The default path of the CSV file.
             has_header (bool): If True, indicates that the CSV file has a header.
             scope (Scope^): The scope of the CSV data node configuration. The default value
                 is `Scope.SCENARIO`.
@@ -505,14 +505,14 @@ class Config:
         from taipy.core.data import CSVDataNode
 
         return cls.configure_data_node(
-            id, CSVDataNode.storage_type(), scope=scope, path=path, has_header=has_header, **properties
+            id, CSVDataNode.storage_type(), scope=scope, default_path=default_path, has_header=has_header, **properties
         )
 
     @classmethod
     def configure_excel_data_node(
         cls,
         id: str,
-        path: str,
+        default_path: str,
         has_header: bool = True,
         sheet_name: Union[List[str], str] = None,
         scope: Scope = DataNodeConfig._DEFAULT_SCOPE,
@@ -522,7 +522,7 @@ class Config:
 
         Parameters:
             id (str): The unique identifier of the new Excel data node configuration.
-            path (str): The path of the Excel file.
+            default_path (str): The path of the Excel file.
             has_header (bool): If True, indicates that the Excel file has a header.
             sheet_name (Union[List[str], str]): The list of sheet names to be used. This
                 can be a unique name.
@@ -539,7 +539,7 @@ class Config:
             id,
             ExcelDataNode.storage_type(),
             scope=scope,
-            path=path,
+            default_path=default_path,
             has_header=has_header,
             sheet_name=sheet_name,
             **properties,

--- a/tests/core/config/checker/test_data_node_config_checker.py
+++ b/tests/core/config/checker/test_data_node_config_checker.py
@@ -49,7 +49,7 @@ class TestDataNodeConfigChecker:
         config._data_nodes["default"].storage_type = "csv"
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "sql"
         collector = IssueCollector()
@@ -59,7 +59,7 @@ class TestDataNodeConfigChecker:
         config._data_nodes["default"].storage_type = "excel"
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "pickle"
         collector = IssueCollector()
@@ -115,13 +115,13 @@ class TestDataNodeConfigChecker:
         config._data_nodes["default"].storage_type = "csv"
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "csv"
         config._data_nodes["default"].properties = {"has_header": True}
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "csv"
         config._data_nodes["default"].properties = {"path": "bar"}
@@ -144,13 +144,13 @@ class TestDataNodeConfigChecker:
         config._data_nodes["default"].storage_type = "excel"
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "excel"
         config._data_nodes["default"].properties = {"has_header": True}
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        assert len(collector.errors) == 0
 
         config._data_nodes["default"].storage_type = "excel"
         config._data_nodes["default"].properties = {"path": "bar"}

--- a/tests/core/config/test_config.py
+++ b/tests/core/config/test_config.py
@@ -19,13 +19,13 @@ class TestConfig:
         a, b, c, d, e = "foo", "path", True, Scope.PIPELINE, "numpy"
         with mock.patch("taipy.core.config.config.Config.configure_data_node") as mck:
             Config.configure_csv_data_node(a, b, c, d, exposed_type=e)
-            mck.assert_called_once_with(a, "csv", scope=d, path=b, has_header=c, exposed_type=e)
+            mck.assert_called_once_with(a, "csv", scope=d, default_path=b, has_header=c, exposed_type=e)
 
     def test_configure_excel_data_node(self):
         a, b, c, d, e, f = "foo", "path", True, "Sheet1", Scope.PIPELINE, "numpy"
         with mock.patch("taipy.core.config.config.Config.configure_data_node") as mck:
             Config.configure_excel_data_node(a, b, c, d, e, exposed_type=f)
-            mck.assert_called_once_with(a, "excel", scope=e, path=b, has_header=c, sheet_name=d, exposed_type=f)
+            mck.assert_called_once_with(a, "excel", scope=e, default_path=b, has_header=c, sheet_name=d, exposed_type=f)
 
     def test_configure_generic_data_node(self):
         a, b, c, d, e, f, g = "foo", print, print, Scope.PIPELINE, tuple([]), tuple([]), "qux"

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -54,15 +54,7 @@ def test_data_node_config_check():
         Config.check()
 
     with pytest.raises(ConfigurationIssueError):
-        Config.configure_data_node("data_nodes", storage_type="csv")
-        Config.check()
-
-    with pytest.raises(ConfigurationIssueError):
         Config.configure_data_node("data_nodes", storage_type="sql")
-        Config.check()
-
-    with pytest.raises(ConfigurationIssueError):
-        Config.configure_data_node("data_nodes", storage_type="excel")
         Config.check()
 
     with pytest.raises(ConfigurationIssueError):
@@ -141,3 +133,20 @@ def test_data_node_with_env_variable_in_read_fct_params():
             "data_node", storage_type="generic", read_fct_params=["ENV[FOO]", "my_param", "ENV[BAZ]"]
         )
         assert Config.data_nodes["data_node"].read_fct_params == ["bar", "my_param", "qux"]
+
+
+def test_config_data_node_default_path():
+    dn_config = Config.configure_data_node("data_node", "pickle", default_path="foo.p")
+    assert dn_config.default_path == "foo.p"
+    dn = _DataManager._get_or_create(dn_config)
+    assert dn.path == "foo.p"
+    dn.path = "baz.p"
+    assert dn.path == "baz.p"
+
+
+def test_config_data_node_path_deprecated():
+    with pytest.warns(DeprecationWarning):
+        dn_config = Config.configure_data_node("data_node", "pickle", path="foo.p")
+        assert dn_config.path == "foo.p"
+        dn = _DataManager._get_or_create(dn_config)
+        assert dn.path == "foo.p"

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -166,3 +166,17 @@ class TestCSVDataNode:
 
         csv_dn.write(None)
         assert len(csv_dn.read()) == 0
+
+    def test_set_path(self):
+        dn = CSVDataNode("foo", Scope.PIPELINE, properties={"default_path": "foo.csv"})
+        assert dn.path == "foo.csv"
+        dn.path = "bar.csv"
+        assert dn.path == "bar.csv"
+
+    def test_path_deprecated(self):
+        with pytest.warns(DeprecationWarning):
+            CSVDataNode("foo", Scope.PIPELINE, properties={"path": "foo.csv"})
+
+    def test_raise_error_when_path_not_exist(self):
+        with pytest.raises(MissingRequiredProperty):
+            CSVDataNode("foo", Scope.PIPELINE)

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -13,15 +13,15 @@ import os
 import pathlib
 
 import pytest
-
 from taipy.core.common.alias import DataNodeId
 from taipy.core.common.scope import Scope
-from taipy.core.config.config import Config
 from taipy.core.config.data_node_config import DataNodeConfig
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data.csv import CSVDataNode
 from taipy.core.data.in_memory import InMemoryDataNode
 from taipy.core.data.pickle import PickleDataNode
+
+from taipy.core.config.config import Config
 from taipy.core.exceptions.exceptions import InvalidDataNodeType, ModelNotFound
 
 
@@ -217,14 +217,14 @@ class TestDataManager:
         csv = _DataManager._create_and_set(csv_dn, None)
         assert csv.config_id == "foo"
         assert isinstance(csv, CSVDataNode)
-        assert csv.path == "path_from_config_file"
+        assert csv._path == "path_from_config_file"
         assert csv.has_header
 
         csv_dn = Config.configure_data_node(id="baz", storage_type="csv", path="bar", has_header=True)
         csv = _DataManager._create_and_set(csv_dn, None)
         assert csv.config_id == "baz"
         assert isinstance(csv, CSVDataNode)
-        assert csv.path == "bar"
+        assert csv._path == "bar"
         assert csv.has_header
 
     def test_get_if_not_exists(self):

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -16,12 +16,12 @@ from typing import Dict
 import numpy as np
 import pandas as pd
 import pytest
-
 from taipy.core.common.alias import DataNodeId
 from taipy.core.common.scope import Scope
-from taipy.core.config.config import Config
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data.excel import ExcelDataNode
+
+from taipy.core.config.config import Config
 from taipy.core.exceptions.exceptions import (
     MissingRequiredProperty,
     NoData,
@@ -658,3 +658,17 @@ class TestExcelDataNode:
 
         for sheet_name in sheet_names:
             assert np.array_equal(data_pandas[sheet_name].values, multi_sheet_content[sheet_name].values)
+
+    def test_set_path(self):
+        dn = ExcelDataNode("foo", Scope.PIPELINE, properties={"default_path": "foo.xlsx"})
+        assert dn.path == "foo.xlsx"
+        dn.path = "bar.xlsx"
+        assert dn.path == "bar.xlsx"
+
+    def test_path_deprecated(self):
+        with pytest.warns(DeprecationWarning):
+            ExcelDataNode("foo", Scope.PIPELINE, properties={"path": "foo.csv"})
+
+    def test_raise_error_when_path_not_exist(self):
+        with pytest.raises(MissingRequiredProperty):
+            ExcelDataNode("foo", Scope.PIPELINE)

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -13,11 +13,11 @@ import os
 import pathlib
 
 import pytest
-
 from taipy.core.common.scope import Scope
-from taipy.core.config.config import Config
 from taipy.core.data._data_manager import _DataManager
 from taipy.core.data.pickle import PickleDataNode
+
+from taipy.core.config.config import Config
 from taipy.core.exceptions.exceptions import InvalidConfigurationId, NoData
 
 
@@ -93,3 +93,31 @@ class TestPickleDataNodeEntity:
         )
         assert isinstance(pickle_dict.read(), dict)
         assert pickle_dict.read() == {"bar": 12, "baz": "qux", "quux": [13]}
+
+    def test_default_path_overrides_path(self):
+        dn = PickleDataNode(
+            "foo",
+            Scope.PIPELINE,
+            properties={
+                "default_data": "bar",
+                "default_path": "foo.FILE.p",
+                "path": "bar.FILE.p",
+            },
+        )
+        assert dn.path == "foo.FILE.p"
+
+    def test_set_path(self):
+        dn = PickleDataNode("foo", Scope.PIPELINE, properties={"default_path": "foo.p"})
+        assert dn.path == "foo.p"
+        dn.path = "bar.p"
+        assert dn.path == "bar.p"
+
+    def test_is_file_generated(self):
+        dn = PickleDataNode("foo", Scope.PIPELINE, properties={})
+        assert dn.is_file_generated
+        dn.path = "bar.p"
+        assert not dn.is_file_generated
+
+    def test_path_deprecated(self):
+        with pytest.warns(DeprecationWarning):
+            PickleDataNode("foo", Scope.PIPELINE, properties={"path": "foo.p"})

--- a/tests/test_complex_application.py
+++ b/tests/test_complex_application.py
@@ -73,16 +73,16 @@ def test_complex():
     excel_path_out = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/res.xlsx")
     csv_path_out = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/res.csv")
 
-    inp_csv_dn_1 = Config.configure_csv_data_node("dn_csv_in_1", path=csv_path_inp)
-    inp_csv_dn_2 = Config.configure_csv_data_node("dn_csv_in_2", path=csv_path_inp)
+    inp_csv_dn_1 = Config.configure_csv_data_node("dn_csv_in_1", default_path=csv_path_inp)
+    inp_csv_dn_2 = Config.configure_csv_data_node("dn_csv_in_2", default_path=csv_path_inp)
 
-    inp_excel_dn_1 = Config.configure_excel_data_node("dn_excel_in_1", path=excel_path_inp, sheet_name="Sheet1")
-    inp_excel_dn_2 = Config.configure_excel_data_node("dn_excel_in_2", path=excel_path_inp, sheet_name="Sheet1")
+    inp_excel_dn_1 = Config.configure_excel_data_node("dn_excel_in_1", default_path=excel_path_inp, sheet_name="Sheet1")
+    inp_excel_dn_2 = Config.configure_excel_data_node("dn_excel_in_2", default_path=excel_path_inp, sheet_name="Sheet1")
 
     placeholder = Config.configure_in_memory_data_node("dn_placeholder", 10)
 
-    dn_csv_sum = Config.configure_csv_data_node("dn_sum_csv", path=csv_path_sum)
-    dn_excel_sum = Config.configure_excel_data_node("dn_sum_excel", path=excel_path_sum, sheet_name="Sheet1")
+    dn_csv_sum = Config.configure_csv_data_node("dn_sum_csv", default_path=csv_path_sum)
+    dn_excel_sum = Config.configure_excel_data_node("dn_sum_excel", default_path=excel_path_sum, sheet_name="Sheet1")
 
     dn_subtract_csv_excel = Config.configure_pickle_data_node("dn_subtract_csv_excel")
     dn_mult = Config.configure_pickle_data_node("dn_mult")


### PR DESCRIPTION
* default_path for pickle data node

* Fix

* Update pickle.py

* fix test

* Fix the is_file_generated method.

* rename

* Default path for csv and excel

* Modify test as path is not required anymore

* Add test configure data node default path

* update configure csv and pickle data node signature

* Add test for old API

Co-authored-by: jrobinAV <88036007+jrobinAV@users.noreply.github.com>
(cherry picked from commit 51f028017327f93028a5c7acc702b556009226b5)