### PR TITLE
Fix/ Setup library for ParquetDataNode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-versions }}
 
-      - name: Pyodbc and Pymysql and Psycopg2
+      - name: Pyodbc and Pymysql and Psycopg2 and Pyarrow
         env:
           TOX_PARALLEL_NO_SPINNER: 1
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-versions }}
 
-      - name: Pyodbc and Pymysql and Psycopg2 and Pyarrow
+      - name: Pyodbc and Pymysql and Psycopg2 and Fastparquet
         env:
           TOX_PARALLEL_NO_SPINNER: 1
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Tox
         run: pip install tox
 
-      - name: Run linter and all tests except Pyodbc's, Pymysql's, Psycopg2's, and Pyarrow
+      - name: Run linter and all tests except Pyodbc's, Pymysql's, Psycopg2's, and Fastparquet
         if: matrix.python-versions == '3.10' && matrix.os == 'windows-latest'
         env:
           TOX_PARALLEL_NO_SPINNER: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Tox
         run: pip install tox
 
-      - name: Run linter and all tests except Pyodbc's and Pymysql's and Psycopg2's
+      - name: Run linter and all tests except Pyodbc's, Pymysql's, Psycopg2's, and Pyarrow
         if: matrix.python-versions == '3.10' && matrix.os == 'windows-latest'
         env:
           TOX_PARALLEL_NO_SPINNER: 1

--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-fastparquet = "2022.11.0"
 modin = {extras = ["dask"], version = "==0.16.2"}
 networkx = "==2.6"
 openpyxl = "==3.0.7"
+pyarrow = "==9.0.0"
 pymongo = "==4.2.0"
 sqlalchemy = "==1.4.18"
 toml = "==0.10"

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+fastparquet = "2022.11.0"
 modin = {extras = ["dask"], version = "==0.16.2"}
 networkx = "==2.6"
 openpyxl = "==3.0.7"
@@ -26,7 +27,6 @@ tox = ">=3.24"
 types-toml = ">=0.10.0"
 autopep8 = "*"
 mongomock = ">=4.1.2"
-pyarrow = "*"
 
 [requires]
 python_version = "3"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
+    "fastparquet==2022.11.0",
     "networkx>=2.6,<3.0",
     "openpyxl>=3.0.7,<4.0",
     "modin[dask]>=0.16.2,<1.0",
@@ -30,7 +31,12 @@ requirements = [
 
 test_requirements = ["pytest>=3.8"]
 
-extras_require = {"mssql": ["pyodbc>=4,<4.1"], "mysql": ["pymysql>1,<1.1"], "postgresql": ["psycopg2>2.9,<2.10"]}
+extras_require = {
+    "arrow": ["pyarrow>=9.0,<10.0"],
+    "mssql": ["pyodbc>=4,<4.1"],
+    "mysql": ["pymysql>1,<1.1"],
+    "postgresql": ["psycopg2>2.9,<2.10"],
+}
 
 setup(
     author="Avaiga",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "fastparquet==2022.11.0",
+    "pyarrow>=9.0,<10.0",
     "networkx>=2.6,<3.0",
     "openpyxl>=3.0.7,<4.0",
     "modin[dask]>=0.16.2,<1.0",
@@ -32,7 +32,7 @@ requirements = [
 test_requirements = ["pytest>=3.8"]
 
 extras_require = {
-    "arrow": ["pyarrow>=9.0,<10.0"],
+    "fastparquet": ["fastparquet==2022.11.0"],
     "mssql": ["pyodbc>=4,<4.1"],
     "mysql": ["pymysql>1,<1.1"],
     "postgresql": ["psycopg2>2.9,<2.10"],

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -406,7 +406,7 @@ class DataNodeConfig(Section):
         id: str,
         default_path: str = None,
         exposed_type=_DEFAULT_EXPOSED_TYPE,
-        engine: str = "auto",
+        engine: Optional[str] = "fastparquet",
         compression: Optional[str] = "snappy",
         read_kwargs: Dict = dict(),
         write_kwargs: Dict = dict(),
@@ -420,9 +420,8 @@ class DataNodeConfig(Section):
             id (str): The unique identifier of the new Parquet data node configuration.
             default_path (str): The default path of the Parquet file.
             exposed_type: The exposed type of the data read from Parquet file. The default value is `pandas`.
-            engine (str): Parquet library to use. If 'auto', then the option pandas.io.parquet.engine is used.
-                The default pandas.io.parquet.engine behavior is to try 'pyarrow', falling back to 'fastparquet' if 'pyarrow' is unavailable.
-                `{'auto', 'pyarrow', 'fastparquet'}`, default `'auto'`.
+            engine (Optional[str]): Parquet library to use. Possible values are _"fastparquet"_ or _"pyarrow"_.
+                The default value is _"fastparquet"_.
             compression (Optional[str]): Name of the compression to use. Use None for no compression.
                 `{'snappy', 'gzip', 'brotli', None}`, default `'snappy'`.
             read_kwargs (Optional[Dict]): Additional parameters passed to the `pandas.read_parquet` method.

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -406,7 +406,7 @@ class DataNodeConfig(Section):
         id: str,
         default_path: str = None,
         exposed_type=_DEFAULT_EXPOSED_TYPE,
-        engine: Optional[str] = "fastparquet",
+        engine: Optional[str] = "pyarrow",
         compression: Optional[str] = "snappy",
         read_kwargs: Dict = dict(),
         write_kwargs: Dict = dict(),
@@ -421,7 +421,7 @@ class DataNodeConfig(Section):
             default_path (str): The default path of the Parquet file.
             exposed_type: The exposed type of the data read from Parquet file. The default value is `pandas`.
             engine (Optional[str]): Parquet library to use. Possible values are _"fastparquet"_ or _"pyarrow"_.
-                The default value is _"fastparquet"_.
+                The default value is _"pyarrow"_.
             compression (Optional[str]): Name of the compression to use. Use None for no compression.
                 `{'snappy', 'gzip', 'brotli', None}`, default `'snappy'`.
             read_kwargs (Optional[Dict]): Additional parameters passed to the `pandas.read_parquet` method.

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -55,7 +55,7 @@ class ParquetDataNode(DataNode):
             - _"default_path"_ `(str)`: The default path of the Parquet file.\n
             - _"exposed_type"_: The exposed type of the data read from Parquet file. The default value is `pandas`.\n
             - _"engine"_ `(Optional[str])`: Parquet library to use. Possible values are _"fastparquet"_ or _"pyarrow"_.
-                The default value is _"fastparquet"_.
+                The default value is _"pyarrow"_.
             - _"compression"_ `(Optional[str])`: Name of the compression to use. Use None for no compression.
                 `{'snappy', 'gzip', 'brotli', None}`, default `'snappy'`.\n
             - _"read_kwargs"_ `(Optional[Dict])`: Additional parameters passed to the _pandas.read_parquet_ method.\n
@@ -103,7 +103,7 @@ class ParquetDataNode(DataNode):
             )
 
         if self.__ENGINE_PROPERTY not in properties.keys():
-            properties[self.__ENGINE_PROPERTY] = "fastparquet"
+            properties[self.__ENGINE_PROPERTY] = "pyarrow"
         if properties[self.__ENGINE_PROPERTY] not in self.__VALID_PARQUET_ENGINES:
             raise UnknownParquetEngine(
                 f"Invalid parquet engine: {properties[self.__ENGINE_PROPERTY]}. Supported engines are {', '.join(self.__VALID_PARQUET_ENGINES)}"

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -150,7 +150,7 @@ class ParquetDataNode(DataNode):
             **properties,
         )
         if not self._last_edit_date and isfile(self._path):
-            self.unlock_edit()
+            self.last_edit_date = datetime.now()  # type: ignore
 
     @classmethod
     def storage_type(cls) -> str:

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -20,7 +20,12 @@ from taipy.config.common.scope import Scope
 
 from ..common._reload import _self_reload
 from ..common.alias import DataNodeId, JobId
-from ..exceptions.exceptions import InvalidExposedType, MissingRequiredProperty
+from ..exceptions.exceptions import (
+    InvalidExposedType,
+    MissingRequiredProperty,
+    UnknownCompressionAlgorithm,
+    UnknownParquetEngine,
+)
 from .data_node import DataNode
 
 
@@ -49,9 +54,8 @@ class ParquetDataNode(DataNode):
 
             - _"default_path"_ `(str)`: The default path of the Parquet file.\n
             - _"exposed_type"_: The exposed type of the data read from Parquet file. The default value is `pandas`.\n
-            - _"engine"_ `(str)`: Parquet library to use. If 'auto', then the option pandas.io.parquet.engine is used.
-                The default pandas.io.parquet.engine behavior is to try 'pyarrow', falling back to 'fastparquet' if 'pyarrow' is unavailable.
-                `{'auto', 'pyarrow', 'fastparquet'}`, default `'auto'`. \n
+            - _"engine"_ `(Optional[str])`: Parquet library to use. Possible values are _"fastparquet"_ or _"pyarrow"_.
+                The default value is _"fastparquet"_.
             - _"compression"_ `(Optional[str])`: Name of the compression to use. Use None for no compression.
                 `{'snappy', 'gzip', 'brotli', None}`, default `'snappy'`.\n
             - _"read_kwargs"_ `(Optional[Dict])`: Additional parameters passed to the _pandas.read_parquet_ method.\n
@@ -69,7 +73,9 @@ class ParquetDataNode(DataNode):
     __PATH_KEY = "path"
     __DEFAULT_PATH_KEY = "default_path"
     __ENGINE_PROPERTY = "engine"
+    __VALID_PARQUET_ENGINES = ["pyarrow", "fastparquet"]
     __COMPRESSION_PROPERTY = "compression"
+    __VALID_COMPRESSION_ALGORITHMS = ["snappy", "gzip", "brotli"]
     __READ_KWARGS_PROPERTY = "read_kwargs"
     __WRITE_KWARGS_PROPERTY = "write_kwargs"
     _REQUIRED_PROPERTIES: List[str] = []
@@ -97,10 +103,21 @@ class ParquetDataNode(DataNode):
             )
 
         if self.__ENGINE_PROPERTY not in properties.keys():
-            properties[self.__ENGINE_PROPERTY] = "pyarrow"
+            properties[self.__ENGINE_PROPERTY] = "fastparquet"
+        if properties[self.__ENGINE_PROPERTY] not in self.__VALID_PARQUET_ENGINES:
+            raise UnknownParquetEngine(
+                f"Invalid parquet engine: {properties[self.__ENGINE_PROPERTY]}. Supported engines are {', '.join(self.__VALID_PARQUET_ENGINES)}"
+            )
 
         if self.__COMPRESSION_PROPERTY not in properties.keys():
             properties[self.__COMPRESSION_PROPERTY] = "snappy"
+        if (
+            properties[self.__COMPRESSION_PROPERTY]
+            and properties[self.__COMPRESSION_PROPERTY] not in self.__VALID_COMPRESSION_ALGORITHMS
+        ):
+            raise UnknownCompressionAlgorithm(
+                f"Unsupported compression algorithm: {properties[self.__COMPRESSION_PROPERTY]}. Supported algorithms are {', '.join(self.__VALID_COMPRESSION_ALGORITHMS)}"
+            )
 
         if self.__READ_KWARGS_PROPERTY not in properties.keys():
             properties[self.__READ_KWARGS_PROPERTY] = {}
@@ -215,6 +232,11 @@ class ParquetDataNode(DataNode):
             return None
 
         kwargs = self.properties[self.__READ_KWARGS_PROPERTY]
+        kwargs.update(
+            {
+                self.__ENGINE_PROPERTY: self.properties[self.__ENGINE_PROPERTY],
+            }
+        )
         kwargs.update(read_kwargs)
 
         if self.properties[self.__EXPOSED_TYPE_PROPERTY] == self.__EXPOSED_TYPE_PANDAS:

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -46,6 +46,14 @@ class UnknownDatabaseEngine(Exception):
     """Raised if the database engine is not known when creating a connection with a SQLDataNode."""
 
 
+class UnknownParquetEngine(Exception):
+    """Raised if the parquet engine is not known or not supported when create a ParquetDataNode."""
+
+
+class UnknownCompressionAlgorithm(Exception):
+    """Raised if the compression algorithm is not supported by ParquetDataNode."""
+
+
 class NonExistingDataNode(Exception):
     """Raised if a requested DataNode is not known by the DataNode Manager."""
 

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -61,9 +61,9 @@ def create_custom_class(**kwargs):
 
 
 class TestParquetDataNode:
-    __engine = ["fastparquet"]
-    if util.find_spec("pyarrow"):
-        __engine.append("pyarrow")
+    __engine = ["pyarrow"]
+    if util.find_spec("fastparquet"):
+        __engine.append("fastparquet")
 
     def test_create(self):
         path = "data/node/path"
@@ -84,7 +84,7 @@ class TestParquetDataNode:
         assert dn.path == path
         assert dn.exposed_type == "pandas"
         assert dn.compression == "snappy"
-        assert dn.engine == "fastparquet"
+        assert dn.engine == "pyarrow"
 
         with pytest.raises(InvalidConfigurationId):
             dn = ParquetDataNode("foo bar", Scope.PIPELINE, name="super name", properties={"path": path})
@@ -258,7 +258,7 @@ class TestParquetDataNode:
         print(dn.read())
         assert set(dn.read().columns) == set(read_kwargs["columns"])
 
-        # !!! filter doesn't work with `fastparquet` through pandas interface
+        # !!! filter doesn't work with `fastparquet` without partition_cols
         if engine == "pyarrow":
             assert len(dn.read()) != len(df)
             assert len(dn.read()) == 2

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -12,6 +12,7 @@
 import os
 import pathlib
 from datetime import datetime
+from importlib import util
 from time import sleep
 
 import modin.pandas as modin_pd
@@ -26,6 +27,14 @@ from src.taipy.core.exceptions.exceptions import InvalidExposedType, MissingRequ
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 from taipy.config.exceptions.exceptions import InvalidConfigurationId
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup():
+    yield
+    path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.parquet")
+    if os.path.isfile(path):
+        os.remove(path)
 
 
 class MyCustomObject:
@@ -46,6 +55,10 @@ def create_custom_class(**kwargs):
 
 
 class TestParquetDataNode:
+    __engine = ["fastparquet"]
+    if util.find_spec("pyarrow"):
+        __engine.append("pyarrow")
+
     def test_create(self):
         path = "data/node/path"
         compression = "snappy"
@@ -65,6 +78,7 @@ class TestParquetDataNode:
         assert dn.path == path
         assert dn.exposed_type == "pandas"
         assert dn.compression == "snappy"
+        assert dn.engine == "fastparquet"
 
         with pytest.raises(InvalidConfigurationId):
             dn = ParquetDataNode("foo bar", Scope.PIPELINE, name="super name", properties={"path": path})
@@ -76,8 +90,7 @@ class TestParquetDataNode:
         not_ready_dn = _DataManager._bulk_get_or_create([not_ready_dn_cfg])[not_ready_dn_cfg]
         assert not not_ready_dn.is_ready_for_reading
 
-        path = str(parquet_file_path)
-        ready_dn_cfg = Config.configure_data_node("ready_data_node_config_id", "parquet", path=path)
+        ready_dn_cfg = Config.configure_data_node("ready_data_node_config_id", "parquet", path=parquet_file_path)
         ready_dn = _DataManager._bulk_get_or_create([ready_dn_cfg])[ready_dn_cfg]
         assert ready_dn.is_ready_for_reading
 
@@ -87,35 +100,41 @@ class TestParquetDataNode:
         with pytest.raises(MissingRequiredProperty):
             ParquetDataNode("foo", Scope.PIPELINE, DataNodeId("dn_id"), properties={})
 
-    def test_read_with_exposed_types(self, parquet_file_path):
-        not_existing_parquet = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": "nonexistent.parquet"})
+    @pytest.mark.parametrize("engine", __engine)
+    def test_read(self, engine, parquet_file_path):
+        not_existing_parquet = ParquetDataNode(
+            "foo", Scope.PIPELINE, properties={"path": "nonexistent.parquet", "engine": engine}
+        )
         with pytest.raises(NoData):
             assert not_existing_parquet.read() is None
             not_existing_parquet.read_or_raise()
 
-        path = str(parquet_file_path)
-        df = pd.read_parquet(path)
+        df = pd.read_parquet(parquet_file_path)
         # Create ParquetDataNode without exposed_type (Default is pandas.DataFrame)
-        parquet_data_node_as_pandas = ParquetDataNode("bar", Scope.PIPELINE, properties={"path": path})
+        parquet_data_node_as_pandas = ParquetDataNode(
+            "bar", Scope.PIPELINE, properties={"path": parquet_file_path, "engine": engine}
+        )
         data_pandas = parquet_data_node_as_pandas.read()
         assert isinstance(data_pandas, pd.DataFrame)
         assert len(data_pandas) == 2
         assert data_pandas.equals(df)
         assert np.array_equal(data_pandas.to_numpy(), df.to_numpy())
 
-        # Create ParquetDataNode with modin exposed_type
-        parquet_data_node_as_modin = ParquetDataNode(
-            "bar", Scope.PIPELINE, properties={"path": path, "exposed_type": "modin"}
-        )
-        data_modin = parquet_data_node_as_modin.read()
-        assert isinstance(data_modin, modin_pd.DataFrame)
-        assert len(data_modin) == 2
-        assert data_modin.equals(df)
-        assert np.array_equal(data_modin.to_numpy(), df.to_numpy())
+        # !!! Modin still check for pyarrow eventhough it is not necessary when using `fastparquet`
+        if engine == "pyarrow":
+            # Create ParquetDataNode with modin exposed_type
+            parquet_data_node_as_modin = ParquetDataNode(
+                "bar", Scope.PIPELINE, properties={"path": parquet_file_path, "exposed_type": "modin", "engine": engine}
+            )
+            data_modin = parquet_data_node_as_modin.read()
+            assert isinstance(data_modin, modin_pd.DataFrame)
+            assert len(data_modin) == 2
+            assert data_modin.equals(df)
+            assert np.array_equal(data_modin.to_numpy(), df.to_numpy())
 
         # Create ParquetDataNode with numpy exposed_type
         parquet_data_node_as_numpy = ParquetDataNode(
-            "bar", Scope.PIPELINE, properties={"path": path, "has_header": True, "exposed_type": "numpy"}
+            "bar", Scope.PIPELINE, properties={"path": parquet_file_path, "exposed_type": "numpy", "engine": engine}
         )
         data_numpy = parquet_data_node_as_numpy.read()
         assert isinstance(data_numpy, np.ndarray)
@@ -128,14 +147,11 @@ class TestParquetDataNode:
         dn.path = "bar.parquet"
         assert dn.path == "bar.parquet"
 
-    def test_raise_error_when_path_not_exist(self):
-        with pytest.raises(MissingRequiredProperty):
-            ParquetDataNode("foo", Scope.PIPELINE)
-
-    def test_read_write_after_modify_path(self, parquet_file_path):
-        path = str(parquet_file_path)
-        new_path = str(pathlib.Path(parquet_file_path).with_name("nonexistent.parquet"))
-        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": path})
+    @pytest.mark.parametrize("engine", __engine)
+    def test_read_write_after_modify_path(self, engine):
+        path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")
+        new_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/temp.parquet")
+        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": path, "engine": engine})
         read_data = dn.read()
         assert read_data is not None
         dn.path = new_path
@@ -144,15 +160,7 @@ class TestParquetDataNode:
         dn.write(read_data)
         assert dn.read().equals(read_data)
 
-    def test_pandas_exposed_type(self, parquet_file_path):
-        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": parquet_file_path, "exposed_type": "pandas"})
-        assert isinstance(dn.read(), pd.DataFrame)
-
-    def test_numpy_exposed_type(self, parquet_file_path):
-        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": parquet_file_path, "exposed_type": "numpy"})
-        assert isinstance(dn.read(), np.ndarray)
-
-    def test_custom_exposed_type(self):
+    def test_read_custom_exposed_type(self):
         example_parquet_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")
 
         dn = ParquetDataNode(
@@ -213,88 +221,105 @@ class TestParquetDataNode:
         temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.parquet"))
         dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path})
 
-        example_csv_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.csv")
-        df = pd.read_csv(example_csv_path)
+        df = pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}])
         dn.write(df)
 
         assert pathlib.Path(temp_file_path).exists()
         assert isinstance(dn.read(), pd.DataFrame)
 
-    def test_pandas_parquet_defaults(self, default_data_frame: pd.DataFrame):
-        # If Pandas changes their defaults, we may consider doing the same
-        pyarrow_snappy_bytes = default_data_frame.to_parquet(engine="pyarrow", compression="snappy")
-
-        assumed_default_engine = "pyarrow"
-        default_compression_bytes = default_data_frame.to_parquet(engine=assumed_default_engine)
-        assert default_compression_bytes == pyarrow_snappy_bytes
-
-        assumed_default_compression = "snappy"
-        default_engine_bytes = default_data_frame.to_parquet(compression=assumed_default_compression)
-        assert default_engine_bytes == pyarrow_snappy_bytes
-
-    def test_pandas_parquet_config_kwargs(self, tmpdir_factory):
-        read_kwargs = {"columns": ["text"], "filters": [("integer", "<", 10)]}
+    @pytest.mark.parametrize("engine", __engine)
+    def test_pandas_parquet_config_kwargs(self, engine, tmpdir_factory):
+        read_kwargs = {"filters": [("integer", "<", 10)], "columns": ["integer"]}
         temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.parquet"))
-        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "read_kwargs": read_kwargs})
+        dn = ParquetDataNode(
+            "foo", Scope.PIPELINE, properties={"path": temp_file_path, "engine": engine, "read_kwargs": read_kwargs}
+        )
 
-        example_csv_path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.csv")
-        df = pd.read_csv(example_csv_path)
+        df = pd.read_csv(os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.csv"))
         dn.write(df)
 
         assert set(pd.read_parquet(temp_file_path).columns) == {"id", "integer", "text"}
+        print(dn.read())
         assert set(dn.read().columns) == set(read_kwargs["columns"])
-        assert len(dn.read()) != len(df)
-        assert len(dn.read()) == 2
 
-    def test_kwarg_precedence(self, tmpdir_factory, default_data_frame: pd.DataFrame):
+        # !!! filter doesn't work with `fastparquet` through pandas interface
+        if engine == "pyarrow":
+            assert len(dn.read()) != len(df)
+            assert len(dn.read()) == 2
+
+    @pytest.mark.parametrize("engine", __engine)
+    def test_kwarg_precedence(self, engine, tmpdir_factory, default_data_frame):
         # Precedence:
         # 1. Class read/write methods
         # 2. Defined in read_kwargs and write_kwargs, in properties
         # 3. Defined top-level in properties
 
         temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.parquet"))
-        df = default_data_frame
+        temp_file_2_path = str(tmpdir_factory.mktemp("data").join("temp_2.parquet"))
+        df = default_data_frame.copy(deep=True)
 
         ## Write
         # 3
         comp3 = "snappy"
-        dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path, "compression": comp3})
+        dn = ParquetDataNode(
+            "foo", Scope.PIPELINE, properties={"path": temp_file_path, "engine": engine, "compression": comp3}
+        )
         dn.write(df)
-        assert pathlib.Path(temp_file_path).open("rb").read() == df.to_parquet(compression=comp3)
+        df.to_parquet(path=temp_file_2_path, compression=comp3, engine=engine)
+        with open(temp_file_2_path, "rb") as tf:
+            assert pathlib.Path(temp_file_path).open("rb").read() == tf.read()
 
         # 3 and 2
         comp2 = "gzip"
         dn = ParquetDataNode(
             "foo",
             Scope.PIPELINE,
-            properties={"path": temp_file_path, "compression": comp3, "write_kwargs": {"compression": comp2}},
+            properties={
+                "path": temp_file_path,
+                "engine": engine,
+                "compression": comp3,
+                "write_kwargs": {"compression": comp2},
+            },
         )
         dn.write(df)
-        assert pathlib.Path(temp_file_path).open("rb").read() == df.to_parquet(compression=comp2)
+        df.to_parquet(path=temp_file_2_path, compression=comp2, engine=engine)
+        with open(temp_file_2_path, "rb") as tf:
+            assert pathlib.Path(temp_file_path).open("rb").read() == tf.read()
 
         # 3, 2 and 1
         comp1 = "brotli"
         dn = ParquetDataNode(
             "foo",
             Scope.PIPELINE,
-            properties={"path": temp_file_path, "compression": comp3, "write_kwargs": {"compression": comp2}},
+            properties={
+                "path": temp_file_path,
+                "engine": engine,
+                "compression": comp3,
+                "write_kwargs": {"compression": comp2},
+            },
         )
         dn.write_with_kwargs(df, compression=comp1)
-        assert pathlib.Path(temp_file_path).open("rb").read() == df.to_parquet(compression=comp1)
+        df.to_parquet(path=temp_file_2_path, compression=comp1, engine=engine)
+        with open(temp_file_2_path, "rb") as tf:
+            assert pathlib.Path(temp_file_path).open("rb").read() == tf.read()
 
         ## Read
-        df.to_parquet(temp_file_path)
+        df.to_parquet(temp_file_path, engine=engine)
         # 2
         cols2 = ["a", "b"]
         dn = ParquetDataNode(
-            "foo", Scope.PIPELINE, properties={"path": temp_file_path, "read_kwargs": {"columns": cols2}}
+            "foo",
+            Scope.PIPELINE,
+            properties={"path": temp_file_path, "engine": engine, "read_kwargs": {"columns": cols2}},
         )
         assert set(dn.read().columns) == set(cols2)
 
         # 1
         cols1 = ["a"]
         dn = ParquetDataNode(
-            "foo", Scope.PIPELINE, properties={"path": temp_file_path, "read_kwargs": {"columns": cols2}}
+            "foo",
+            Scope.PIPELINE,
+            properties={"path": temp_file_path, "engine": engine, "read_kwargs": {"columns": cols2}},
         )
         assert set(dn.read_with_kwargs(columns=cols1).columns) == set(cols1)
 

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -23,7 +23,13 @@ import pytest
 from src.taipy.core.common.alias import DataNodeId
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.parquet import ParquetDataNode
-from src.taipy.core.exceptions.exceptions import InvalidExposedType, MissingRequiredProperty, NoData
+from src.taipy.core.exceptions.exceptions import (
+    InvalidExposedType,
+    MissingRequiredProperty,
+    NoData,
+    UnknownCompressionAlgorithm,
+    UnknownParquetEngine,
+)
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 from taipy.config.exceptions.exceptions import InvalidConfigurationId
@@ -172,6 +178,16 @@ class TestParquetDataNode:
             "foo", Scope.PIPELINE, properties={"path": example_parquet_path, "exposed_type": create_custom_class}
         )
         assert all([isinstance(obj, MyOtherCustomObject) for obj in dn.read()])
+
+    def test_raise_error_unknown_parquet_engine(self):
+        path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")
+        with pytest.raises(UnknownParquetEngine):
+            ParquetDataNode("foo", Scope.PIPELINE, properties={"path": path, "engine": "foo"})
+
+    def test_raise_error_unknown_compression_algorithm(self):
+        path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")
+        with pytest.raises(UnknownCompressionAlgorithm):
+            ParquetDataNode("foo", Scope.PIPELINE, properties={"path": path, "compression": "foo"})
 
     def test_raise_error_invalid_exposed_type(self):
         path = os.path.join(pathlib.Path(__file__).parent.resolve(), "data_sample/example.parquet")

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     black taipy tests
     flake8 taipy tests
 
-[testenv:without-pyodbc-pymysql-psycopg2]
+[testenv:without-pyodbc-pymysql-psycopg2-fastparquet]
 commands =
     pipenv install --dev --skip-lock
     pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = true
 isolated_build = true
-envlist = clean, lint, without-pyodbc-pymysql-psycopg2-pyarrow
+envlist = clean, lint, without-pyodbc-pymysql-psycopg2-fastparquet
 
 [pytest]
 filterwarnings =
@@ -37,7 +37,7 @@ commands =
     pip install pyodbc
     pip install pymysql
     pip install psycopg2
-    pip install pyarrow
+    pip install fastparquet
     pytest tests
 
 [testenv:coverage]
@@ -51,7 +51,7 @@ commands =
     pipenv install pyodbc --skip-lock
     pipenv install pymysql --skip-lock
     pipenv install psycopg2 --skip-lock
-    pipenv install pyarrow --skip-lock
+    pipenv install fastparquet --skip-lock
     pytest -s --cov=src --cov-append --cov-report=xml --cov-report term-missing tests
     coverage report
     coverage html

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = true
 isolated_build = true
-envlist = clean, lint, without-pyodbc-pymysql-psycopg2
+envlist = clean, lint, without-pyodbc-pymysql-psycopg2-pyarrow
 
 [pytest]
 filterwarnings =
@@ -37,6 +37,7 @@ commands =
     pip install pyodbc
     pip install pymysql
     pip install psycopg2
+    pip install pyarrow
     pytest tests
 
 [testenv:coverage]
@@ -50,6 +51,7 @@ commands =
     pipenv install pyodbc --skip-lock
     pipenv install pymysql --skip-lock
     pipenv install psycopg2 --skip-lock
+    pipenv install pyarrow --skip-lock
     pytest -s --cov=src --cov-append --cov-report=xml --cov-report term-missing tests
     coverage report
     coverage html


### PR DESCRIPTION
Finishing https://github.com/Avaiga/taipy-core/issues/351.

In this PR:
- `fastparquet` is used as the default engine instead of `pyarrow`.
- Add test for both `fastparquet` and `pyarrow`.

Some existing problems with `fastparquet`:
1. Modin does support both for read and write Parquet. However, their internal code still check if arrow is installed or not. This is weird, and I’ve open an Issue on Modin (https://github.com/modin-project/modin/issues/5285).
2. The filter argument does not work with `fastparquet`, only work with `pyarrow`. It is not that `fastparquet` doesn’t support filter, just not though pandas interface.

@FabienLelaquais @jrobinAV @florian-vuillemot @toan-quach What do you think about these problems?