### PR TITLE
Feat/#412 Update `--force` and add `--clean-entities` options on versioning

### DIFF
--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -65,41 +65,39 @@ class Core:
             self._dispatcher = _SchedulerFactory._remove_dispatcher()
             _TaipyLogger._get_logger().info("Core service has been stopped.")
 
-    def __setup_versioning_module(self, mode, _version_number, _force):
+    def __setup_versioning_module(self, mode, _version_number, force, clean_entities):
         if mode == "development":
-            curren_version_number = _VersionManagerFactory._build_manager()._get_development_version()
+            current_version_number = _VersionManagerFactory._build_manager()._get_development_version()
 
-            clean_all_entities_by_version(curren_version_number)
-            _TaipyLogger._get_logger().info(
-                f"Development mode: Clean all entities with version {curren_version_number}"
-            )
+            clean_all_entities_by_version(current_version_number)
+            _TaipyLogger._get_logger().info(f"Development mode: Clean all entities of version {current_version_number}")
 
-            _VersionManagerFactory._build_manager()._set_development_version(curren_version_number)
+            _VersionManagerFactory._build_manager()._set_development_version(current_version_number)
 
-        elif mode == "experiment":
+        elif mode in ["experiment", "production"]:
+            default_version_number = {
+                "experiment": str(uuid.uuid4()),
+                "production": _VersionManagerFactory._build_manager()._get_latest_version(),
+            }
+
+            version_setter = {
+                "experiment": _VersionManagerFactory._build_manager()._set_experiment_version,
+                "production": _VersionManagerFactory._build_manager()._set_production_version,
+            }
+
             if _version_number:
-                curren_version_number = _version_number
+                current_version_number = _version_number
             else:
-                curren_version_number = str(uuid.uuid4())
-            force = _force
+                current_version_number = default_version_number[mode]
+
+            if clean_entities:
+                clean_all_entities_by_version(current_version_number)
+                _TaipyLogger._get_logger().info(f"Clean all entities of version {current_version_number}")
 
             try:
-                _VersionManagerFactory._build_manager()._set_experiment_version(curren_version_number, force)
-            except VersionConflictWithPythonConfig as e:
-                raise SystemExit(e.message)
-
-        elif mode == "production":
-            if _version_number:
-                curren_version_number = _version_number
-            else:
-                curren_version_number = _VersionManagerFactory._build_manager()._get_latest_version()
-            force = _force
-
-            try:
-                _VersionManagerFactory._build_manager()._set_production_version(curren_version_number, force)
+                version_setter[mode](current_version_number, force)
             except VersionConflictWithPythonConfig as e:
                 raise SystemExit(e.message)
 
         else:
-            _TaipyLogger._get_logger().error("Undefined execution mode.")
-            return
+            raise SystemExit(f"Undefined execution mode: {mode}.")

--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -65,7 +65,7 @@ class Core:
             self._dispatcher = _SchedulerFactory._remove_dispatcher()
             _TaipyLogger._get_logger().info("Core service has been stopped.")
 
-    def __setup_versioning_module(self, mode, _version_number, _override):
+    def __setup_versioning_module(self, mode, _version_number, _force):
         if mode == "development":
             curren_version_number = _VersionManagerFactory._build_manager()._get_development_version()
 
@@ -81,10 +81,10 @@ class Core:
                 curren_version_number = _version_number
             else:
                 curren_version_number = str(uuid.uuid4())
-            override = _override
+            force = _force
 
             try:
-                _VersionManagerFactory._build_manager()._set_experiment_version(curren_version_number, override)
+                _VersionManagerFactory._build_manager()._set_experiment_version(curren_version_number, force)
             except VersionConflictWithPythonConfig as e:
                 raise SystemExit(e.message)
 
@@ -93,10 +93,10 @@ class Core:
                 curren_version_number = _version_number
             else:
                 curren_version_number = _VersionManagerFactory._build_manager()._get_latest_version()
-            override = _override
+            force = _force
 
             try:
-                _VersionManagerFactory._build_manager()._set_production_version(curren_version_number, override)
+                _VersionManagerFactory._build_manager()._set_production_version(curren_version_number, force)
             except VersionConflictWithPythonConfig as e:
                 raise SystemExit(e.message)
 

--- a/src/taipy/core/_version/_version_cli.py
+++ b/src/taipy/core/_version/_version_cli.py
@@ -74,6 +74,12 @@ class _VersioningCLI:
         )
 
         core_parser.add_argument(
+            "--clean-entities",
+            action="store_true",
+            help="Clean all entities before running the application. Default to False.",
+        )
+
+        core_parser.add_argument(
             "--list-versions", "-l", action="store_true", help="List all existing versions of the Taipy application."
         )
 
@@ -147,4 +153,4 @@ class _VersioningCLI:
             version_number = args.production
             mode = "production"
 
-        return mode, version_number, args.force
+        return mode, version_number, args.force, args.clean_entities

--- a/src/taipy/core/_version/_version_cli.py
+++ b/src/taipy/core/_version/_version_cli.py
@@ -76,7 +76,7 @@ class _VersioningCLI:
         core_parser.add_argument(
             "--clean-entities",
             action="store_true",
-            help="Clean all entities before running the application. Default to False.",
+            help="Clean all current version entities before running the application. Default to False.",
         )
 
         core_parser.add_argument(

--- a/src/taipy/core/_version/_version_cli.py
+++ b/src/taipy/core/_version/_version_cli.py
@@ -67,17 +67,20 @@ class _VersioningCLI:
         )
 
         core_parser.add_argument(
-            "--override",
-            "-o",
+            "--force",
+            "-f",
             action="store_true",
-            help="Override the version if existed. Default to False.",
+            help="Force override the configuration of the version if existed. Default to False.",
         )
+
         core_parser.add_argument(
             "--list-versions", "-l", action="store_true", help="List all existing versions of the Taipy application."
         )
+
         core_parser.add_argument(
             "--delete-version", "-d", metavar="VERSION", help="Delete a Taipy version by version number."
         )
+
         core_parser.add_argument(
             "--delete-production-version",
             "-dp",
@@ -144,4 +147,4 @@ class _VersioningCLI:
             version_number = args.production
             mode = "production"
 
-        return mode, version_number, args.override
+        return mode, version_number, args.force

--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -46,7 +46,7 @@ class _VersionManager(_Manager[_Version]):
             return default
 
     @classmethod
-    def _get_or_create(cls, id: str, override: bool) -> _Version:
+    def _get_or_create(cls, id: str, force: bool) -> _Version:
         if version := cls._get(id):
             config_diff = _ConfigComparator(version.config, Config._applied_config)
             if config_diff["added_items"] or config_diff["removed_items"] or config_diff["modified_items"]:
@@ -54,7 +54,7 @@ class _VersionManager(_Manager[_Version]):
                     f"The Configuration of version {id} is conflict with the current Python Config."
                 )
 
-                if override:
+                if force:
                     _TaipyLogger._get_logger().warning(f"Overriding version {id} ...")
                     version.config = Config._applied_config
                 else:
@@ -82,7 +82,7 @@ class _VersionManager(_Manager[_Version]):
 
     @classmethod
     def _set_development_version(cls, version_number: str) -> str:
-        cls._get_or_create(version_number, override=True)
+        cls._get_or_create(version_number, force=True)
         cls._repository._set_development_version(version_number)
         return version_number
 
@@ -94,7 +94,7 @@ class _VersionManager(_Manager[_Version]):
             return cls._set_development_version(str(uuid.uuid4()))
 
     @classmethod
-    def _set_experiment_version(cls, version_number: str, override: bool) -> str:
+    def _set_experiment_version(cls, version_number: str, force: bool) -> str:
         if version_number == cls._get_development_version():
             raise SystemExit(
                 f"Version number {version_number} is already a development version. Please choose a different version "
@@ -107,7 +107,7 @@ class _VersionManager(_Manager[_Version]):
                 f"number for experiment mode. "
             )
 
-        cls._get_or_create(version_number, override)
+        cls._get_or_create(version_number, force)
         cls._repository._set_latest_version(version_number)
         return version_number
 
@@ -121,7 +121,7 @@ class _VersionManager(_Manager[_Version]):
             return cls._set_development_version(str(uuid.uuid4()))
 
     @classmethod
-    def _set_production_version(cls, version_number: str, override: bool) -> str:
+    def _set_production_version(cls, version_number: str, force: bool) -> str:
         production_versions = cls._get_production_version()
 
         # Check if all previous production versions are compatible with current Python Config
@@ -142,7 +142,7 @@ class _VersionManager(_Manager[_Version]):
         if version_number == cls._get_development_version():
             cls._set_development_version(str(uuid.uuid4()))
 
-        cls._get_or_create(version_number, override)
+        cls._get_or_create(version_number, force)
         cls._repository._set_production_version(version_number)
         return version_number
 

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -284,7 +284,7 @@ class VersionConflictWithPythonConfig(Exception):
 
             message += "\n"
 
-        message += "To override these changes, run your application with --override option."
+        message += "To override these changes, run your application with --force option."
 
         self.message = message
 

--- a/tests/core/version/test_version_cli.py
+++ b/tests/core/version/test_version_cli.py
@@ -42,10 +42,10 @@ def reset_configuration_singleton():
 def test_version_cli_return_value():
     # Test default cli values
     _VersioningCLI._create_parser()
-    mode, version_number, override = _VersioningCLI._parse_arguments()
+    mode, version_number, force = _VersioningCLI._parse_arguments()
     assert mode == "development"
     assert version_number == ""
-    assert not override
+    assert not force
 
     # Test Dev mode
     with patch("sys.argv", ["prog", "--development"]):
@@ -58,29 +58,29 @@ def test_version_cli_return_value():
 
     # Test Experiment mode
     with patch("sys.argv", ["prog", "--experiment"]):
-        mode, version_number, override = _VersioningCLI._parse_arguments()
+        mode, version_number, force = _VersioningCLI._parse_arguments()
     assert mode == "experiment"
     assert version_number == ""
-    assert not override
+    assert not force
 
     with patch("sys.argv", ["prog", "--experiment", "2.1"]):
-        mode, version_number, override = _VersioningCLI._parse_arguments()
+        mode, version_number, force = _VersioningCLI._parse_arguments()
     assert mode == "experiment"
     assert version_number == "2.1"
-    assert not override
+    assert not force
 
-    with patch("sys.argv", ["prog", "--experiment", "2.1", "--override"]):
-        mode, version_number, override = _VersioningCLI._parse_arguments()
+    with patch("sys.argv", ["prog", "--experiment", "2.1", "--force"]):
+        mode, version_number, force = _VersioningCLI._parse_arguments()
     assert mode == "experiment"
     assert version_number == "2.1"
-    assert override
+    assert force
 
     # Test Production mode
     with patch("sys.argv", ["prog", "--production"]):
-        mode, version_number, override = _VersioningCLI._parse_arguments()
+        mode, version_number, force = _VersioningCLI._parse_arguments()
     assert mode == "production"
     assert version_number == ""
-    assert not override
+    assert not force
 
 
 def test_dev_mode_clean_all_entities_of_the_latest_version():
@@ -273,7 +273,7 @@ def test_production_mode_load_all_entities_from_previous_production_version():
     assert len(_JobManager._get_all()) == 2
 
 
-def test_override_experiment_version():
+def test_force_override_experiment_version():
     scenario_config = config_scenario()
 
     core = Core()
@@ -299,13 +299,13 @@ def test_override_experiment_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --override parameter, a SystemExit will be raised
+    # Without --force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--experiment", "1.0"]):
             core.run()
 
-    # With --override parameter
-    with patch("sys.argv", ["prog", "--experiment", "1.0", "--override"]):
+    # With --force parameter
+    with patch("sys.argv", ["prog", "--experiment", "1.0", "--force"]):
         core.run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"
@@ -323,7 +323,7 @@ def test_override_experiment_version():
     assert len(_JobManager._get_all()) == 2
 
 
-def test_override_production_version():
+def test_force_override_production_version():
     scenario_config = config_scenario()
 
     core = Core()
@@ -351,13 +351,13 @@ def test_override_production_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --override parameter, a SystemExit will be raised
+    # Without --force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--production", "1.0"]):
             core.run()
 
-    # With --override parameter
-    with patch("sys.argv", ["prog", "--production", "1.0", "--override"]):
+    # With --force parameter
+    with patch("sys.argv", ["prog", "--production", "1.0", "--force"]):
         core.run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"
@@ -483,7 +483,7 @@ def test_list_version():
     assert "Development" in version_list[5] and "latest" not in version_list[5]
 
 
-def test_modify_config_properties_without_override():
+def test_modify_config_properties_without_force():
     scenario_config = config_scenario()
 
     core = Core()

--- a/tests/core/version/test_version_manager.py
+++ b/tests/core/version/test_version_manager.py
@@ -22,7 +22,7 @@ def test_save_and_get_version_entity(tmpdir):
 
     version = _Version(id="foo", config=Config._applied_config)
 
-    _VersionManager._get_or_create(id="foo", override=False)
+    _VersionManager._get_or_create(id="foo", force=False)
 
     version_1 = _VersionManager._get(version.id)
     assert version_1.id == version.id


### PR DESCRIPTION
This PR updates versioning command line options as discussed in https://github.com/Avaiga/taipy-core/issues/412

There are a lot of changes, most are just renaming from `override` to `force`.
The most important file to review is `src/taipy/core/_core.py` and `src/taipy/core/_version/_version_cli.py` (and the tests too).