### PR TITLE
add overloads for taipy.get()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -108,12 +108,12 @@ def get(entity_id: ScenarioId) -> Scenario:
 
 
 @overload
-def get(entity_id: TaskId) -> Task:
+def get(entity_id: CycleId) -> Cycle:
     ...
 
 
 @overload
-def get(entity_id: CycleId) -> Cycle:
+def get(entity_id: JobId) -> Job:
     ...
 
 

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -12,7 +12,7 @@
 import pathlib
 import shutil
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union, overload
 
 from taipy.config.config import Config
 from taipy.logger._taipy_logger import _TaipyLogger
@@ -86,7 +86,34 @@ def submit(
     if isinstance(entity, Task):
         return _TaskManagerFactory._build_manager()._submit(entity, force=force, wait=wait, timeout=timeout)
 
+@overload
+def get(entity_id: TaskId) -> Task:
+    ...
 
+
+@overload
+def get(entity_id: DataNodeId) -> DataNode:
+    ...
+
+
+@overload
+def get(entity_id: PipelineId) -> Pipeline:
+    ...
+
+
+@overload
+def get(entity_id: ScenarioId) -> Scenario:
+    ...
+
+
+@overload
+def get(entity_id: TaskId) -> Task:
+    ...
+
+
+@overload
+def get(entity_id: CycleId) -> Cycle:
+    ...
 def get(
     entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]
 ) -> Union[Task, DataNode, Pipeline, Scenario, Job, Cycle]:

--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -86,6 +86,7 @@ def submit(
     if isinstance(entity, Task):
         return _TaskManagerFactory._build_manager()._submit(entity, force=force, wait=wait, timeout=timeout)
 
+
 @overload
 def get(entity_id: TaskId) -> Task:
     ...
@@ -114,6 +115,8 @@ def get(entity_id: TaskId) -> Task:
 @overload
 def get(entity_id: CycleId) -> Cycle:
     ...
+
+
 def get(
     entity_id: Union[TaskId, DataNodeId, PipelineId, ScenarioId, JobId, CycleId]
 ) -> Union[Task, DataNode, Pipeline, Scenario, Job, Cycle]:


### PR DESCRIPTION
For use in applications, it is useful to know that if you pass a specific Id type, you get the corresponding type back.  So this PR adds overloads for `taipy.get()` to make it more friendlier when using typing checks.

Seems that black did some reformatting as well.
