### PR TITLE
fix failed test due to recursive call when raise NotMatchSheetNameAnd…

### DIFF
--- a/src/taipy/core/data/excel.py
+++ b/src/taipy/core/data/excel.py
@@ -84,7 +84,7 @@ class ExcelDataNode(DataNode):
         if self.__HAS_HEADER_PROPERTY not in properties.keys():
             properties[self.__HAS_HEADER_PROPERTY] = True
         if self.__EXPOSED_TYPE_PROPERTY in properties.keys():
-            properties[self.__EXPOSED_TYPE_PROPERTY] = self.__exposed_types_to_dict(properties)
+            properties[self.__EXPOSED_TYPE_PROPERTY] = self.__exposed_types_to_dict(properties, config_id)
 
         self._path = properties.get(self.__PATH_KEY, properties.get(self.__DEFAULT_PATH_KEY))
         if self._path is None:
@@ -118,7 +118,7 @@ class ExcelDataNode(DataNode):
         self._path = value
         self.properties[self.__PATH_KEY] = value
 
-    def __exposed_types_to_dict(self, properties):
+    def __exposed_types_to_dict(self, properties, config_id):
         if properties[self.__EXPOSED_TYPE_PROPERTY] == self.__EXPOSED_TYPE_NUMPY:
             return properties[self.__EXPOSED_TYPE_PROPERTY]
         if isinstance(properties[self.__EXPOSED_TYPE_PROPERTY], Dict):
@@ -131,7 +131,7 @@ class ExcelDataNode(DataNode):
                     for sheet_name, custom_obj in zip(sheet_names, properties[self.__EXPOSED_TYPE_PROPERTY])
                 }
             raise NotMatchSheetNameAndCustomObject(
-                f"Sheet name and custom object do not match for data node config {self.config_id}."
+                f"Sheet name and custom object do not match for data node config {config_id}."
             )
         return {sheet_name: properties[self.__EXPOSED_TYPE_PROPERTY] for sheet_name in sheet_names}
 

--- a/tests/core/_scheduler/test_scheduler.py
+++ b/tests/core/_scheduler/test_scheduler.py
@@ -203,10 +203,10 @@ def test_submit_task_in_parallel():
     task = _create_task(partial(lock_multiply, lock))
 
     with lock:
-        job = _Scheduler.submit_task(task, "submit_id")
         assert task.output[f"{task.config_id}_output0"].read() == 0
+        job = _Scheduler.submit_task(task, "submit_id")
         assert_true_after_1_minute_max(job.is_running)
-        assert len(_SchedulerFactory._dispatcher._dispatched_processes) == 1
+        assert_true_after_1_minute_max(lambda: len(_SchedulerFactory._dispatcher._dispatched_processes) == 1)
 
     assert_true_after_1_minute_max(lambda: task.output[f"{task.config_id}_output0"].read() == 42)
     assert_true_after_1_minute_max(job.is_completed)

--- a/tests/core/_scheduler/test_scheduler.py
+++ b/tests/core/_scheduler/test_scheduler.py
@@ -263,14 +263,13 @@ def test_submit_task_multithreading_multiple_task_in_sync_way_to_check_job_statu
     with lock_0:
         job_0 = _Scheduler.submit_task(task_0, "submit_id_0")
         assert_true_after_1_minute_max(job_0.is_running)
-        assert len(_SchedulerFactory._dispatcher._dispatched_processes) == 1
+        assert_true_after_1_minute_max(lambda: len(_SchedulerFactory._dispatcher._dispatched_processes) == 1)
         with lock_1:
             with lock_2:
-                job_2 = _Scheduler.submit_task(task_2, "submit_id_2")
-                job_1 = _Scheduler.submit_task(task_1, "submit_id_1")
-
                 assert task_1.output[f"{task_1.config_id}_output0"].read() == 0
                 assert task_2.output[f"{task_2.config_id}_output0"].read() == 0
+                job_2 = _Scheduler.submit_task(task_2, "submit_id_2")
+                job_1 = _Scheduler.submit_task(task_1, "submit_id_1")
                 assert_true_after_1_minute_max(job_0.is_running)
                 assert_true_after_1_minute_max(job_1.is_pending)
                 assert_true_after_1_minute_max(job_2.is_running)


### PR DESCRIPTION
Fix recursive error raising NotMatchSheetNameAndCustomObject

**Cause found**:  the fail test is caused by trying to call self.config_id before it is set => call __getattr__ => call self._properties (not yet set) => call __getattr__ and created a recursion