### PR TITLE
fix default data node storage type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -301,7 +301,7 @@ class DataNodeConfig(Section):
     @staticmethod
     def _configure(
         id: str,
-        storage_type: str = _DEFAULT_STORAGE_TYPE,
+        storage_type: Optional[str] = None,
         scope: Scope = _DEFAULT_SCOPE,
         cacheable: bool = False,
         **properties,
@@ -309,11 +309,11 @@ class DataNodeConfig(Section):
         """Configure a new data node configuration.
         Parameters:
             id (str): The unique identifier of the new data node configuration.
-            storage_type (str): The data node configuration storage type. The possible values
-                are _"pickle"_ (which the default value, unless it has been overloaded by the
+            storage_type (str or None): The data node configuration storage type. The possible values
+                are _None_ (which is the default value of _"pickle"_, unless it has been overloaded by the
                 _storage_type_ value set in the default data node configuration
-                (see `(Config.)configure_default_data_node()^`)), _"csv"_, _"excel"_, _"sql_table"_, _"sql"_, _"json"_,
-                _"parquet"_, _"mongo_collection"_, _"in_memory"_, or _"generic"_.
+                (see `(Config.)configure_default_data_node()^`)), _"pickle"_, _"csv"_, _"excel"_, _"sql_table"_,
+                _"sql"_, _"json"_, _"parquet"_, _"mongo_collection"_, _"in_memory"_, or _"generic"_.
             scope (Scope^): The scope of the data node configuration. The default value is
                 `Scope.SCENARIO` (or the one specified in
                 `(Config.)configure_default_data_node()^`).

--- a/tests/core/config/test_default_config.py
+++ b/tests/core/config/test_default_config.py
@@ -104,3 +104,13 @@ def test_default_configuration():
     _test_default_scenario_config(ScenarioConfig.default_config())
     assert len(default_config._sections[ScenarioConfig.name]) == 1
     assert len(Config.scenarios) == 1
+
+
+def test_configure_default_data_node():
+    data_node1 = Config.configure_data_node(id="input_data1")
+    assert data_node1.storage_type == "pickle"
+
+    Config.configure_default_data_node("in_memory")
+
+    data_node2 = Config.configure_data_node(id="input_data2")
+    assert data_node2.storage_type == "in_memory"


### PR DESCRIPTION
There is an issue that if you configure the default data node to have a storage type other than `"pickle"`, using `configure_default_data_node()`, that value is not respected.  This PR fixes that issue.  Added a test to test it.

Note - it seems that black did some extra reformatting of some of the code.
