### PR TITLE
Fix - SQLDataNode write

### DIFF
--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -15,6 +15,7 @@ import urllib.parse
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import MetaData, Table, create_engine, text
 
@@ -181,6 +182,9 @@ class SQLDataNode(DataNode):
             if isinstance(data, pd.DataFrame):
                 self._insert_dicts(data.to_dict(orient="records"), table, connection)
                 return
+
+            if isinstance(data, np.ndarray):
+                data = data.tolist()
 
             if not isinstance(data, list):
                 data = [data]

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -13,7 +13,7 @@ import os
 import re
 import urllib.parse
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -202,9 +202,9 @@ class SQLDataNode(DataNode):
                 self._insert_tuples([(x,) for x in data], table, connection)
 
     @staticmethod
-    def _insert_tuples(data: Sequence[Tuple], write_table: Any, connection: Any) -> None:
+    def _insert_tuples(data: List[Union[Tuple, List]], write_table: Any, connection: Any) -> None:
         """
-        :param data: a list of tuples
+        :param data: a list of tuples or lists
         :param write_table: a SQLAlchemy object that represents a table
         :param connection: a SQLAlchemy connection to write the data
 
@@ -225,9 +225,9 @@ class SQLDataNode(DataNode):
                 transaction.commit()
 
     @staticmethod
-    def _insert_dicts(data: Sequence[Dict], write_table: Any, connection: Any) -> None:
+    def _insert_dicts(data: List[Dict], write_table: Any, connection: Any) -> None:
         """
-        :param data: a list of tuples
+        :param data: a list of dictionaries
         :param write_table: a SQLAlchemy object that represents a table
         :param connection: a SQLAlchemy connection to write the data
 

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -177,22 +177,17 @@ class SQLDataNode(DataNode):
         """Check data against a collection of types to handle insertion on the database."""
 
         engine = self.__engine()
+
+        if isinstance(data, pd.DataFrame):
+            data = data.to_dict(orient="records")
+        elif isinstance(data, np.ndarray):
+            data = data.tolist()
+        if not isinstance(data, list):
+            data = [data]
+        if len(data) == 0:
+            return
         with engine.connect() as connection:
             table = self._create_table(engine)
-
-            if isinstance(data, pd.DataFrame):
-                self._insert_dicts(data.to_dict(orient="records"), table, connection)
-                return
-
-            if isinstance(data, np.ndarray):
-                data = data.tolist()
-
-            if not isinstance(data, list):
-                data = [data]
-
-            if len(data) == 0:
-                return
-
             if isinstance(data[0], (tuple, list)):
                 self._insert_tuples(data, table, connection)
             elif isinstance(data[0], dict):

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -169,13 +169,10 @@ class SQLDataNode(DataNode):
             if not isinstance(data, list):
                 data = [data]
 
-            if isinstance(data[0], tuple):
+            if isinstance(data[0], (tuple, list)):
                 self.__insert_tuples(data, write_table, connection)
             elif isinstance(data[0], dict):
                 self.__insert_dicts(data, write_table, connection)
-            elif isinstance(data[0], list):
-                data = list(tuple(x) for x in data)
-                self.__insert_tuples(data, write_table, connection)
             # If data is a primitive type, it will be inserted as a tuple of one element.
             else:
                 self.__insert_tuples([(x,) for x in data], write_table, connection)

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -175,6 +175,7 @@ class SQLDataNode(DataNode):
 
     def _write(self, data) -> None:
         """Check data against a collection of types to handle insertion on the database."""
+
         engine = self.__engine()
         with engine.connect() as connection:
             table = self._create_table(engine)
@@ -188,6 +189,9 @@ class SQLDataNode(DataNode):
 
             if not isinstance(data, list):
                 data = [data]
+
+            if len(data) == 0:
+                return
 
             if isinstance(data[0], (tuple, list)):
                 self._insert_tuples(data, table, connection)

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -210,6 +210,8 @@ class TestSQLDataNode:
             (np.array([1, 2, 3, 4]), [(1,), (2,), (3,), (4,)], "_insert_tuples"),
             (np.array([np.array([1, 2]), np.array([3, 4])]), [[1, 2], [3, 4]], "_insert_tuples"),
             ([], None, None),
+            (pd.DataFrame([]), None, None),
+            (np.array([]), None, None),
         ],
     )
     def test_write(self, data, written_data, called_func):
@@ -252,6 +254,8 @@ class TestSQLDataNode:
                     dn2._write(data)
                     insert_dicts_mock.assert_not_called()
                     insert_tuples_mock.assert_not_called()
+                    engine_mock.assert_not_called()
+                    create_table_mock.assert_not_called()
                 return
 
             with mock.patch(f"src.taipy.core.data.sql.SQLDataNode.{called_func}") as insert_mock:

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -12,6 +12,7 @@
 from importlib import util
 from unittest import mock
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -206,6 +207,8 @@ class TestSQLDataNode:
             ([1, 2, 3, 4], [(1,), (2,), (3,), (4,)], "_insert_tuples"),
             ("foo", [("foo",)], "_insert_tuples"),
             (None, [(None,)], "_insert_tuples"),
+            (np.array([1, 2, 3, 4]), [(1,), (2,), (3,), (4,)], "_insert_tuples"),
+            (np.array([np.array([1, 2]), np.array([3, 4])]), [[1, 2], [3, 4]], "_insert_tuples"),
         ],
     )
     def test_write(self, data, written_data, called_func):


### PR DESCRIPTION
Problems:
- Insert list/tuple: Incorrect SQL syntax
- Insert dict: Table columns are not automatically loaded so it cannot map the values to correct column, so null is inserted everywhere.

Fix:
- Table autoload: Now load all table columns after connected to database so insert_dicts will work.
- Insert list/tuple: Fix SQL syntax, remove insert_lists method and convert lists to tuples instead.

Improvements:
- Refactor _write logic, convert everything to a list first if it is not a list (except pd.DataFrame).