### PR TITLE
Use ubuntu-latest instead of 18.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-versions: [3.9]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-versions: [ '3.8', '3.9', '3.10' ]
-        os: [ ubuntu-18.04, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         python-versions: [ '3.8', '3.9', '3.10' ]
-        os: [ ubuntu-18.04, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-package:
     timeout-minutes: 20
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -53,7 +53,7 @@ jobs:
     needs: [test-package]
     timeout-minutes: 20
     environment: publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         python-versions: ['3.8','3.9','3.10']
-        os: [ubuntu-18.04,windows-latest,macos-latest]
+        os: [ubuntu-latest,windows-latest,macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-package:
     timeout-minutes: 20
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -53,7 +53,7 @@ jobs:
     needs: [test-package]
     timeout-minutes: 20
     name: Release taipy-core Package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-versions: ['3.8', '3.9', '3.10']
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: tox -p all
 
       - name: Ensure no usage of manager or repository classes without factory
-        if: matrix.python-versions == '3.10' && matrix.os == 'ubuntu-18.04'
+        if: matrix.python-versions == '3.10' && matrix.os == 'ubuntu-latest'
         run: |
           ! grep -rP '_ScenarioManager(?!Factory)' taipy --exclude="_scenario_manager*.py" --exclude-dir="__pycache__"
           ! grep -rP '_DataManager(?!Factory)' taipy --exclude="_data_manager*.py" --exclude-dir="__pycache__"


### PR DESCRIPTION
We were using an old version of ubuntu. There is a option to update the version to Ubuntu 20.04 which is already 2 years old. What do you think about just using `ubuntu-latest` as we already use the latest version for windows and mac.

In case you prefer using a fixed version, let me know and I can update the PR.