### PR TITLE
Fix/#415 - Override not working for production mode

### DIFF
--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -124,6 +124,9 @@ class _VersionManager(_Manager[_Version]):
 
         # Check if all previous production versions are compatible with current Python Config
         for production_version in production_versions:
+            if production_version == version_number:
+                continue
+
             if version := cls._get(production_version):
                 config_diff = _ConfigComparator._compare(version.config, Config._applied_config)
                 if config_diff["added_items"] or config_diff["removed_items"] or config_diff["modified_items"]:


### PR DESCRIPTION
Fix for https://github.com/Avaiga/taipy-core/issues/415

The fix is when check if all previous production versions are compatible with current Python Config, we only check for **"previous"** versions, not the current production version since we may want to override it.