### PR TITLE
:construction_worker: Flake8 is now on Github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: black
       args: [--line-length=120]
       language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
# What does this PR do?
Flake8 has left Gitlab and is now on Github.
This PR updates the pre-commit hook config.

# Motivation
Get the pre-commit hooks working for development.