### PR TITLE
Fix/#416 - Entities are cleaned after every submit on development version

### DIFF
--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -432,11 +432,6 @@ def create_scenario(
     Returns:
         The new scenario.
     """
-    if (
-        latest_version_number := _VersionManagerFactory._build_manager()._get_latest_version()
-    ) == _VersionManagerFactory._build_manager()._get_development_version():
-        clean_all_entities_by_version(latest_version_number)
-        _VersionManagerFactory._build_manager()._set_development_version(latest_version_number)
     return _ScenarioManagerFactory._build_manager()._create(config, creation_date, name)
 
 
@@ -448,11 +443,6 @@ def create_pipeline(config: PipelineConfig) -> Pipeline:
     Returns:
         The new pipeline.
     """
-    if (
-        latest_version_number := _VersionManagerFactory._build_manager()._get_latest_version()
-    ) == _VersionManagerFactory._build_manager()._get_development_version():
-        clean_all_entities_by_version(latest_version_number)
-        _VersionManagerFactory._build_manager()._set_development_version(latest_version_number)
     return _PipelineManagerFactory._build_manager()._get_or_create(config)
 
 


### PR DESCRIPTION
Resolve taipy-core 416

The problem is an artifact block of code when developing the versioning system.
This should be removed after we enforce the Core service, but I made a mistake.