### PR TITLE
Feature/#152 expose get_parents function

### DIFF
--- a/src/taipy/core/__init__.py
+++ b/src/taipy/core/__init__.py
@@ -34,6 +34,7 @@ from .taipy import (
     get_data_nodes,
     get_jobs,
     get_latest_job,
+    get_parents,
     get_pipelines,
     get_primary,
     get_primary_scenarios,

--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -49,7 +49,7 @@ class _DataManager(_Manager[DataNode]):
         data_nodes = {}
         for dn_config, owner_id in dn_configs_and_owner_id:
             if dn := created_data_nodes.get((dn_config, owner_id)):
-                if dn.parent_ids:
+                if task_id:
                     dn.parent_ids.update([task_id])
             else:
                 dn = cls._create_and_set(dn_config, owner_id, {task_id} if task_id else None)

--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -44,18 +44,12 @@ class _DataManager(_Manager[DataNode]):
             owner_id = pipeline_id if scope == Scope.PIPELINE else scenario_id if scope == Scope.SCENARIO else None
             dn_configs_and_owner_id.append((dn_config, owner_id))
 
-        created_data_nodes = cls._repository._get_by_configs_and_owner_ids(dn_configs_and_owner_id)  # type: ignore
+        data_nodes = cls._repository._get_by_configs_and_owner_ids(dn_configs_and_owner_id)  # type: ignore
 
-        data_nodes = {}
-        for dn_config, owner_id in dn_configs_and_owner_id:
-            if dn := created_data_nodes.get((dn_config, owner_id)):
-                if task_id:
-                    dn.parent_ids.update([task_id])
-            else:
-                dn = cls._create_and_set(dn_config, owner_id, {task_id} if task_id else None)
-            data_nodes[dn_config] = dn
-
-        return data_nodes
+        return {
+            dn_config: data_nodes.get((dn_config, owner_id)) or cls._create_and_set(dn_config, owner_id, None)
+            for dn_config, owner_id in dn_configs_and_owner_id
+        }
 
     @classmethod
     def _create_and_set(

--- a/src/taipy/core/data/_data_repository.py
+++ b/src/taipy/core/data/_data_repository.py
@@ -110,7 +110,7 @@ class _DataRepository(_AbstractRepository[_DataNodeModel, DataNode]):  # type: i
             data_node.storage_type(),
             data_node._name,
             data_node.owner_id,
-            list(data_node.parent_ids),
+            list(data_node._parent_ids),
             data_node._last_edit_date.isoformat() if data_node._last_edit_date else None,
             data_node._job_ids.data,
             data_node._cacheable,

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -120,6 +120,12 @@ class DataNode(_Entity):
         _warn_deprecated("parent_id", suggest="owner_id")
         self.owner_id = val
 
+    def get_parents(self):
+        """Get parents of the Data Node entity"""
+        from ... import core as tp
+
+        return tp.get_parents(self)
+
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
     def parent_ids(self):

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -92,7 +92,7 @@ class DataNode(_Entity):
         self.config_id = _validate_id(config_id)
         self.id = id or DataNodeId(self.__ID_SEPARATOR.join([self._ID_PREFIX, self.config_id, str(uuid.uuid4())]))
         self.owner_id = owner_id
-        self.parent_ids = parent_ids or set()
+        self._parent_ids = parent_ids or set()
         self._scope = scope
         self._last_edit_date = last_edit_date
         self._name = name or self.id
@@ -119,6 +119,11 @@ class DataNode(_Entity):
         """
         _warn_deprecated("parent_id", suggest="owner_id")
         self.owner_id = val
+
+    @property  # type: ignore
+    @_self_reload(_MANAGER_NAME)
+    def parent_ids(self):
+        return self._parent_ids
 
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)

--- a/src/taipy/core/pipeline/_pipeline_manager.py
+++ b/src/taipy/core/pipeline/_pipeline_manager.py
@@ -93,8 +93,17 @@ class _PipelineManager(_Manager[Pipeline]):
             owner_id,
             {scenario_id} if scenario_id else None,
         )
+        for task in tasks:
+            task._parent_ids.update([pipeline_id])
+        cls.__save_tasks(tasks)
         cls._set(pipeline)
         return pipeline
+
+    @classmethod
+    def __save_tasks(cls, tasks):
+        task_manager = _TaskManagerFactory._build_manager()
+        for i in tasks:
+            task_manager._set(i)
 
     @classmethod
     def _submit(

--- a/src/taipy/core/pipeline/_pipeline_repository.py
+++ b/src/taipy/core/pipeline/_pipeline_repository.py
@@ -45,7 +45,7 @@ class _PipelineRepository(_AbstractRepository[_PipelineModel, Pipeline]):  # typ
         return _PipelineModel(
             pipeline.id,
             pipeline.owner_id,
-            list(pipeline.parent_ids),
+            list(pipeline._parent_ids),
             pipeline.config_id,
             pipeline._properties.data,
             self.__to_task_ids(pipeline._tasks),

--- a/src/taipy/core/pipeline/pipeline.py
+++ b/src/taipy/core/pipeline/pipeline.py
@@ -226,6 +226,12 @@ class Pipeline(_Entity):
         dag.remove_nodes_from(remove)
         return list(nodes for nodes in nx.topological_generations(dag) if (Task in (type(node) for node in nodes)))
 
+    def get_parents(self):
+        """Get parents of the pipeline entity"""
+        from ... import core as tp
+
+        return tp.get_parents(self)
+
     def subscribe(
         self,
         callback: Callable[[Pipeline, Job], None],

--- a/src/taipy/core/pipeline/pipeline.py
+++ b/src/taipy/core/pipeline/pipeline.py
@@ -93,6 +93,9 @@ class Pipeline(_Entity):
         p = tp.get(id)
         self.__dict__ = p.__dict__
 
+    def __hash__(self):
+        return hash(self.id)
+
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
     def tasks(self):

--- a/src/taipy/core/pipeline/pipeline.py
+++ b/src/taipy/core/pipeline/pipeline.py
@@ -62,7 +62,7 @@ class Pipeline(_Entity):
         self.config_id = _validate_id(config_id)
         self.id: PipelineId = pipeline_id or self._new_id(self.config_id)
         self.owner_id = owner_id
-        self.parent_ids = parent_ids or set()
+        self._parent_ids = parent_ids or set()
         self._tasks = tasks
 
         self._subscribers = _ListAttributes(self, subscribers or list())
@@ -83,6 +83,11 @@ class Pipeline(_Entity):
         """
         _warn_deprecated("parent_id", suggest="owner_id")
         self.owner_id = val
+
+    @property  # type: ignore
+    @_self_reload(_MANAGER_NAME)
+    def parent_ids(self):
+        return self._parent_ids
 
     def __getstate__(self):
         return self.id

--- a/src/taipy/core/scenario/_scenario_manager.py
+++ b/src/taipy/core/scenario/_scenario_manager.py
@@ -116,8 +116,17 @@ class _ScenarioManager(_Manager[Scenario]):
             is_primary=is_primary_scenario,
             cycle=cycle,
         )
+        for pipeline in pipelines:
+            pipeline._parent_ids.update([scenario_id])
+        cls.__save_pipelines(pipelines)
         cls._set(scenario)
         return scenario
+
+    @classmethod
+    def __save_pipelines(cls, pipelines):
+        pipeline_manager = _PipelineManagerFactory._build_manager()
+        for i in pipelines:
+            pipeline_manager._set(i)
 
     @classmethod
     def _submit(

--- a/src/taipy/core/scenario/scenario.py
+++ b/src/taipy/core/scenario/scenario.py
@@ -87,6 +87,9 @@ class Scenario(_Entity):
         sc = tp.get(id)
         self.__dict__ = sc.__dict__
 
+    def __hash__(self):
+        return hash(self.id)
+
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
     def pipelines(self):

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -12,11 +12,12 @@
 import pathlib
 import shutil
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from taipy.config.config import Config
 from taipy.logger._taipy_logger import _TaipyLogger
 
+from .common._entity import _Entity
 from .common.alias import CycleId, DataNodeId, JobId, PipelineId, ScenarioId, TaskId
 from .config.pipeline_config import PipelineConfig
 from .config.scenario_config import ScenarioConfig
@@ -498,3 +499,51 @@ def export_scenario(
         _ScenarioManagerFactory._build_manager()._export(scenario_id, folder_path)
     for job_id in entity_ids.job_ids:
         _JobManagerFactory._build_manager()._export(job_id, folder_path)
+
+
+def get_parents(
+    entity: Union[TaskId, DataNodeId, PipelineId, Task, DataNode, Pipeline], parent_dict=None
+) -> Dict[str, Set[_Entity]]:
+    """Get parents of the entity from the entity or its identifier.
+
+    Parameters:
+        entity (Union[TaskId^, DataNodeId^, PipelineId^, Task, DataNode, Pipeline]): The entity of its identifier
+            to get the parent.<br/>
+    Returns:
+        Dict[str, Set[_Entity]]: The dictionary of parents
+        matching the corresponding entity. An empty dictionary if the entity does not have parents.
+    Raises:
+        ModelNotFound^: If _entity_ does not match a correct entity pattern.
+    """
+
+    def update_parent_dict(parents_set, parent_dict, key):
+        if key in parent_dict.keys():
+            parent_dict[key].update(parents_set)
+        else:
+            parent_dict[key] = parents_set
+
+    if isinstance(entity, str):
+        entity = get(entity)  # type: ignore
+
+    if not parent_dict:
+        parent_dict = {}
+
+    parents = {get(parent) for parent in entity.parent_ids}  # type: ignore
+
+    if isinstance(entity, Pipeline):
+        parent_entity_key = "scenarios"
+        update_parent_dict(parents, parent_dict, parent_entity_key)
+
+    if isinstance(entity, Task):
+        parent_entity_key = "pipelines"
+        update_parent_dict(parents, parent_dict, parent_entity_key)
+        for parent in parent_dict[parent_entity_key]:
+            get_parents(parent, parent_dict)
+
+    if isinstance(entity, DataNode):
+        parent_entity_key = "tasks"
+        update_parent_dict(parents, parent_dict, parent_entity_key)
+        for parent in parent_dict[parent_entity_key]:
+            get_parents(parent, parent_dict)
+
+    return parent_dict

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -530,8 +530,10 @@ def get_parents(
     if isinstance(entity, str):
         entity = get(entity)  # type: ignore
 
-    if not parent_dict:
-        parent_dict = {}
+    parent_dict = parent_dict or dict()
+
+    if isinstance(entity, (Scenario, Cycle)):
+        return parent_dict
 
     parents = {get(parent) for parent in entity.parent_ids}  # type: ignore
 

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -507,12 +507,16 @@ def get_parents(
     """Get the parents of an entity from itself or its identifier.
 
     Parameters:
-        entity (Union[TaskId^, DataNodeId^, PipelineId^, Task, DataNode, Pipeline]): The entity or its identifier
-            to get the parents.<br/>
+        entity (Union[TaskId^, DataNodeId^, PipelineId^, Task, DataNode, Pipeline]): The entity or its
+            identifier to get the parents.<br/>
     Returns:
-        Dict[str, Set[_Entity]]: The dictionary of parents matching the corresponding entity with the key
-        is the level of the parent for example 'scenarios', 'pipelines', 'tasks' and the value is a list
-        of the parent entities. An empty dictionary if the entity does not have parents.
+        Dict[str, Set[_Entity]]: The dictionary of all parent entities.
+            They are grouped by their type (Scenario^, Pipelines^, or tasks^) so each key corresponds
+            to a level of the parents and the value is a set of the parent entities.
+            An empty dictionary is returned if the entity does not have parents.<br/>
+            Example: The following instruction returns all the pipelines that include the
+            datanode identified by "my_datanode_id".
+            `taipy.get_parents("id_of_my_datanode")["pipelines"]`
     Raises:
         ModelNotFound^: If _entity_ does not match a correct entity pattern.
     """

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -504,14 +504,15 @@ def export_scenario(
 def get_parents(
     entity: Union[TaskId, DataNodeId, PipelineId, Task, DataNode, Pipeline], parent_dict=None
 ) -> Dict[str, Set[_Entity]]:
-    """Get parents of the entity from the entity or its identifier.
+    """Get the parents of an entity from itself or its identifier.
 
     Parameters:
-        entity (Union[TaskId^, DataNodeId^, PipelineId^, Task, DataNode, Pipeline]): The entity of its identifier
-            to get the parent.<br/>
+        entity (Union[TaskId^, DataNodeId^, PipelineId^, Task, DataNode, Pipeline]): The entity or its identifier
+            to get the parents.<br/>
     Returns:
-        Dict[str, Set[_Entity]]: The dictionary of parents
-        matching the corresponding entity. An empty dictionary if the entity does not have parents.
+        Dict[str, Set[_Entity]]: The dictionary of parents matching the corresponding entity with the key
+        is the level of the parent for example 'scenarios', 'pipelines', 'tasks' and the value is a list
+        of the parent entities. An empty dictionary if the entity does not have parents.
     Raises:
         ModelNotFound^: If _entity_ does not match a correct entity pattern.
     """

--- a/src/taipy/core/task/_task_manager.py
+++ b/src/taipy/core/task/_task_manager.py
@@ -72,7 +72,7 @@ class _TaskManager(_Manager[Task]):
         tasks = []
         for task_config, owner_id in tasks_configs_and_owner_id:
             if task := tasks_by_config.get((task_config, owner_id)):
-                task.parent_ids.update([pipeline_id])
+                tasks.append(task)
             else:
                 inputs = [data_nodes[input_config] for input_config in task_config.input_configs]
                 outputs = [data_nodes[output_config] for output_config in task_config.output_configs]
@@ -82,12 +82,12 @@ class _TaskManager(_Manager[Task]):
                     inputs,
                     outputs,
                     owner_id=owner_id,
-                    parent_ids={pipeline_id} if pipeline_id else None,
+                    parent_ids=set(),
                 )
                 for dn in set(inputs + outputs):
-                    dn.parent_ids.update([task.id])
-            cls._set(task)
-            tasks.append(task)
+                    dn._parent_ids.update([task.id])
+                cls._set(task)
+                tasks.append(task)
         return tasks
 
     @classmethod

--- a/src/taipy/core/task/_task_repository.py
+++ b/src/taipy/core/task/_task_repository.py
@@ -35,7 +35,7 @@ class _TaskRepository(_AbstractRepository[_TaskModel, Task]):  # type: ignore
         return _TaskModel(
             id=task.id,
             owner_id=task.owner_id,
-            parent_ids=list(task.parent_ids),
+            parent_ids=list(task._parent_ids),
             config_id=task.config_id,
             input_ids=self.__to_ids(task.input.values()),
             function_name=task._function.__name__,

--- a/src/taipy/core/task/task.py
+++ b/src/taipy/core/task/task.py
@@ -77,6 +77,12 @@ class Task(_Entity):
         _warn_deprecated("parent_id", suggest="owner_id")
         self.owner_id = val
 
+    def get_parents(self):
+        """Get parents of the task entity"""
+        from ... import core as tp
+
+        return tp.get_parents(self)
+
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
     def parent_ids(self):

--- a/src/taipy/core/task/task.py
+++ b/src/taipy/core/task/task.py
@@ -56,7 +56,7 @@ class Task(_Entity):
         self.config_id = _validate_id(config_id)
         self.id = id or TaskId(self.__ID_SEPARATOR.join([self._ID_PREFIX, self.config_id, str(uuid.uuid4())]))
         self.owner_id = owner_id
-        self.parent_ids = parent_ids or set()
+        self._parent_ids = parent_ids or set()
         self.__input = {dn.config_id: dn for dn in input or []}
         self.__output = {dn.config_id: dn for dn in output or []}
         self._function = function
@@ -76,6 +76,11 @@ class Task(_Entity):
         """
         _warn_deprecated("parent_id", suggest="owner_id")
         self.owner_id = val
+
+    @property  # type: ignore
+    @_self_reload(_MANAGER_NAME)
+    def parent_ids(self):
+        return self._parent_ids
 
     def __hash__(self):
         return hash(self.id)

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -211,8 +211,8 @@ class TestCSVDataNode:
         with pytest.raises(InvalidExposedType):
             CSVDataNode("foo", Scope.PIPELINE, properties={"path": path, "exposed_type": "foo"})
 
-    def test_get_system_modified_date_instead_of_last_edit_date(self):
-        temp_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.csv")
+    def test_get_system_modified_date_instead_of_last_edit_date(self, tmpdir_factory):
+        temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.csv"))
         pd.DataFrame([]).to_csv(temp_file_path)
         dn = CSVDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "exposed_type": "pandas"})
 
@@ -231,5 +231,3 @@ class TestCSVDataNode:
 
         dn.write(pd.DataFrame([7, 8, 9]))
         assert new_edit_date < dn.last_edit_date
-
-        os.unlink(temp_file_path)

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -488,6 +488,13 @@ class TestDataNode:
         assert dn_1.name == "def"
         assert dn_2.name == "def"
 
+        assert dn_1.parent_ids == set()
+        assert dn_2.parent_ids == set()
+        dn_1._parent_ids.update(["t1"])
+        _DataManager._set(dn_1)
+        assert dn_1.parent_ids == {"t1"}
+        assert dn_2.parent_ids == {"t1"}
+
         assert not dn_1.edition_in_progress
         dn_1.edition_in_progress = True
         assert dn_1.edition_in_progress
@@ -529,7 +536,6 @@ class TestDataNode:
         with dn_1 as dn:
             assert dn.config_id == "foo"
             assert dn.owner_id is None
-            assert dn.parent_ids == set()
             assert dn.scope == Scope.PIPELINE
             assert dn.last_edition_date == new_datetime
             assert dn.name == "def"
@@ -551,7 +557,6 @@ class TestDataNode:
 
             assert dn.config_id == "foo"
             assert dn.owner_id is None
-            assert dn.parent_ids == set()
             assert dn.scope == Scope.PIPELINE
             assert dn.last_edition_date == new_datetime
             assert dn.name == "def"
@@ -562,7 +567,6 @@ class TestDataNode:
 
         assert dn_1.config_id == "foo"
         assert dn_1.owner_id is None
-        assert dn.parent_ids == set()
         assert dn_1.scope == Scope.CYCLE
         assert dn_1.last_edition_date == new_datetime_2
         assert dn_1.name == "abc"

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -576,6 +576,11 @@ class TestDataNode:
         assert not dn_1._is_in_context
         assert len(dn_1.job_ids) == 1
 
+    def test_get_parents(self, data_node):
+        with mock.patch("src.taipy.core.get_parents") as mck:
+            data_node.get_parents()
+            mck.assert_called_once_with(data_node)
+
     def test_unlock_edition_deprecated(self):
         dn = FakeDataNode("foo")
 

--- a/tests/core/data/test_excel_data_node.py
+++ b/tests/core/data/test_excel_data_node.py
@@ -874,8 +874,8 @@ class TestExcelDataNode:
                 },
             )
 
-    def test_get_system_modified_date_instead_of_last_edit_date(self):
-        temp_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.xlsx")
+    def test_get_system_modified_date_instead_of_last_edit_date(self, tmpdir_factory):
+        temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.xlsx"))
         pd.DataFrame([]).to_excel(temp_file_path)
         dn = ExcelDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "exposed_type": "pandas"})
 
@@ -894,5 +894,3 @@ class TestExcelDataNode:
 
         dn.write(pd.DataFrame([7, 8, 9]))
         assert new_edit_date < dn.last_edit_date
-
-        os.unlink(temp_file_path)

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -242,8 +242,8 @@ class TestJSONDataNode:
         dn.write({"other": "stuff"})
         assert dn.read() == {"other": "stuff"}
 
-    def test_get_system_modified_date_instead_of_last_edit_date(self):
-        temp_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.json")
+    def test_get_system_modified_date_instead_of_last_edit_date(self, tmpdir_factory):
+        temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.json"))
         pd.DataFrame([]).to_json(temp_file_path)
         dn = JSONDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "exposed_type": "pandas"})
 
@@ -262,5 +262,3 @@ class TestJSONDataNode:
 
         dn.write([1, 2, 3])
         assert new_edit_date < dn.last_edit_date
-
-        os.unlink(temp_file_path)

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -142,8 +142,8 @@ class TestPickleDataNodeEntity:
         dn.write({"other": "stuff"})
         assert dn.read() == {"other": "stuff"}
 
-    def test_get_system_modified_date_instead_of_last_edit_date(self):
-        temp_file_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.pickle")
+    def test_get_system_modified_date_instead_of_last_edit_date(self, tmpdir_factory):
+        temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.pickle"))
         pd.DataFrame([]).to_pickle(temp_file_path)
         dn = PickleDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "exposed_type": "pandas"})
 
@@ -162,5 +162,3 @@ class TestPickleDataNodeEntity:
 
         dn.write(pd.DataFrame([7, 8, 9]))
         assert new_edit_date < dn.last_edit_date
-
-        os.unlink(temp_file_path)

--- a/tests/core/pipeline/test_pipeline.py
+++ b/tests/core/pipeline/test_pipeline.py
@@ -341,6 +341,12 @@ def test_auto_set_and_reload(task):
     assert not pipeline_1._is_in_context
 
 
+def test_get_parents(pipeline):
+    with mock.patch("src.taipy.core.get_parents") as mck:
+        pipeline.get_parents()
+        mck.assert_called_once_with(pipeline)
+
+
 def test_subscribe_pipeline():
     with mock.patch("src.taipy.core.subscribe_pipeline") as mck:
         pipeline = Pipeline("id", {}, [])

--- a/tests/core/pipeline/test_pipeline.py
+++ b/tests/core/pipeline/test_pipeline.py
@@ -270,6 +270,10 @@ def test_auto_set_and_reload(task):
 
     assert pipeline_1.parent_ids == set()
     assert pipeline_2.parent_ids == set()
+    pipeline_1._parent_ids.update(["sc1"])
+    _PipelineManager._set(pipeline_1)
+    assert pipeline_1.parent_ids == {"sc1"}
+    assert pipeline_2.parent_ids == {"sc1"}
 
     assert len(pipeline_1.tasks) == 0
     pipeline_1.tasks = [task]
@@ -318,7 +322,6 @@ def test_auto_set_and_reload(task):
         assert pipeline.owner_id is None
         assert len(pipeline.subscribers) == 0
         assert pipeline._is_in_context
-        assert pipeline.parent_ids == set()
 
         pipeline.tasks = []
         pipeline.owner_id = None
@@ -330,14 +333,12 @@ def test_auto_set_and_reload(task):
         assert pipeline.owner_id is None
         assert len(pipeline.subscribers) == 0
         assert pipeline._is_in_context
-        assert pipeline.parent_ids == set()
 
     assert pipeline_1.config_id == "foo"
     assert len(pipeline_1.tasks) == 0
     assert pipeline_1.owner_id is None
     assert len(pipeline_1.subscribers) == 1
     assert not pipeline_1._is_in_context
-    assert pipeline.parent_ids == set()
 
 
 def test_subscribe_pipeline():

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -242,6 +242,78 @@ def test_create_and_delete_scenario():
     assert len(_ScenarioManager._get_all()) == 0
 
 
+def test_assign_scenario_as_parent_of_pipeline():
+    dn_config_1 = Config.configure_data_node("dn_1", "in_memory", scope=Scope.SCENARIO)
+    dn_config_2 = Config.configure_data_node("dn_2", "in_memory", scope=Scope.SCENARIO)
+    dn_config_3 = Config.configure_data_node("dn_3", "in_memory", scope=Scope.SCENARIO)
+    task_config_1 = Config.configure_task("task_1", print, [dn_config_1], [dn_config_2])
+    task_config_2 = Config.configure_task("task_2", print, [dn_config_2], [dn_config_3])
+    task_config_3 = Config.configure_task("task_3", print, [dn_config_2], [dn_config_3])
+    pipeline_config_1 = Config.configure_pipeline("pipeline_1", [task_config_1, task_config_2])
+    pipeline_config_2 = Config.configure_pipeline("pipeline_2", [task_config_1, task_config_3])
+
+    scenario_config_1 = Config.configure_scenario("scenario_1", [pipeline_config_1])
+    scenario_config_2 = Config.configure_scenario("scenario_2", [pipeline_config_1, pipeline_config_2])
+
+    pipeline = _PipelineManager._get_or_create(pipeline_config_1, "scenario_id")
+
+    assert pipeline.parent_ids == {"scenario_id"}
+    assert all([task.parent_ids == {pipeline.id} for task in pipeline.tasks.values()])
+
+    _PipelineManager._delete_all()
+
+    scenario = _ScenarioManager._create(scenario_config_1)
+    pipelines = scenario.pipelines.values()
+    assert all([pipeline.parent_ids == {scenario.id} for pipeline in pipelines])
+    for pipeline in pipelines:
+        assert all([task.parent_ids == {pipeline.id} for task in pipeline.tasks.values()])
+
+    scenario = _ScenarioManager._create(scenario_config_2)
+    pipelines = scenario.pipelines
+    assert all([pipeline.parent_ids == {scenario.id} for pipeline in pipelines.values()])
+    tasks = {}
+    for pipeline in pipelines.values():
+        tasks.update(pipeline.tasks)
+    assert tasks["task_1"].parent_ids == {pipelines["pipeline_1"].id, pipelines["pipeline_2"].id}
+    assert tasks["task_2"].parent_ids == {pipelines["pipeline_1"].id}
+    assert tasks["task_3"].parent_ids == {pipelines["pipeline_2"].id}
+
+    _ScenarioManager._hard_delete(scenario.id)
+
+    dn_config_1 = Config.configure_data_node("dn_1", "in_memory", scope=Scope.GLOBAL)
+    dn_config_2 = Config.configure_data_node("dn_2", "in_memory", scope=Scope.GLOBAL)
+    dn_config_3 = Config.configure_data_node("dn_3", "in_memory", scope=Scope.GLOBAL)
+    task_config_1 = Config.configure_task("task_1", print, [dn_config_1], [dn_config_2])
+    task_config_2 = Config.configure_task("task_2", print, [dn_config_2], [dn_config_3])
+    task_config_3 = Config.configure_task("task_3", print, [dn_config_2], [dn_config_3])
+    pipeline_config_1 = Config.configure_pipeline("pipeline_1", [task_config_1, task_config_2])
+    pipeline_config_2 = Config.configure_pipeline("pipeline_2", [task_config_1, task_config_3])
+
+    scenario_config_1 = Config.configure_scenario("scenario_1", [pipeline_config_1])
+    scenario_config_2 = Config.configure_scenario("scenario_2", [pipeline_config_1, pipeline_config_2])
+
+    scenario_1 = _ScenarioManager._create(scenario_config_1)
+    assert scenario_1.pipelines["pipeline_1"].parent_ids == {scenario_1.id}
+    tasks = {}
+    for pipeline in scenario_1.pipelines.values():
+        tasks.update(pipeline.tasks)
+    assert tasks["task_1"].parent_ids == {scenario_1.pipelines["pipeline_1"].id}
+    assert tasks["task_2"].parent_ids == {scenario_1.pipelines["pipeline_1"].id}
+
+    scenario_2 = _ScenarioManager._create(scenario_config_2)
+    assert scenario_1.pipelines["pipeline_1"].parent_ids == {scenario_1.id, scenario_2.id}
+    assert scenario_2.pipelines["pipeline_1"].parent_ids == {scenario_1.id, scenario_2.id}
+    assert scenario_2.pipelines["pipeline_2"].parent_ids == {scenario_2.id}
+
+    tasks = {}
+    for pipeline in scenario_2.pipelines.values():
+        tasks.update(pipeline.tasks)
+
+    assert tasks["task_1"].parent_ids == {scenario_2.pipelines["pipeline_1"].id, scenario_2.pipelines["pipeline_2"].id}
+    assert tasks["task_2"].parent_ids == {scenario_2.pipelines["pipeline_1"].id}
+    assert tasks["task_3"].parent_ids == {scenario_2.pipelines["pipeline_2"].id}
+
+
 def mult_by_2(nb: int):
     return nb * 2
 

--- a/tests/core/task/test_task.py
+++ b/tests/core/task/test_task.py
@@ -194,6 +194,12 @@ def test_auto_set_and_reload(data_node):
     assert not task_1._is_in_context
 
 
+def test_get_parents(task):
+    with mock.patch("src.taipy.core.get_parents") as mck:
+        task.get_parents()
+        mck.assert_called_once_with(task)
+
+
 def test_submit_task(task: Task):
     with mock.patch("src.taipy.core.task._task_manager._TaskManager._submit") as mock_submit:
         task.submit([], True)

--- a/tests/core/task/test_task.py
+++ b/tests/core/task/test_task.py
@@ -168,6 +168,13 @@ def test_auto_set_and_reload(data_node):
     assert task_1.function == mock_func
     assert task_2.function == mock_func
 
+    assert task_1.parent_ids == set()
+    assert task_2.parent_ids == set()
+    task_1._parent_ids.update(["p1"])
+    _TaskManager._set(task_1)
+    assert task_1.parent_ids == {"p1"}
+    assert task_2.parent_ids == {"p1"}
+
     with task_1 as task:
         assert task.config_id == "foo"
         assert task.owner_id is None

--- a/tests/core/task/test_task_manager.py
+++ b/tests/core/task/test_task_manager.py
@@ -82,27 +82,6 @@ def test_assign_task_as_parent_of_datanode():
     assert dns["dn_3"].parent_ids == {tasks[1].id}
 
 
-def test_assign_pipeline_as_parent_of_task():
-    dn_config_1 = Config.configure_data_node("dn_1", "in_memory", scope=Scope.SCENARIO)
-    dn_config_2 = Config.configure_data_node("dn_2", "in_memory", scope=Scope.SCENARIO)
-    dn_config_3 = Config.configure_data_node("dn_3", "in_memory", scope=Scope.SCENARIO)
-    task_config_1 = Config.configure_task("task_1", print, [dn_config_1], [dn_config_2])
-    task_config_2 = Config.configure_task("task_2", print, [dn_config_2], [dn_config_3])
-    task_config_3 = Config.configure_task("task_3", print, [dn_config_2], [dn_config_3])
-    tasks_1 = _TaskManager._bulk_get_or_create([task_config_1, task_config_2], "scenario_id", "pipeline_id_1")
-    tasks_2 = _TaskManager._bulk_get_or_create([task_config_1, task_config_3], "scenario_id", "pipeline_id_2")
-
-    assert len(tasks_1) == 2
-    assert len(tasks_2) == 2
-
-    # TODO: This test is currently failing due to persistency
-    # The feature of parent_ids still works but doesn't have persistency in it
-    # assert tasks_1[0].parent_ids == {"pipeline_id_1", "pipeline_id_2"}
-    assert tasks_2[0].parent_ids == {"pipeline_id_1", "pipeline_id_2"}
-    assert tasks_1[1].parent_ids == {"pipeline_id_1"}
-    assert tasks_2[1].parent_ids == {"pipeline_id_2"}
-
-
 def test_do_not_recreate_existing_task():
     input_config_scope_pipeline = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE)
     output_config_scope_pipeline = Config.configure_data_node("my_output", "in_memory", scope=Scope.PIPELINE)

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -377,3 +377,61 @@ class TestTaipy:
             tp.export_scenario(scenario_1.id, Config.global_config.storage_folder)
 
         shutil.rmtree("./tmp", ignore_errors=True)
+
+    def test_get_parents(self):
+        def assert_result_parents_and_expected_parents(parents, expected_parents):
+            for key, items in expected_parents.items():
+                assert len(parents[key]) == len(expected_parents[key])
+                parent_ids = [parent.id for parent in parents[key]]
+                assert all([item.id in parent_ids for item in items])
+
+        dn_config_1 = Config.configure_data_node(id="d1", storage_type="in_memory", scope=Scope.SCENARIO)
+        dn_config_2 = Config.configure_data_node(id="d2", storage_type="in_memory", scope=Scope.SCENARIO)
+        dn_config_3 = Config.configure_data_node(id="d3", storage_type="in_memory", scope=Scope.SCENARIO)
+        task_config_1 = Config.configure_task("t1", print, dn_config_1, dn_config_2)
+        task_config_2 = Config.configure_task("t2", print, dn_config_2, dn_config_3)
+        pipeline_config_1 = Config.configure_pipeline("p1", task_config_1)
+        pipeline_config_2 = Config.configure_pipeline("p2", [task_config_1, task_config_2])
+        scenario_cfg_1 = Config.configure_scenario("s1", [pipeline_config_1, pipeline_config_2], Frequency.DAILY)
+
+        scenario = tp.create_scenario(scenario_cfg_1)
+        pipelines = scenario.pipelines
+        tasks = {}
+        for pipeline in pipelines.values():
+            tasks.update(pipeline.tasks)
+
+        expected_parents = {
+            "scenarios": {scenario},
+            "pipelines": {pipelines["p1"], pipelines["p2"]},
+            "tasks": {tasks["t1"]},
+        }
+        parents = tp.get_parents(scenario.pipelines["p1"].tasks["t1"].data_nodes["d1"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {
+            "scenarios": {scenario},
+            "pipelines": {pipelines["p1"], pipelines["p2"]},
+            "tasks": {tasks["t1"], tasks["t2"]},
+        }
+        parents = tp.get_parents(scenario.pipelines["p1"].tasks["t1"].data_nodes["d2"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {"scenarios": {scenario}, "pipelines": {pipelines["p2"]}, "tasks": {tasks["t2"]}}
+        parents = tp.get_parents(scenario.pipelines["p2"].tasks["t2"].data_nodes["d3"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {"scenarios": {scenario}, "pipelines": {pipelines["p1"], pipelines["p2"]}}
+        parents = tp.get_parents(scenario.pipelines["p2"].tasks["t1"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {"scenarios": {scenario}, "pipelines": {pipelines["p2"]}}
+        parents = tp.get_parents(scenario.pipelines["p2"].tasks["t2"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {"scenarios": {scenario}}
+        parents = tp.get_parents(scenario.pipelines["p1"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {"scenarios": {scenario}}
+        parents = tp.get_parents(scenario.pipelines["p2"])
+        assert_result_parents_and_expected_parents(parents, expected_parents)

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -435,3 +435,11 @@ class TestTaipy:
         expected_parents = {"scenarios": {scenario}}
         parents = tp.get_parents(scenario.pipelines["p2"])
         assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {}
+        parents = tp.get_parents(scenario)
+        assert_result_parents_and_expected_parents(parents, expected_parents)
+
+        expected_parents = {}
+        parents = tp.get_parents(scenario.cycle)
+        assert_result_parents_and_expected_parents(parents, expected_parents)


### PR DESCRIPTION
#152 
This ticket includes:
- Adding auto-reloading for parent_ids
- exposing the get_parents() API in taipy.py
- fix bugs in parent_ids assigning:
  - the proper flow of assigning parent_ids should be only to assign the parent_ids to the child entity when the parent entity is created (getting the children entities -> creating the parent entity -> assigning the parent_ids of the children entity) 
  - this helps prevent assigning new parent id to the children parent_ids when the parent entity is not created, for reference: the pipeline_id is generated new all the time but it doesn't guarantee that the pipeline entity will be created, therefore an unknown pipeline_id could be assigned to the child task entity by mistake
  - although assigning scenario parent to pipeline children does not have this issue as the scenario is guaranteed to be created new every time but for the purpose of being consistent, it will also follow this flow
  