### PR TITLE
Fix writing modin df to ParquetDataNode

### DIFF
--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -213,7 +213,10 @@ class ParquetDataNode(DataNode):
         }
         kwargs.update(self.properties[self.__WRITE_KWARGS_PROPERTY])
         kwargs.update(write_kwargs)
-        pd.DataFrame(data).to_parquet(self._path, **kwargs)
+        if isinstance(data, (pd.DataFrame, modin_pd.DataFrame)):
+            data.to_parquet(self._path, **kwargs)
+        else:
+            pd.DataFrame(data).to_parquet(self._path, **kwargs)
 
         self._last_edit_date = datetime.now()
         if job_id:

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -233,12 +233,18 @@ class TestParquetDataNode:
         assert new_edit_date < dn.last_edit_date
         os.unlink(temp_file_path)
 
-    def test_write_to_disk(self, tmpdir_factory):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            [{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}],
+            pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}]),
+            modin_pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}]),
+        ],
+    )
+    def test_write_to_disk(self, tmpdir_factory, data):
         temp_file_path = str(tmpdir_factory.mktemp("data").join("temp.parquet"))
         dn = ParquetDataNode("foo", Scope.PIPELINE, properties={"path": temp_file_path})
-
-        df = pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}])
-        dn.write(df)
+        dn.write(data)
 
         assert pathlib.Path(temp_file_path).exists()
         assert isinstance(dn.read(), pd.DataFrame)


### PR DESCRIPTION
Fixing an issue with writing modin DataFrames to ParquetDataNode.

I'm re-implementing the behavior from CSVDataNode which I wrongly removed previously. Without this, passing a modin df to pd.DataFrame causes it to lose the column names, which is not what we want.