### PR TITLE
[hotfix 2.1] add overloads for taipy.get() (#438)

### DIFF
--- a/src/taipy/core/taipy.py
+++ b/src/taipy/core/taipy.py
@@ -12,7 +12,7 @@
 import pathlib
 import shutil
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union, overload
 
 from taipy.config.config import Config
 from taipy.logger._taipy_logger import _TaipyLogger
@@ -85,6 +85,36 @@ def submit(
         return _PipelineManagerFactory._build_manager()._submit(entity, force=force, wait=wait, timeout=timeout)
     if isinstance(entity, Task):
         return _TaskManagerFactory._build_manager()._submit(entity, force=force, wait=wait, timeout=timeout)
+
+
+@overload
+def get(entity_id: TaskId) -> Task:
+    ...
+
+
+@overload
+def get(entity_id: DataNodeId) -> DataNode:
+    ...
+
+
+@overload
+def get(entity_id: PipelineId) -> Pipeline:
+    ...
+
+
+@overload
+def get(entity_id: ScenarioId) -> Scenario:
+    ...
+
+
+@overload
+def get(entity_id: CycleId) -> Cycle:
+    ...
+
+
+@overload
+def get(entity_id: JobId) -> Job:
+    ...
 
 
 def get(


### PR DESCRIPTION
@toan-quach can you review the PR to be merged in branch release/2.1?

Here is an extract from python documentation:

@typing.overload
The @overload decorator allows describing functions and methods that support multiple different combinations of argument types. A series of @overload-decorated definitions must be followed by exactly one non-@overload-decorated definition (for the same function/method). The @overload-decorated definitions are for the benefit of the type checker only, since they will be overwritten by the non-@overload-decorated definition, while the latter is used at runtime but should be ignored by a type checker. At runtime, calling a @overload-decorated function directly will raise [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError). An example of overload that gives a more precise type than can be expressed using a union or a type variable:

```
@overload
def process(response: None) -> None:
    ...
@overload
def process(response: int) -> tuple[int, str]:
    ...
@overload
def process(response: bytes) -> str:
    ...
def process(response):
    <actual implementation>
```

See [PEP 484](https://peps.python.org/pep-0484/) for more details and comparison with other typing semantics.
