### PR TITLE
Feature/ Block Config update when Taipy is running

### DIFF
--- a/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
@@ -42,7 +42,6 @@ class _JobDispatcher(threading.Thread):
         threading.Thread.__init__(self, name="Thread-Taipy-JobDispatcher")
         self.daemon = True
         self.scheduler = scheduler
-        print("dispatcher is created")
         Config.block_update()
 
     def start(self):

--- a/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
@@ -8,6 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
 import threading
 from abc import abstractmethod
 from multiprocessing import Lock
@@ -41,6 +42,10 @@ class _JobDispatcher(threading.Thread):
         threading.Thread.__init__(self, name="Thread-Taipy-JobDispatcher")
         self.daemon = True
         self.scheduler = scheduler
+        Config.block_update()
+
+    def __del__(self):
+        Config.unblock_update()
 
     def start(self):
         """Start the dispatcher"""

--- a/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
@@ -138,6 +138,7 @@ class _JobDispatcher(threading.Thread):
         try:
             if mode != JobConfig._DEVELOPMENT_MODE:
                 Config._applied_config = _TomlSerializer()._deserialize(config_as_string)
+                Config.block_update()
             inputs: List[DataNode] = list(task.input.values())
             outputs: List[DataNode] = list(task.output.values())
             fct = task.function

--- a/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
@@ -42,10 +42,8 @@ class _JobDispatcher(threading.Thread):
         threading.Thread.__init__(self, name="Thread-Taipy-JobDispatcher")
         self.daemon = True
         self.scheduler = scheduler
+        print("dispatcher is created")
         Config.block_update()
-
-    def __del__(self):
-        Config.unblock_update()
 
     def start(self):
         """Start the dispatcher"""

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -13,6 +13,7 @@ from copy import copy
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from taipy.config._config import _Config
+from taipy.config.common._config_blocker import _ConfigBlocker
 from taipy.config.common._template_handler import _TemplateHandler as _tpl
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
@@ -201,6 +202,7 @@ class DataNodeConfig(Section):
         return _tpl._replace_templates(self._storage_type)
 
     @storage_type.setter  # type: ignore
+    @_ConfigBlocker._check()
     def storage_type(self, val):
         self._storage_type = val
 
@@ -209,6 +211,7 @@ class DataNodeConfig(Section):
         return _tpl._replace_templates(self._scope)
 
     @scope.setter  # type: ignore
+    @_ConfigBlocker._check()
     def scope(self, val):
         self._scope = val
 
@@ -217,6 +220,7 @@ class DataNodeConfig(Section):
         return _tpl._replace_templates(self._cacheable)
 
     @cacheable.setter  # type: ignore
+    @_ConfigBlocker._check()
     def cacheable(self, val):
         self._cacheable = val
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,7 @@ def teardown():
 
 
 def init_config():
+    Config.unblock_update()
     Config._default_config = _Config()._default_config()
     Config._python_config = _Config()
     Config._file_config = None

--- a/tests/core/_scheduler/_dispatcher/test_job_dispatcher.py
+++ b/tests/core/_scheduler/_dispatcher/test_job_dispatcher.py
@@ -81,13 +81,15 @@ def test_build_standalone_job_dispatcher():
 
 def test_can_execute_2_workers():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     m = multiprocessing.Manager()
     lock = m.Lock()
 
     task_id = TaskId("task_id1")
     output = list(_DataManager._bulk_get_or_create([Config.configure_data_node("input1", default_data=21)]).values())
+
+    _SchedulerFactory._build_dispatcher()
+
     task = Task(
         config_id="name",
         input=[],

--- a/tests/core/_scheduler/test_scheduler.py
+++ b/tests/core/_scheduler/test_scheduler.py
@@ -40,6 +40,7 @@ from tests.core.utils import assert_true_after_1_minute_max
 @pytest.fixture(scope="function", autouse=True)
 def reset_configuration_singleton():
     yield
+    Config.unblock_update()
     Config._python_config = _Config()
     Config._file_config = None
     Config._env_file_config = None
@@ -87,12 +88,13 @@ def _error():
 
 def test_submit_task():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     before_creation = datetime.now()
     sleep(0.1)
     task = _create_task(multiply)
     output_dn_id = task.output[f"{task.config_id}_output0"].id
+
+    _SchedulerFactory._build_dispatcher()
 
     assert _DataManager._get(output_dn_id).last_edition_date > before_creation
     assert _DataManager._get(output_dn_id).job_ids == []
@@ -137,7 +139,6 @@ def test_submit_pipeline_generate_unique_submit_id(pipeline, task):
 
 def test_submit_task_that_return_multiple_outputs():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     def return_2tuple(nb1, nb2):
         return multiply(nb1, nb2), multiply(nb1, nb2) / 2
@@ -147,6 +148,8 @@ def test_submit_task_that_return_multiple_outputs():
 
     with_tuple = _create_task(return_2tuple, 2)
     with_list = _create_task(return_list, 2)
+
+    _SchedulerFactory._build_dispatcher()
 
     _Scheduler.submit_task(with_tuple, "submit_id_1")
     _Scheduler.submit_task(with_list, "submit_id_2")
@@ -165,7 +168,6 @@ def test_submit_task_that_return_multiple_outputs():
 
 def test_submit_task_returns_single_iterable_output():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     def return_2tuple(nb1, nb2):
         return multiply(nb1, nb2), multiply(nb1, nb2) / 2
@@ -175,6 +177,8 @@ def test_submit_task_returns_single_iterable_output():
 
     task_with_tuple = _create_task(return_2tuple, 1)
     task_with_list = _create_task(return_list, 1)
+
+    _SchedulerFactory._build_dispatcher()
 
     _Scheduler.submit_task(task_with_tuple, "submit_id_1")
     assert task_with_tuple.output[f"{task_with_tuple.config_id}_output0"].read() == (42, 21)
@@ -186,12 +190,13 @@ def test_submit_task_returns_single_iterable_output():
 
 def test_data_node_not_written_due_to_wrong_result_nb():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     def return_2tuple():
         return lambda nb1, nb2: (multiply(nb1, nb2), multiply(nb1, nb2) / 2)
 
     task = _create_task(return_2tuple(), 3)
+
+    _SchedulerFactory._build_dispatcher()
 
     job = _Scheduler.submit_task(task, "submit_id")
     assert task.output[f"{task.config_id}_output0"].read() == 0
@@ -258,9 +263,10 @@ def test_submit_task_in_parallel():
     lock = m.Lock()
 
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(partial(lock_multiply, lock))
+
+    _SchedulerFactory._build_dispatcher()
 
     with lock:
         assert task.output[f"{task.config_id}_output0"].read() == 0
@@ -321,7 +327,6 @@ def test_submit_task_synchronously_in_parallel_with_timeout():
 
 def test_submit_task_multithreading_multiple_task():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     m = multiprocessing.Manager()
     lock_1 = m.Lock()
@@ -329,6 +334,8 @@ def test_submit_task_multithreading_multiple_task():
 
     task_1 = _create_task(partial(lock_multiply, lock_1))
     task_2 = _create_task(partial(lock_multiply, lock_2))
+
+    _SchedulerFactory._build_dispatcher()
 
     with lock_1:
         with lock_2:
@@ -355,7 +362,6 @@ def test_submit_task_multithreading_multiple_task():
 
 def test_submit_task_multithreading_multiple_task_in_sync_way_to_check_job_status():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     m = multiprocessing.Manager()
     lock_0 = m.Lock()
@@ -365,6 +371,8 @@ def test_submit_task_multithreading_multiple_task_in_sync_way_to_check_job_statu
     task_0 = _create_task(partial(lock_multiply, lock_0))
     task_1 = _create_task(partial(lock_multiply, lock_1))
     task_2 = _create_task(partial(lock_multiply, lock_2))
+
+    _SchedulerFactory._build_dispatcher()
 
     with lock_0:
         job_0 = _Scheduler.submit_task(task_0, "submit_id_0")
@@ -404,7 +412,6 @@ def test_submit_task_multithreading_multiple_task_in_sync_way_to_check_job_statu
 
 def test_blocked_task():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     m = multiprocessing.Manager()
     lock_1 = m.Lock()
@@ -413,6 +420,9 @@ def test_blocked_task():
     foo_cfg = Config.configure_data_node("foo", default_data=1)
     bar_cfg = Config.configure_data_node("bar")
     baz_cfg = Config.configure_data_node("baz")
+
+    _SchedulerFactory._build_dispatcher()
+
     dns = _DataManager._bulk_get_or_create([foo_cfg, bar_cfg, baz_cfg])
     foo = dns[foo_cfg]
     bar = dns[bar_cfg]
@@ -472,7 +482,6 @@ def modified_config_task(n):
 
 def test_can_exec_task_with_modified_config():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
     Config.configure_global_app(
         storage_folder=".my_data/", clean_entities_enabled=True, custom_property="custom_property"
     )
@@ -481,6 +490,9 @@ def test_can_exec_task_with_modified_config():
     dn_output_config = Config.configure_data_node("output", "pickle")
     task_config = Config.configure_task("task_config", modified_config_task, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline = _PipelineManager._get_or_create(pipeline_config)
 
     jobs = pipeline.submit()
@@ -493,14 +505,15 @@ def test_can_exec_task_with_modified_config():
 
 def test_can_execute_task_with_development_mode():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("input", "pickle", scope=Scope.PIPELINE, default_data=1)
     dn_output_config = Config.configure_data_node("output", "pickle")
     task_config = Config.configure_task("task_config", mult_by_2, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
-    pipeline = _PipelineManager._get_or_create(pipeline_config)
 
+    _SchedulerFactory._build_dispatcher()
+
+    pipeline = _PipelineManager._get_or_create(pipeline_config)
     pipeline.submit()
     while pipeline.output.edit_in_progress:
         sleep(1)
@@ -528,12 +541,13 @@ def test_need_to_run_output_not_cacheable():
 
 def test_need_to_run_output_cacheable_no_input():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     hello_world_cfg = Config.configure_data_node("hello_world", cacheable=True)
     task_cfg = Config.configure_task("name", input=[], function=nothing, output=[hello_world_cfg])
-    task = _create_task_from_config(task_cfg)
 
+    _SchedulerFactory._build_dispatcher()
+
+    task = _create_task_from_config(task_cfg)
     assert _SchedulerFactory._dispatcher._needs_to_run(task)
     _Scheduler.submit_task(task, "submit_id")
 
@@ -542,14 +556,15 @@ def test_need_to_run_output_cacheable_no_input():
 
 def test_need_to_run_output_cacheable_no_validity_period():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     hello_cfg = Config.configure_data_node("hello", default_data="Hello ")
     world_cfg = Config.configure_data_node("world", default_data="world !")
     hello_world_cfg = Config.configure_data_node("hello_world", cacheable=True)
     task_cfg = Config.configure_task("name", input=[hello_cfg, world_cfg], function=concat, output=[hello_world_cfg])
-    task = _create_task_from_config(task_cfg)
 
+    _SchedulerFactory._build_dispatcher()
+
+    task = _create_task_from_config(task_cfg)
     assert _SchedulerFactory._dispatcher._needs_to_run(task)
     _Scheduler.submit_task(task, "submit_id")
 
@@ -558,12 +573,13 @@ def test_need_to_run_output_cacheable_no_validity_period():
 
 def test_need_to_run_output_cacheable_with_validity_period_up_to_date():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     hello_cfg = Config.configure_data_node("hello", default_data="Hello ")
     world_cfg = Config.configure_data_node("world", default_data="world !")
     hello_world_cfg = Config.configure_data_node("hello_world", cacheable=True, validity_days=1)
     task_cfg = Config.configure_task("name", input=[hello_cfg, world_cfg], function=concat, output=[hello_world_cfg])
+    _SchedulerFactory._build_dispatcher()
+
     task = _create_task_from_config(task_cfg)
 
     assert _SchedulerFactory._dispatcher._needs_to_run(task)
@@ -620,11 +636,3 @@ def _create_task(function, nb_outputs=1):
 
 def _create_task_from_config(task_cfg):
     return _TaskManager()._bulk_get_or_create([task_cfg])[0]
-
-
-def wait_job_to_complete(job):
-    start = datetime.now()
-    while (datetime.now() - start).seconds < 60:
-        sleep(0.1)  # Limit CPU usage
-        if job.is_finished():
-            return

--- a/tests/core/_scheduler/test_scheduler_factory.py
+++ b/tests/core/_scheduler/test_scheduler_factory.py
@@ -49,7 +49,7 @@ def test_build_scheduler():
         initialize.assert_called_once()
 
 
-def test_build_dispatcher():
+def test_build_development_dispatcher():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
     _SchedulerFactory._scheduler = None
     _SchedulerFactory._dispatcher = None
@@ -67,6 +67,8 @@ def test_build_dispatcher():
     _SchedulerFactory._build_dispatcher()
     assert isinstance(_SchedulerFactory._dispatcher, _DevelopmentJobDispatcher)
 
+
+def test_build_standalone_dispatcher():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
     _SchedulerFactory._build_dispatcher()
     assert isinstance(_SchedulerFactory._dispatcher, _StandaloneJobDispatcher)
@@ -82,7 +84,3 @@ def test_build_dispatcher():
     _SchedulerFactory._build_dispatcher(force_restart=True)
     assert _SchedulerFactory._dispatcher.is_running()
     assert _SchedulerFactory._dispatcher._nb_available_workers == 2
-
-    Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
-    assert isinstance(_SchedulerFactory._dispatcher, _DevelopmentJobDispatcher)

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -15,9 +15,12 @@ from unittest import mock
 
 import pytest
 
+from src.taipy.core._scheduler._scheduler_factory import _SchedulerFactory
 from src.taipy.core.config import DataNodeConfig
+from src.taipy.core.config.job_config import JobConfig
+from taipy.config.common.scope import Scope
 from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationIssueError
+from taipy.config.exceptions.exceptions import ConfigurationIssueError, ConfigurationUpdateBlocked
 
 
 def test_data_node_config_check():
@@ -122,3 +125,43 @@ def test_data_node_with_env_variable_in_read_fct_params():
             "data_node", storage_type="generic", read_fct_params=["ENV[FOO]", "my_param", "ENV[BAZ]"]
         )
         assert Config.data_nodes["data_node"].read_fct_params == ["bar", "my_param", "qux"]
+
+
+def test_block_datanode_config_update_in_development_mode():
+    data_node_id = "data_node_id"
+    Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
+    data_node_config = Config.configure_data_node(
+        id=data_node_id,
+        storage_type="pickle",
+        default_path="foo.p",
+        scope=Scope.SCENARIO,
+        cacheable=False,
+    )
+
+    assert Config.data_nodes[data_node_id].id == data_node_id
+    assert Config.data_nodes[data_node_id].default_path == "foo.p"
+    assert Config.data_nodes[data_node_id].storage_type == "pickle"
+    assert Config.data_nodes[data_node_id].scope == Scope.SCENARIO
+    assert Config.data_nodes[data_node_id].cacheable == False
+    assert Config.data_nodes[data_node_id].properties == {"default_path": "foo.p"}
+
+    _SchedulerFactory._build_dispatcher()
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.storage_type = "foo"
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.scope = Scope.PIPELINE
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.cacheable = True
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.properties = {"foo": "bar"}
+
+    assert Config.data_nodes[data_node_id].id == data_node_id
+    assert Config.data_nodes[data_node_id].default_path == "foo.p"
+    assert Config.data_nodes[data_node_id].storage_type == "pickle"
+    assert Config.data_nodes[data_node_id].scope == Scope.SCENARIO
+    assert Config.data_nodes[data_node_id].cacheable == False
+    assert Config.data_nodes[data_node_id].properties == {"default_path": "foo.p"}

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -165,3 +165,43 @@ def test_block_datanode_config_update_in_development_mode():
     assert Config.data_nodes[data_node_id].scope == Scope.SCENARIO
     assert Config.data_nodes[data_node_id].cacheable == False
     assert Config.data_nodes[data_node_id].properties == {"default_path": "foo.p"}
+
+
+def test_block_datanode_config_update_in_standalone_mode():
+    data_node_id = "data_node_id"
+    Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE)
+    data_node_config = Config.configure_data_node(
+        id=data_node_id,
+        storage_type="pickle",
+        default_path="foo.p",
+        scope=Scope.SCENARIO,
+        cacheable=False,
+    )
+
+    assert Config.data_nodes[data_node_id].id == data_node_id
+    assert Config.data_nodes[data_node_id].default_path == "foo.p"
+    assert Config.data_nodes[data_node_id].storage_type == "pickle"
+    assert Config.data_nodes[data_node_id].scope == Scope.SCENARIO
+    assert Config.data_nodes[data_node_id].cacheable == False
+    assert Config.data_nodes[data_node_id].properties == {"default_path": "foo.p"}
+
+    _SchedulerFactory._build_dispatcher()
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.storage_type = "foo"
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.scope = Scope.PIPELINE
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.cacheable = True
+
+    with pytest.raises(ConfigurationUpdateBlocked):
+        data_node_config.properties = {"foo": "bar"}
+
+    assert Config.data_nodes[data_node_id].id == data_node_id
+    assert Config.data_nodes[data_node_id].default_path == "foo.p"
+    assert Config.data_nodes[data_node_id].storage_type == "pickle"
+    assert Config.data_nodes[data_node_id].scope == Scope.SCENARIO
+    assert Config.data_nodes[data_node_id].cacheable == False
+    assert Config.data_nodes[data_node_id].properties == {"default_path": "foo.p"}

--- a/tests/core/cycle/test_cycle_manager.py
+++ b/tests/core/cycle/test_cycle_manager.py
@@ -183,7 +183,6 @@ def test_get_cycle_start_date_and_end_date():
 
 def test_hard_delete_shared_entities():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_config_1 = Config.configure_data_node("my_input_1", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_config_2 = Config.configure_data_node("my_input_2", "in_memory", scope=Scope.SCENARIO, default_data="testing")
@@ -205,6 +204,9 @@ def test_hard_delete_shared_entities():
     scenario_config_2 = Config.configure_scenario(
         "scenario_config_2", [pipeline_config_3]
     )  # No Frequency so cycle attached to scenarios
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_1 = _ScenarioManager._create(scenario_config_1)
     scenario_2 = _ScenarioManager._create(scenario_config_1)
     scenario_3 = _ScenarioManager._create(scenario_config_2)

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -255,7 +255,6 @@ class TestDataNode:
 
     def test_do_not_recompute_data_node_in_cache_but_continue_pipeline_execution(self):
         Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-        _SchedulerFactory._build_dispatcher()
 
         a = Config.configure_data_node("A", "pickle", default_data="A")
         b = Config.configure_data_node("B", "pickle", cacheable=True)
@@ -268,6 +267,8 @@ class TestDataNode:
         pipeline_c = Config.configure_pipeline("pipeline_c", [task_a_b, task_b_c])
         pipeline_d = Config.configure_pipeline("pipeline_d", [task_a_b, task_b_d])
         scenario_cfg = Config.configure_scenario("scenario", [pipeline_c, pipeline_d])
+
+        _SchedulerFactory._build_dispatcher()
 
         scenario = tp.create_scenario(scenario_cfg)
         scenario.submit()

--- a/tests/core/job/test_job_manager.py
+++ b/tests/core/job/test_job_manager.py
@@ -60,8 +60,9 @@ def lock_multiply(lock, nb1: float, nb2: float):
 
 def test_create_jobs():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
     task = _create_task(multiply, name="get_job")
+
+    _SchedulerFactory._build_dispatcher()
 
     job_1 = _JobManager._create(task, [print], "submit_id", True)
     assert _JobManager._get(job_1.id) == job_1
@@ -82,9 +83,10 @@ def test_create_jobs():
 
 def test_get_job():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(multiply, name="get_job")
+
+    _SchedulerFactory._build_dispatcher()
 
     job_1 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_1")
     assert _JobManager._get(job_1.id) == job_1
@@ -97,10 +99,11 @@ def test_get_job():
 
 def test_get_latest_job():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(multiply, name="get_latest_job")
     task_2 = _create_task(multiply, name="get_latest_job_2")
+
+    _SchedulerFactory._build_dispatcher()
 
     job_1 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_1")
     assert _JobManager._get_latest(task) == job_1
@@ -123,9 +126,10 @@ def test_get_job_unknown():
 
 def test_get_jobs():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(multiply, name="get_all_jobs")
+
+    _SchedulerFactory._build_dispatcher()
 
     job_1 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_1")
     job_2 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_2")
@@ -135,9 +139,10 @@ def test_get_jobs():
 
 def test_delete_job():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(multiply, name="delete_job")
+
+    _SchedulerFactory._build_dispatcher()
 
     job_1 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_1")
     job_2 = _SchedulerFactory._scheduler.submit_task(task, "submit_id_2")
@@ -159,8 +164,8 @@ def inner_lock_multiply(nb1: float, nb2: float):
 
 def test_raise_when_trying_to_delete_unfinished_job():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
     task = _create_task(inner_lock_multiply, name="delete_unfinished_job")
+    _SchedulerFactory._build_dispatcher()
     with lock:
         job = _SchedulerFactory._scheduler.submit_task(task, "submit_id")
 
@@ -176,9 +181,11 @@ def test_raise_when_trying_to_delete_unfinished_job():
 
 def test_force_deleting_unfinished_job():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(inner_lock_multiply, name="delete_unfinished_job")
+
+    _SchedulerFactory._build_dispatcher()
+
     with lock:
         job = _SchedulerFactory._scheduler.submit_task(task, "submit_id")
         assert_true_after_1_minute_max(job.is_running)
@@ -190,9 +197,11 @@ def test_force_deleting_unfinished_job():
 
 def test_cancel_single_job():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=1)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(inner_lock_multiply, name="cancel_single_job")
+
+    _SchedulerFactory._build_dispatcher()
+
     assert_true_after_1_minute_max(_SchedulerFactory._dispatcher.is_running)
     _SchedulerFactory._dispatcher.stop()
     assert_true_after_1_minute_max(lambda: not _SchedulerFactory._dispatcher.is_running())
@@ -212,9 +221,11 @@ def test_cancel_single_job():
 @mock.patch("src.taipy.core._scheduler._scheduler._Scheduler._cancel_jobs")
 def test_cancel_canceled_abandoned_failed_jobs(cancel_jobs, schedule_job):
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=1)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(inner_lock_multiply, name="cancel_single_job")
+
+    _SchedulerFactory._build_dispatcher()
+
     assert_true_after_1_minute_max(_SchedulerFactory._dispatcher.is_running)
     _SchedulerFactory._dispatcher.stop()
     assert_true_after_1_minute_max(lambda: not _SchedulerFactory._dispatcher.is_running())
@@ -247,9 +258,11 @@ def test_cancel_canceled_abandoned_failed_jobs(cancel_jobs, schedule_job):
 @mock.patch("src.taipy.core.job.job.Job.canceled")
 def test_cancel_completed_skipped_jobs(cancel_jobs, schedule_job):
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=1)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(inner_lock_multiply, name="cancel_single_job")
+
+    _SchedulerFactory._build_dispatcher()
+
     assert_true_after_1_minute_max(_SchedulerFactory._dispatcher.is_running)
     _SchedulerFactory._dispatcher.stop()
     assert_true_after_1_minute_max(lambda: not _SchedulerFactory._dispatcher.is_running())
@@ -278,9 +291,11 @@ def test_cancel_completed_skipped_jobs(cancel_jobs, schedule_job):
 
 def test_cancel_single_running_job():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    _SchedulerFactory._build_dispatcher()
 
     task = _create_task(inner_lock_multiply, name="cancel_single_job")
+
+    _SchedulerFactory._build_dispatcher()
+
     assert_true_after_1_minute_max(_SchedulerFactory._dispatcher.is_running)
     assert_true_after_1_minute_max(lambda: _SchedulerFactory._dispatcher._nb_available_workers == 2)
 

--- a/tests/core/pipeline/test_pipeline_manager.py
+++ b/tests/core/pipeline/test_pipeline_manager.py
@@ -286,7 +286,6 @@ def mult_by_3(nb: int):
 def test_get_or_create_data():
     # only create intermediate data node once
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_config_1 = Config.configure_data_node("foo", "in_memory", Scope.PIPELINE, default_data=1)
     dn_config_2 = Config.configure_data_node("bar", "in_memory", Scope.PIPELINE, default_data=0)
@@ -296,6 +295,8 @@ def test_get_or_create_data():
     task_config_mult_by_3 = Config.configure_task("mult_by_3", mult_by_3, [dn_config_2], dn_config_6)
     pipeline_config = Config.configure_pipeline("by_6", [task_config_mult_by_two, task_config_mult_by_3])
     # dn_1 ---> mult_by_two ---> dn_2 ---> mult_by_3 ---> dn_6
+
+    _SchedulerFactory._build_dispatcher()
 
     assert len(_DataManager._get_all()) == 0
     assert len(_TaskManager._get_all()) == 0
@@ -332,7 +333,6 @@ def test_get_or_create_data():
 
 def test_create_pipeline_and_modify_properties_does_not_modify_config():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_config_1 = Config.configure_data_node("foo", "in_memory", Scope.PIPELINE, default_data=1)
     dn_config_2 = Config.configure_data_node("bar", "in_memory", Scope.PIPELINE, default_data=0)
@@ -341,6 +341,8 @@ def test_create_pipeline_and_modify_properties_does_not_modify_config():
     task_config_mult_by_two = Config.configure_task("mult_by_two", mult_by_two, [dn_config_1], dn_config_2)
     task_config_mult_by_3 = Config.configure_task("mult_by_3", mult_by_3, [dn_config_2], dn_config_6)
     pipeline_config = Config.configure_pipeline("by_6", [task_config_mult_by_two, task_config_mult_by_3], foo="bar")
+
+    _SchedulerFactory._build_dispatcher()
 
     assert len(pipeline_config.properties) == 1
     assert pipeline_config.properties.get("foo") == "bar"
@@ -374,7 +376,6 @@ def notify_multi_param(*args, **kwargs):
 
 def test_pipeline_notification_subscribe(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
@@ -389,6 +390,8 @@ def test_pipeline_notification_subscribe(mocker):
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     pipeline = _PipelineManager._get_or_create(pipeline_config)
 
@@ -427,7 +430,6 @@ def test_pipeline_notification_subscribe(mocker):
 
 def test_pipeline_notification_subscribe_multi_param(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
@@ -442,6 +444,8 @@ def test_pipeline_notification_subscribe_multi_param(mocker):
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     notify = mocker.Mock()
@@ -460,7 +464,6 @@ def test_pipeline_notification_subscribe_multi_param(mocker):
 
 def test_pipeline_notification_unsubscribe(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
@@ -475,6 +478,8 @@ def test_pipeline_notification_unsubscribe(mocker):
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     pipeline = _PipelineManager._get_or_create(pipeline_config)
 
@@ -493,7 +498,6 @@ def test_pipeline_notification_unsubscribe(mocker):
 
 def test_pipeline_notification_unsubscribe_multi_param():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     pipeline_config = Config.configure_pipeline(
         "by_6",
@@ -506,6 +510,8 @@ def test_pipeline_notification_unsubscribe_multi_param():
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     pipeline = _PipelineManager._get_or_create(pipeline_config)
 
@@ -529,7 +535,6 @@ def test_pipeline_notification_unsubscribe_multi_param():
 
 def test_pipeline_notification_subscribe_all():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     pipeline_config = Config.configure_pipeline(
         "by_6",
@@ -542,6 +547,8 @@ def test_pipeline_notification_subscribe_all():
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     pipeline_config.id = "other_pipeline"
@@ -684,7 +691,6 @@ def test_do_not_recreate_existing_pipeline_except_same_config():
 
 def test_hard_delete_one_single_pipeline_with_pipeline_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_output_config = Config.configure_data_node(
@@ -692,6 +698,9 @@ def test_hard_delete_one_single_pipeline_with_pipeline_data_nodes():
     )
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     _PipelineManager._submit(pipeline.id)
 
@@ -710,12 +719,14 @@ def test_hard_delete_one_single_pipeline_with_pipeline_data_nodes():
 
 def test_hard_delete_one_single_pipeline_with_scenario_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.SCENARIO, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.SCENARIO)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     pipeline.submit()
 
@@ -734,12 +745,14 @@ def test_hard_delete_one_single_pipeline_with_scenario_data_nodes():
 
 def test_hard_delete_one_single_pipeline_with_cycle_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.CYCLE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.CYCLE)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     pipeline.submit()
 
@@ -758,12 +771,14 @@ def test_hard_delete_one_single_pipeline_with_cycle_data_nodes():
 
 def test_hard_delete_one_single_pipeline_with_pipeline_and_global_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.GLOBAL)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline = _PipelineManager._get_or_create(pipeline_config)
     pipeline.submit()
 
@@ -782,12 +797,14 @@ def test_hard_delete_one_single_pipeline_with_pipeline_and_global_data_nodes():
 
 def test_hard_delete_one_pipeline_among_two_with_pipeline_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.GLOBAL)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline_1 = _PipelineManager._get_or_create(pipeline_config)
     pipeline_2 = _PipelineManager._get_or_create(pipeline_config)
     _PipelineManager._submit(pipeline_1.id)
@@ -808,7 +825,6 @@ def test_hard_delete_one_pipeline_among_two_with_pipeline_data_nodes():
 
 def test_hard_delete_shared_entities():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     input_dn = Config.configure_data_node("my_input", "in_memory", scope=Scope.CYCLE, default_data="testing")
     intermediate_dn = Config.configure_data_node("my_inter", "in_memory", scope=Scope.SCENARIO, default_data="testing")
@@ -816,6 +832,9 @@ def test_hard_delete_shared_entities():
     task_1 = Config.configure_task("task_1", print, input_dn, intermediate_dn)
     task_2 = Config.configure_task("task_2", print, intermediate_dn, output_dn)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_1, task_2])
+
+    _SchedulerFactory._build_dispatcher()
+
     pipeline_1 = _PipelineManager._get_or_create(pipeline_config)
     pipeline_2 = _PipelineManager._get_or_create(pipeline_config)
     _PipelineManager._submit(pipeline_1.id)

--- a/tests/core/scenario/test_scenario_manager.py
+++ b/tests/core/scenario/test_scenario_manager.py
@@ -152,13 +152,14 @@ def test_set_and_get_scenario(cycle):
 
 def test_create_scenario_does_not_modify_config():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     creation_date_1 = datetime.now()
     name_1 = "name_1"
     scenario_config = Config.configure_scenario("sc", [], Frequency.DAILY)
     assert scenario_config.properties.get("name") is None
     assert len(scenario_config.properties) == 0
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario = _ScenarioManager._create(scenario_config, creation_date=creation_date_1, name=name_1)
     assert len(scenario_config.properties) == 0
@@ -180,7 +181,6 @@ def test_create_scenario_does_not_modify_config():
 
 def test_create_and_delete_scenario():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     creation_date_1 = datetime.now()
     creation_date_2 = creation_date_1 + timedelta(minutes=10)
@@ -191,6 +191,8 @@ def test_create_and_delete_scenario():
     assert len(_ScenarioManager._get_all()) == 0
 
     scenario_config = Config.configure_scenario("sc", [], Frequency.DAILY)
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario_1 = _ScenarioManager._create(scenario_config, creation_date=creation_date_1, name=name_1)
     assert scenario_1.config_id == "sc"
@@ -328,7 +330,6 @@ def mult_by_4(nb: int):
 
 def test_scenario_manager_only_creates_data_node_once():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_config_1 = Config.configure_data_node("foo", "in_memory", Scope.PIPELINE, default_data=1)
     dn_config_2 = Config.configure_data_node("bar", "in_memory", Scope.SCENARIO, default_data=0)
@@ -345,6 +346,8 @@ def test_scenario_manager_only_creates_data_node_once():
     scenario_config = Config.configure_scenario(
         "awesome_scenario", [pipeline_config_1, pipeline_config_2], Frequency.DAILY
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     assert len(_DataManager._get_all()) == 0
     assert len(_TaskManager._get_all()) == 0
@@ -370,7 +373,6 @@ def test_scenario_manager_only_creates_data_node_once():
 
 def test_notification_subscribe(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
@@ -390,6 +392,8 @@ def test_notification_subscribe(mocker):
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario = _ScenarioManager._create(scenario_config)
 
@@ -425,7 +429,7 @@ class Notify:
 
 def test_notification_subscribe_multiple_params(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
+
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
     scenario_config = Config.configure_scenario(
@@ -445,6 +449,8 @@ def test_notification_subscribe_multiple_params(mocker):
         ],
     )
     notify = mocker.Mock()
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario = _ScenarioManager._create(scenario_config)
     _ScenarioManager._subscribe(callback=notify, params=["foobar", 123, 1.2], scenario=scenario)
@@ -469,7 +475,6 @@ def notify2(*args, **kwargs):
 
 def test_notification_unsubscribe(mocker):
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     mocker.patch("src.taipy.core.common._reload._reload", side_effect=lambda m, o: o)
 
@@ -490,6 +495,8 @@ def test_notification_unsubscribe(mocker):
         ],
     )
 
+    _SchedulerFactory._build_dispatcher()
+
     scenario = _ScenarioManager._create(scenario_config)
 
     notify_1 = notify1
@@ -508,7 +515,6 @@ def test_notification_unsubscribe(mocker):
 
 def test_notification_unsubscribe_multi_param():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     scenario_config = Config.configure_scenario(
         "awesome_scenario",
@@ -526,6 +532,8 @@ def test_notification_unsubscribe_multi_param():
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario = _ScenarioManager._create(scenario_config)
 
@@ -553,7 +561,6 @@ def test_notification_unsubscribe_multi_param():
 
 def test_scenario_notification_subscribe_all():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     scenario_config = Config.configure_scenario(
         "awesome_scenario",
@@ -571,6 +578,8 @@ def test_scenario_notification_subscribe_all():
             )
         ],
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     scenario = _ScenarioManager._create(scenario_config)
     scenario_config.id = "other_scenario"
@@ -623,13 +632,15 @@ def test_get_set_primary_scenario():
 
 def test_hard_delete_one_single_scenario_with_scenario_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.SCENARIO, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.SCENARIO)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario.id)
 
@@ -648,13 +659,15 @@ def test_hard_delete_one_single_scenario_with_scenario_data_nodes():
 
 def test_hard_delete_one_single_scenario_with_pipeline_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.PIPELINE)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario.id)
 
@@ -673,13 +686,15 @@ def test_hard_delete_one_single_scenario_with_pipeline_data_nodes():
 
 def test_hard_delete_one_single_scenario_with_one_pipeline_and_one_scenario_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.SCENARIO)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario.id)
 
@@ -698,13 +713,15 @@ def test_hard_delete_one_single_scenario_with_one_pipeline_and_one_scenario_data
 
 def test_hard_delete_one_single_scenario_with_one_pipeline_and_one_global_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.GLOBAL, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.PIPELINE)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario.id)
 
@@ -738,13 +755,15 @@ def test_hard_delete_one_single_scenario_with_one_pipeline_and_one_global_data_n
 
 def test_hard_delete_one_scenario_among_two_with_one_pipeline_and_one_global_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.GLOBAL, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.PIPELINE)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_1 = _ScenarioManager._create(scenario_config)
     scenario_2 = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario_1.id)
@@ -766,13 +785,15 @@ def test_hard_delete_one_scenario_among_two_with_one_pipeline_and_one_global_dat
 
 def test_hard_delete_one_scenario_among_two_with_scenario_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.SCENARIO, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.SCENARIO)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_1 = _ScenarioManager._create(scenario_config)
     scenario_2 = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario_1.id)
@@ -794,13 +815,15 @@ def test_hard_delete_one_scenario_among_two_with_scenario_data_nodes():
 
 def test_hard_delete_one_scenario_among_two_with_cycle_data_nodes():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_input_config = Config.configure_data_node("my_input", "in_memory", scope=Scope.CYCLE, default_data="testing")
     dn_output_config = Config.configure_data_node("my_output", "in_memory", scope=Scope.CYCLE)
     task_config = Config.configure_task("task_config", print, dn_input_config, dn_output_config)
     pipeline_config = Config.configure_pipeline("pipeline_config", [task_config])
     scenario_config = Config.configure_scenario("scenario_config", [pipeline_config])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_1 = _ScenarioManager._create(scenario_config)
     scenario_2 = _ScenarioManager._create(scenario_config)
     _ScenarioManager._submit(scenario_1.id)
@@ -822,7 +845,6 @@ def test_hard_delete_one_scenario_among_two_with_cycle_data_nodes():
 
 def test_hard_delete_shared_entities():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     dn_config_1 = Config.configure_data_node("my_input_1", "in_memory", scope=Scope.PIPELINE, default_data="testing")
     dn_config_2 = Config.configure_data_node("my_input_2", "in_memory", scope=Scope.SCENARIO, default_data="testing")
@@ -837,6 +859,9 @@ def test_hard_delete_shared_entities():
     scenario_config_1 = Config.configure_scenario(
         "scenario_config_1", [pipeline_config_1, pipeline_config_2, pipeline_config_3]
     )
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_1 = _ScenarioManager._create(scenario_config_1)
     scenario_2 = _ScenarioManager._create(scenario_config_1)
     scenario_1.submit()
@@ -959,7 +984,6 @@ def addition(n1, n2):
 
 def test_scenarios_comparison_development_mode():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     scenario_config = Config.configure_scenario(
         "Awesome_scenario",
@@ -978,6 +1002,8 @@ def test_scenarios_comparison_development_mode():
         ],
         comparators={"bar": [subtraction], "foo": [subtraction, addition]},
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     assert scenario_config.comparators is not None
     scenario_1 = _ScenarioManager._create(scenario_config)
@@ -1012,7 +1038,6 @@ def test_scenarios_comparison_development_mode():
 
 def test_scenarios_comparison_standalone_mode():
     Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     scenario_config = Config.configure_scenario(
         "Awesome_scenario",
@@ -1031,6 +1056,8 @@ def test_scenarios_comparison_standalone_mode():
         ],
         comparators={"bar": [subtraction], "foo": [subtraction, addition]},
     )
+
+    _SchedulerFactory._build_dispatcher()
 
     assert scenario_config.comparators is not None
     scenario_1 = _ScenarioManager._create(scenario_config)
@@ -1203,10 +1230,12 @@ def test_tags():
 
 def test_authorized_tags():
     Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    _SchedulerFactory._build_dispatcher()
 
     scenario = Scenario("SCENARIO_1", [], {"authorized_tags": ["foo", "bar"]}, ScenarioId("SCENARIO_1"))
     scenario_2_cfg = Config.configure_scenario("SCENARIO_2", [], Frequency.DAILY, authorized_tags=["foo", "bar"])
+
+    _SchedulerFactory._build_dispatcher()
+
     scenario_2 = _ScenarioManager._create(scenario_2_cfg)
     _ScenarioManager._set(scenario)
 
@@ -1251,6 +1280,12 @@ def test_scenario_create_from_task_config():
     task_config_1 = Config.configure_task("t1", print, data_node_1_config, data_node_2_config, scope=Scope.GLOBAL)
     task_config_2 = Config.configure_task("t2", print, data_node_2_config, data_node_3_config, scope=Scope.GLOBAL)
     scenario_config_1 = Config.configure_scenario_from_tasks("s1", task_configs=[task_config_1, task_config_2])
+
+    pipeline_name = "p1"
+    scenario_config_2 = Config.configure_scenario_from_tasks(
+        "s2", task_configs=[task_config_1, task_config_2], pipeline_id=pipeline_name
+    )
+
     _ScenarioManager._submit(_ScenarioManager._create(scenario_config_1))
     assert len(_ScenarioManager._get_all()) == 1
     assert len(_PipelineManager._get_all()) == 1
@@ -1260,10 +1295,6 @@ def test_scenario_create_from_task_config():
     assert isinstance(scenario_config_1.pipeline_configs[0].id, str)
     assert scenario_config_1.pipeline_configs[0].id == f"{scenario_config_1.id}_pipeline"
 
-    pipeline_name = "p1"
-    scenario_config_2 = Config.configure_scenario_from_tasks(
-        "s2", task_configs=[task_config_1, task_config_2], pipeline_id=pipeline_name
-    )
     _ScenarioManager._submit(_ScenarioManager._create(scenario_config_2))
     assert len(_ScenarioManager._get_all()) == 2
     assert len(_PipelineManager._get_all()) == 2

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -9,36 +9,73 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import pytest
+
 from src.taipy.core import Core
 from src.taipy.core._scheduler._dispatcher import _DevelopmentJobDispatcher, _StandaloneJobDispatcher
 from src.taipy.core._scheduler._scheduler import _Scheduler
 from src.taipy.core._scheduler._scheduler_factory import _SchedulerFactory
 from src.taipy.core.config.job_config import JobConfig
 from taipy.config import Config
+from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
-def test_run_core_as_a_service():
-    _SchedulerFactory._dispatcher = None
+class TestCore:
+    def test_run_core_as_a_service_development_mode(self):
+        _SchedulerFactory._dispatcher = None
 
-    core = Core()
-    assert core._scheduler is not None
-    assert core._scheduler == _Scheduler
-    assert _SchedulerFactory._scheduler is not None
-    assert _SchedulerFactory._scheduler == _Scheduler
+        core = Core()
+        assert core._scheduler is not None
+        assert core._scheduler == _Scheduler
+        assert _SchedulerFactory._scheduler is not None
+        assert _SchedulerFactory._scheduler == _Scheduler
 
-    assert core._dispatcher is None
-    assert _SchedulerFactory._dispatcher is None
+        assert core._dispatcher is None
+        assert _SchedulerFactory._dispatcher is None
 
-    Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
-    core.run()
-    assert core._dispatcher is not None
-    assert isinstance(core._dispatcher, _DevelopmentJobDispatcher)
-    assert isinstance(_SchedulerFactory._dispatcher, _DevelopmentJobDispatcher)
+        Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
+        core.run()
+        assert core._dispatcher is not None
+        assert isinstance(core._dispatcher, _DevelopmentJobDispatcher)
+        assert isinstance(_SchedulerFactory._dispatcher, _DevelopmentJobDispatcher)
 
-    Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-    core.run()
-    assert core._dispatcher is not None
-    assert isinstance(core._dispatcher, _StandaloneJobDispatcher)
-    assert isinstance(_SchedulerFactory._dispatcher, _StandaloneJobDispatcher)
-    assert core._dispatcher.is_running()
-    assert _SchedulerFactory._dispatcher.is_running()
+    def test_run_core_as_a_service_standalone_mode(self):
+        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
+        _SchedulerFactory._dispatcher = None
+
+        core = Core()
+        assert core._scheduler is not None
+        assert core._scheduler == _Scheduler
+        assert _SchedulerFactory._scheduler is not None
+        assert _SchedulerFactory._scheduler == _Scheduler
+
+        assert core._dispatcher is None
+        assert _SchedulerFactory._dispatcher is None
+
+        Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
+        core.run()
+        assert core._dispatcher is not None
+        assert isinstance(core._dispatcher, _StandaloneJobDispatcher)
+        assert isinstance(_SchedulerFactory._dispatcher, _StandaloneJobDispatcher)
+        assert core._dispatcher.is_running()
+        assert _SchedulerFactory._dispatcher.is_running()
+
+    def test_block_config_update_when_core_service_is_running_development_mode(self):
+        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
+        _SchedulerFactory._dispatcher = None
+
+        core = Core()
+        Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
+        core.run()
+        with pytest.raises(ConfigurationUpdateBlocked):
+            input_cfg_1 = Config.configure_data_node(id="i1")
+
+    def test_block_config_update_when_core_service_is_running_standalone_mode(self):
+        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
+        _SchedulerFactory._dispatcher = None
+
+        core = Core()
+        Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
+        core.run()
+        with pytest.raises(ConfigurationUpdateBlocked):
+            input_cfg_1 = Config.configure_data_node(id="i1")

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -40,7 +40,6 @@ class TestCore:
         assert isinstance(_SchedulerFactory._dispatcher, _DevelopmentJobDispatcher)
 
     def test_run_core_as_a_service_standalone_mode(self):
-        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
         _SchedulerFactory._dispatcher = None
 
         core = Core()
@@ -61,21 +60,19 @@ class TestCore:
         assert _SchedulerFactory._dispatcher.is_running()
 
     def test_block_config_update_when_core_service_is_running_development_mode(self):
-        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
         _SchedulerFactory._dispatcher = None
 
         core = Core()
         Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
         core.run()
         with pytest.raises(ConfigurationUpdateBlocked):
-            input_cfg_1 = Config.configure_data_node(id="i1")
+            blocked_config = Config.configure_data_node(id="i1")
 
     def test_block_config_update_when_core_service_is_running_standalone_mode(self):
-        # The test is failed because the job dispatcher is not deleted after core.run() from previous function
         _SchedulerFactory._dispatcher = None
 
         core = Core()
         Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
         core.run()
         with pytest.raises(ConfigurationUpdateBlocked):
-            input_cfg_1 = Config.configure_data_node(id="i1")
+            blocked_config = Config.configure_data_node(id="i1")

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -18,6 +18,7 @@ from unittest import mock
 import pytest
 
 import src.taipy.core.taipy as tp
+from src.taipy.core import Core
 from src.taipy.core.common.alias import CycleId, JobId, PipelineId, ScenarioId, TaskId
 from src.taipy.core.config.job_config import JobConfig
 from src.taipy.core.config.pipeline_config import PipelineConfig
@@ -240,38 +241,6 @@ class TestTaipy:
             tp.cancel_job("job_id")
             mck.assert_called_once_with("job_id")
 
-    def test_block_config_when_core_is_running_in_standalone_mode(self):
-        Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE)
-
-        input_cfg_1 = Config.configure_data_node(id="i1", storage_type="pickle", default_data=1, scope=Scope.PIPELINE)
-        output_cfg_1 = Config.configure_data_node(id="o1", storage_type="pickle", scope=Scope.PIPELINE)
-        task_cfg_1 = Config.configure_task("t1", print, input_cfg_1, output_cfg_1)
-        pipeline_cfg_1 = Config.configure_pipeline("p1", task_cfg_1)
-        scenario_cfg_1 = Config.configure_scenario("s1", pipeline_cfg_1, Frequency.DAILY)
-
-        input_cfg_2 = Config.configure_data_node(id="i2", storage_type="pickle", default_data=2, scope=Scope.SCENARIO)
-        output_cfg_2 = Config.configure_data_node(id="o2", storage_type="pickle", scope=Scope.SCENARIO)
-        task_cfg_2 = Config.configure_task("t2", print, input_cfg_2, output_cfg_2)
-        pipeline_cfg_2 = Config.configure_pipeline("p2", task_cfg_2)
-        scenario_cfg_2 = Config.configure_scenario("s2", pipeline_cfg_2, Frequency.DAILY)
-
-        scenario_1 = tp.create_scenario(scenario_cfg_1)
-        scenario_2 = tp.create_scenario(scenario_cfg_2)
-
-        print("Before submit job 1")
-        job_1 = tp.submit(scenario_1)  # A Job dispatcher is created
-        job_1 = job_1[scenario_1.p1.id][0]
-        print("After submit job 1")
-        # When the job is finished, the job dispatcher is deleted.
-
-        print("Before submit job 2")
-        job_2 = tp.submit(scenario_2)
-        job_2 = job_2[scenario_2.p2.id][0]
-        print("After submit job 2")
-
-        with pytest.raises(ConfigurationUpdateBlocked):
-            scenario_3_config = Config.configure_scenario("my_scenario_3", pipeline_cfg_2)
-
     def test_block_config_when_core_is_running_in_development_mode(self):
         Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
 
@@ -281,28 +250,28 @@ class TestTaipy:
         pipeline_cfg_1 = Config.configure_pipeline("p1", task_cfg_1)
         scenario_cfg_1 = Config.configure_scenario("s1", pipeline_cfg_1, Frequency.DAILY)
 
-        input_cfg_2 = Config.configure_data_node(id="i2", storage_type="pickle", default_data=2, scope=Scope.SCENARIO)
-        output_cfg_2 = Config.configure_data_node(id="o2", storage_type="pickle", scope=Scope.SCENARIO)
-        task_cfg_2 = Config.configure_task("t2", print, input_cfg_2, output_cfg_2)
-        pipeline_cfg_2 = Config.configure_pipeline("p2", task_cfg_2)
-        scenario_cfg_2 = Config.configure_scenario("s2", pipeline_cfg_2, Frequency.DAILY)
-
         scenario_1 = tp.create_scenario(scenario_cfg_1)
-        scenario_2 = tp.create_scenario(scenario_cfg_2)
-
-        print("Before submit job 1")
-        job_1 = tp.submit(scenario_1)  # A Job dispatcher is created
-        job_1 = job_1[scenario_1.p1.id][0]
-        print("After submit job 1")
-        # When the job is finished, the job dispatcher is deleted.
-
-        print("Before submit job 2")
-        job_2 = tp.submit(scenario_2)
-        job_2 = job_2[scenario_2.p2.id][0]
-        print("After submit job 2")
+        tp.submit(scenario_1)
 
         with pytest.raises(ConfigurationUpdateBlocked):
-            scenario_3_config = Config.configure_scenario("my_scenario_3", pipeline_cfg_2)
+            blocked_scenario_config = Config.configure_scenario("block_scenario", pipeline_cfg_1)
+
+    def test_block_config_when_core_is_running_in_standalone_mode(self):
+        Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE)
+
+        input_cfg_1 = Config.configure_data_node(id="i1", storage_type="pickle", default_data=1, scope=Scope.PIPELINE)
+        output_cfg_1 = Config.configure_data_node(id="o1", storage_type="pickle", scope=Scope.PIPELINE)
+        task_cfg_1 = Config.configure_task("t1", print, input_cfg_1, output_cfg_1)
+        pipeline_cfg_1 = Config.configure_pipeline("p1", task_cfg_1)
+        scenario_cfg_1 = Config.configure_scenario("s1", pipeline_cfg_1, Frequency.DAILY)
+
+        Core().run()
+
+        scenario_1 = tp.create_scenario(scenario_cfg_1)
+        tp.submit(scenario_1)
+
+        with pytest.raises(ConfigurationUpdateBlocked):
+            blocked_scenario_config = Config.configure_scenario("block_scenario", pipeline_cfg_1)
 
     def test_get_data_node(self, data_node):
         with mock.patch("src.taipy.core.data._data_manager._DataManager._get") as mck:

--- a/tests/test_taipy.py
+++ b/tests/test_taipy.py
@@ -329,6 +329,9 @@ class TestTaipy:
         assert len(_CycleManager._get_all()) == 1
         assert len(_JobManager._get_all()) == 1
 
+        # Temporarily unblock config update to test config global app
+        Config.unblock_update()
+
         # Test with clean entities disabled
         Config.configure_global_app(clean_entities_enabled=False)
         success = tp.clean_all_entities()


### PR DESCRIPTION
When running the core service, a JobDispatcher is created in a separated thread.

Without `core.run()`, each time `tp.submit()` is called, a different JobDispatcher is created and deleted when the job is done.

My proposal is to call `Config.block_update()` whenever `build_dispatcher()` is called.
Then, we only unblock it when taipy application is terminated. 

This is not ideal though.