### PR TITLE
Refactor Version control system for other repositories implementation

### DIFF
--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -175,3 +175,7 @@ class _VersionManager(_Manager[_Version]):
             return version.id
 
         raise NonExistingVersion(version_number)
+
+    @classmethod
+    def _delete_entities_of_multiple_types(cls, _entity_ids):
+        return NotImplementedError

--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -90,7 +90,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_development_version(cls) -> str:
         try:
             return cls._repository._get_development_version()
-        except FileNotFoundError:
+        except:
             return cls._set_development_version(str(uuid.uuid4()))
 
     @classmethod
@@ -113,7 +113,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_latest_version(cls) -> str:
         try:
             return cls._repository._get_latest_version()
-        except FileNotFoundError:
+        except:
             # If there is no version in the system yet, create a new version as development version
             # This set the default versioning behavior on Jupyter notebook to Development mode
             return cls._set_development_version(str(uuid.uuid4()))
@@ -145,7 +145,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_production_version(cls) -> List[str]:
         try:
             return cls._repository._get_production_version()
-        except FileNotFoundError:
+        except:
             return []
 
     @classmethod

--- a/src/taipy/core/_version/_version_manager_factory.py
+++ b/src/taipy/core/_version/_version_manager_factory.py
@@ -21,6 +21,6 @@ class _VersionManagerFactory(_ManagerFactory):
     @classmethod
     def _build_manager(cls) -> Type[_VersionManager]:  # type: ignore
         if cls._using_enterprise():
-            return _load_fct(cls._TAIPY_ENTERPRISE_CORE_MODULE + ".version._version_manager", "_VersionManager")  # type: ignore
+            return _load_fct(cls._TAIPY_ENTERPRISE_CORE_MODULE + "._version._version_manager", "_VersionManager")  # type: ignore
         _VersionManager._repository = _VersionRepositoryFactory._build_repository()  # type: ignore
         return _VersionManager

--- a/src/taipy/core/_version/_version_repository.py
+++ b/src/taipy/core/_version/_version_repository.py
@@ -1,0 +1,96 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import pathlib
+from datetime import datetime
+from typing import Any, Iterable, List, Optional, Union
+
+from taipy.config import Config
+
+from .._repository._repository import _AbstractRepository
+from .._repository._repository_adapter import _RepositoryAdapter
+from ._version import _Version
+from ._version_model import _VersionModel
+
+
+class _VersionRepository(_AbstractRepository[_VersionModel, _Version]):  # type: ignore
+    _LATEST_VERSION_KEY = "latest_version"
+    _DEVELOPMENT_VERSION_KEY = "development_version"
+    _PRODUCTION_VERSION_KEY = "production_version"
+
+    def __init__(self, **kwargs):
+        kwargs.update({"to_model_fct": self._to_model, "from_model_fct": self._from_model})
+        self.repo = _RepositoryAdapter.select_base_repository()(**kwargs)
+
+    @property
+    def repository(self):
+        return self.repo
+
+    def _to_model(self, version: _Version):
+        return _VersionModel(
+            id=version.id, config=Config._to_json(version.config), creation_date=version.creation_date.isoformat()
+        )
+
+    def _from_model(self, model):
+        version = _Version(id=model.id, config=Config._from_json(model.config))
+        version.creation_date = datetime.fromisoformat(model.creation_date)
+        return version
+
+    def load(self, model_id: str) -> _Version:
+        return self.repo.load(model_id)
+
+    def _load_all(self, version_number: Optional[str] = "all") -> List[_Version]:
+        return self.repo._load_all(version_number)
+
+    def _load_all_by(self, by, version_number: Optional[str] = "all") -> List[_Version]:
+        return self.repo._load_all_by(by, version_number)
+
+    def _save(self, entity: _Version):
+        return self.repo._save(entity)
+
+    def _delete(self, entity_id: str):
+        return self.repo._delete(entity_id)
+
+    def _delete_all(self):
+        return self.repo._delete_all()
+
+    def _delete_many(self, ids: Iterable[str]):
+        return self.repo._delete_many(ids)
+
+    def _delete_by(self, attribute: str, value: str, version_number: Optional[str] = None):
+        return self.repo._delete_by(attribute, value, version_number)
+
+    def _search(self, attribute: str, value: Any, version_number: Optional[str] = None) -> Optional[_Version]:
+        return self.repo._search(attribute, value, version_number)
+
+    def _export(self, entity_id: str, folder_path: Union[str, pathlib.Path]):
+        return self.repo._export(entity_id, folder_path)
+
+    def _set_latest_version(self, version_number):
+        self.repo._set_latest_version(version_number)
+
+    def _get_latest_version(self) -> str:
+        return self.repo._get_latest_version()
+
+    def _set_development_version(self, version_number):
+        self.repo._set_development_version(version_number)
+
+    def _get_development_version(self) -> str:
+        return self.repo._get_development_version()
+
+    def _set_production_version(self, version_number):
+        self.repo._set_production_version(version_number)
+
+    def _get_production_version(self) -> List[str]:
+        return self.repo._get_production_version()
+
+    def _delete_production_version(self, version_number):
+        self.repo._delete_production_version(version_number)

--- a/src/taipy/core/_version/_version_repository_factory.py
+++ b/src/taipy/core/_version/_version_repository_factory.py
@@ -11,12 +11,18 @@
 
 from typing import Any, Union
 
+from taipy.config import Config
+
 from .._repository._repository_factory import _RepositoryFactory
 from ..common._utils import _load_fct
 from ._version_fs_repository import _VersionFSRepository
+from ._version_sql_repository import _VersionSQLRepository
 
 
 class _VersionRepositoryFactory(_RepositoryFactory):
+
+    _REPOSITORY_MAP = {"default": _VersionFSRepository, "sql": _VersionSQLRepository}
+
     @classmethod
     def _build_repository(cls) -> Union[_VersionFSRepository, Any]:  # type: ignore
         if cls._using_enterprise():
@@ -24,4 +30,4 @@ class _VersionRepositoryFactory(_RepositoryFactory):
                 cls._TAIPY_ENTERPRISE_CORE_MODULE + "._version._version_repository_factory", "_VersionRepositoryFactory"
             )
             return factory._build_repository()  # type: ignore
-        return _VersionFSRepository()
+        return cls._REPOSITORY_MAP.get(Config.global_config.repository_type, cls._REPOSITORY_MAP.get("default"))()  # type: ignore

--- a/src/taipy/core/_version/_version_sql_repository.py
+++ b/src/taipy/core/_version/_version_sql_repository.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from ._version_model import _VersionModel
+from ._version_repository import _VersionRepository
+
+
+class _VersionSQLRepository(_VersionRepository):
+    def __init__(self):
+        super().__init__(model=_VersionModel, model_name="version")
+
+    # TODO: Implement _VersionSQLRepository functionalities

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -483,7 +483,7 @@ def clean_all_entities_by_version(version_number):
     try:
         version_number = version_manager._replace_version_number(version_number)
     except NonExistingVersion as e:
-        raise SystemExit(e)
+        raise SystemExit(e.message)
 
     _JobManagerFactory._build_manager()._delete_by_version(version_number)
     _ScenarioManagerFactory._build_manager()._delete_by_version(version_number)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,6 +284,7 @@ def close_sql_database_session_connection():
     _TaskRepositoryFactory._build_repository().repo.session.close_all()
     _JobRepositoryFactory._build_repository().repo.session.close_all()
     _CycleRepositoryFactory._build_repository().repo.session.close_all()
+    _VersionRepositoryFactory._build_repository().repo.session.close_all()
 
 
 def init_config():


### PR DESCRIPTION
To summarize the PR:
- `_VersionFSRepository` is now inherit from `_VersionRepository` for easier implementation of other repositories.
- The `_VersionSQLRepository` should be on `src/taipy/core/_version/_version_sql_repository.py` (at the TODO comment).
- The test cases for SQL repo are failing (expected).
- This PR also fixed some issue with error message and factories for the _Version.