### PR TITLE
Feat/ Improve Config.check() on Core

### DIFF
--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -31,7 +31,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._check_storage_type(data_node_config_id, data_node_config)
             self._check_scope(data_node_config_id, data_node_config)
             self._check_required_properties(data_node_config_id, data_node_config)
-            self._check_generic_read_write_fct(data_node_config_id, data_node_config)
+            self._check_callable(data_node_config_id, data_node_config)
             self._check_generic_read_write_fct_params(data_node_config_id, data_node_config)
             self._check_exposed_type(data_node_config_id, data_node_config)
         return self._collector
@@ -103,13 +103,19 @@ class _DataNodeConfigChecker(_ConfigChecker):
                             f" `{data_node_config_id}` must be populated with a List or a Tuple.",
                         )
 
-    def _check_generic_read_write_fct(self, data_node_config_id: str, data_node_config: DataNodeConfig):
-        if data_node_config.storage_type == DataNodeConfig._STORAGE_TYPE_VALUE_GENERIC:
-            properties_to_check = [
+    def _check_callable(self, data_node_config_id: str, data_node_config: DataNodeConfig):
+        properties_to_check = {
+            DataNodeConfig._STORAGE_TYPE_VALUE_GENERIC: [
                 DataNodeConfig._REQUIRED_READ_FUNCTION_GENERIC_PROPERTY,
                 DataNodeConfig._REQUIRED_WRITE_FUNCTION_GENERIC_PROPERTY,
-            ]
-            for prop_key in properties_to_check:
+            ],
+            DataNodeConfig._STORAGE_TYPE_VALUE_SQL: [
+                DataNodeConfig._REQUIRED_WRITE_QUERY_BUILDER_SQL_PROPERTY,
+            ],
+        }
+
+        if data_node_config.storage_type in properties_to_check.keys():
+            for prop_key in properties_to_check[data_node_config.storage_type]:
                 prop_value = data_node_config.properties.get(prop_key) if data_node_config.properties else None
                 if prop_value and not callable(prop_value):
                     self._error(

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -41,8 +41,8 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._error(
                 data_node_config._STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
-                f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNode `{data_node_config_id}` must be either csv, "
-                f"sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet or in_memory.",
+                f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be either csv, "
+                f"sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory.",
             )
 
     def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):
@@ -50,7 +50,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._error(
                 data_node_config._SCOPE_KEY,
                 data_node_config.scope,
-                f"`{data_node_config._SCOPE_KEY}` field of DataNode `{data_node_config_id}` must be populated with a "
+                f"`{data_node_config._SCOPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be populated with a "
                 f"Scope value.",
             )
 
@@ -80,10 +80,10 @@ class _DataNodeConfigChecker(_ConfigChecker):
                 for required_property in required_properties:
                     if not data_node_config.properties or required_property not in data_node_config.properties:
                         self._error(
-                            "properties",
                             required_property,
-                            f"`{data_node_config_id}` DataNode is missing the required "
-                            f"property `{required_property}` for type `{storage_type}`",
+                            None,
+                            f"DataNodeConfig `{data_node_config_id}` is missing the required "
+                            f"property `{required_property}` for type `{storage_type}`.",
                         )
 
     def _check_generic_read_write_fct_params(self, data_node_config_id: str, data_node_config: DataNodeConfig):
@@ -99,7 +99,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
                         self._error(
                             prop_key,
                             prop_value,
-                            f"`{prop_key}` field of DataNode"
+                            f"`{prop_key}` field of DataNodeConfig"
                             f" `{data_node_config_id}` must be populated with a Tuple value.",
                         )
 
@@ -115,7 +115,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
                     self._error(
                         prop_key,
                         prop_value,
-                        f"`{prop_key}` of DataNode `{data_node_config_id}` must be populated with a Callable function.",
+                        f"`{prop_key}` of DataNodeConfig `{data_node_config_id}` must be populated with a Callable function.",
                     )
 
     def _check_exposed_type(self, data_node_config_id: str, data_node_config: DataNodeConfig):
@@ -125,6 +125,6 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._error(
                 data_node_config._EXPOSED_TYPE_KEY,
                 data_node_config.exposed_type,
-                f"The `{data_node_config._EXPOSED_TYPE_KEY}` of the DataNodeConfig `{data_node_config_id}` "
-                f'must be either "pandas", "modin", "numpy" or a custom type.',
+                f"The `{data_node_config._EXPOSED_TYPE_KEY}` of DataNodeConfig `{data_node_config_id}` "
+                f'must be either "pandas", "modin", "numpy", or a custom type.',
             )

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -41,8 +41,8 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._error(
                 data_node_config._STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
-                f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be either csv, "
-                f"sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory.",
+                f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be"
+                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory.",
             )
 
     def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):
@@ -50,8 +50,8 @@ class _DataNodeConfigChecker(_ConfigChecker):
             self._error(
                 data_node_config._SCOPE_KEY,
                 data_node_config.scope,
-                f"`{data_node_config._SCOPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be populated with a "
-                f"Scope value.",
+                f"`{data_node_config._SCOPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be"
+                f" populated with a Scope value.",
             )
 
     def _check_required_properties(self, data_node_config_id: str, data_node_config: DataNodeConfig):
@@ -115,7 +115,8 @@ class _DataNodeConfigChecker(_ConfigChecker):
                     self._error(
                         prop_key,
                         prop_value,
-                        f"`{prop_key}` of DataNodeConfig `{data_node_config_id}` must be populated with a Callable function.",
+                        f"`{prop_key}` of DataNodeConfig `{data_node_config_id}` must be"
+                        f" populated with a Callable function.",
                     )
 
     def _check_exposed_type(self, data_node_config_id: str, data_node_config: DataNodeConfig):

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -79,12 +79,20 @@ class _DataNodeConfigChecker(_ConfigChecker):
                                 ]
                 for required_property in required_properties:
                     if not data_node_config.properties or required_property not in data_node_config.properties:
-                        self._error(
-                            required_property,
-                            None,
-                            f"DataNodeConfig `{data_node_config_id}` is missing the required "
-                            f"property `{required_property}` for type `{storage_type}`.",
-                        )
+                        if data_node_config_id == DataNodeConfig._DEFAULT_KEY:
+                            self._warning(
+                                required_property,
+                                None,
+                                f"DataNodeConfig `{data_node_config_id}` is missing the required "
+                                f"property `{required_property}` for type `{storage_type}`.",
+                            )
+                        else:
+                            self._error(
+                                required_property,
+                                None,
+                                f"DataNodeConfig `{data_node_config_id}` is missing the required "
+                                f"property `{required_property}` for type `{storage_type}`.",
+                            )
 
     def _check_generic_read_write_fct_params(self, data_node_config_id: str, data_node_config: DataNodeConfig):
         if data_node_config.storage_type == DataNodeConfig._STORAGE_TYPE_VALUE_GENERIC:

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -95,12 +95,12 @@ class _DataNodeConfigChecker(_ConfigChecker):
             for prop_key in properties_to_check:
                 if data_node_config.properties and prop_key in data_node_config.properties:
                     prop_value = data_node_config.properties[prop_key]
-                    if not isinstance(prop_value, tuple):  # type: ignore
+                    if not isinstance(prop_value, (list, tuple)):
                         self._error(
                             prop_key,
                             prop_value,
                             f"`{prop_key}` field of DataNodeConfig"
-                            f" `{data_node_config_id}` must be populated with a Tuple value.",
+                            f" `{data_node_config_id}` must be populated with a List or a Tuple.",
                         )
 
     def _check_generic_read_write_fct(self, data_node_config_id: str, data_node_config: DataNodeConfig):

--- a/src/taipy/core/config/checkers/_job_config_checker.py
+++ b/src/taipy/core/config/checkers/_job_config_checker.py
@@ -36,6 +36,6 @@ class _JobConfigChecker(_ConfigChecker):
                     self._error(
                         DataNodeConfig._STORAGE_TYPE_KEY,
                         data_node_config.storage_type,
-                        f"DataNode {cfg_id}: In-memory storage type can ONLY be used in "
-                        f"{JobConfig._DEVELOPMENT_MODE} mode",
+                        f"DataNode `{cfg_id}`: In-memory storage type can ONLY be used in "
+                        f"{JobConfig._DEVELOPMENT_MODE} mode.",
                     )

--- a/src/taipy/core/config/checkers/_scenario_config_checker.py
+++ b/src/taipy/core/config/checkers/_scenario_config_checker.py
@@ -47,8 +47,8 @@ class _ScenarioConfigChecker(_ConfigChecker):
             self._error(
                 scenario_config._FREQUENCY_KEY,
                 scenario_config.frequency,
-                f"{scenario_config._FREQUENCY_KEY} field of ScenarioConfig `{scenario_config_id}` must be populated with a "
-                f"Frequency value.",
+                f"{scenario_config._FREQUENCY_KEY} field of ScenarioConfig `{scenario_config_id}` must be"
+                f" populated with a Frequency value.",
             )
 
     def _check_comparators(self, scenario_config_id: str, scenario_config: ScenarioConfig):

--- a/src/taipy/core/config/checkers/_scenario_config_checker.py
+++ b/src/taipy/core/config/checkers/_scenario_config_checker.py
@@ -47,7 +47,7 @@ class _ScenarioConfigChecker(_ConfigChecker):
             self._error(
                 scenario_config._FREQUENCY_KEY,
                 scenario_config.frequency,
-                f"{scenario_config._FREQUENCY_KEY} field of Scenario {scenario_config_id} must be populated with a "
+                f"{scenario_config._FREQUENCY_KEY} field of ScenarioConfig `{scenario_config_id}` must be populated with a "
                 f"Frequency value.",
             )
 
@@ -56,5 +56,5 @@ class _ScenarioConfigChecker(_ConfigChecker):
             self._info(
                 scenario_config._COMPARATOR_KEY,
                 scenario_config.comparators,
-                f"No scenario {scenario_config._COMPARATOR_KEY} defined for scenario {scenario_config_id}",
+                f"No scenario {scenario_config._COMPARATOR_KEY} defined for ScenarioConfig `{scenario_config_id}`.",
             )

--- a/src/taipy/core/config/checkers/_task_config_checker.py
+++ b/src/taipy/core/config/checkers/_task_config_checker.py
@@ -47,12 +47,12 @@ class _TaskConfigChecker(_ConfigChecker):
             self._error(
                 task_config._FUNCTION,
                 task_config.function,
-                f"{task_config._FUNCTION} field of Task {task_config_id} is empty.",
+                f"{task_config._FUNCTION} field of TaskConfig `{task_config_id}` is empty.",
             )
         else:
             if not callable(task_config.function):
                 self._error(
                     task_config._FUNCTION,
                     task_config.function,
-                    f"{task_config._FUNCTION} field of task {task_config_id} must be populated with Callable value.",
+                    f"{task_config._FUNCTION} field of TaskConfig `{task_config_id}` must be populated with Callable value.",
                 )

--- a/src/taipy/core/config/checkers/_task_config_checker.py
+++ b/src/taipy/core/config/checkers/_task_config_checker.py
@@ -54,5 +54,6 @@ class _TaskConfigChecker(_ConfigChecker):
                 self._error(
                     task_config._FUNCTION,
                     task_config.function,
-                    f"{task_config._FUNCTION} field of TaskConfig `{task_config_id}` must be populated with Callable value.",
+                    f"{task_config._FUNCTION} field of TaskConfig `{task_config_id}` must be"
+                    f" populated with Callable value.",
                 )

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -549,8 +549,10 @@ class DataNodeConfig(Section):
             read_fct (Callable): The Python function called to read the data.
             write_fct (Callable): The Python function called to write the data.
                 The provided function must have at least one parameter that receives the data to be written.
-            read_fct_params (Optional[Union[List, Tuple]]): The parameters that are passed to _read_fct_ to read the data.
-            write_fct_params (Optional[Union[List, Tuple]]): The parameters that are passed to _write_fct_ to write the data.
+            read_fct_params (Optional[Union[List, Tuple]]): The list of parameters that are passed to the _read_fct_
+                to read data.
+            write_fct_params (Optional[Union[List, Tuple]]): The list of parameters that are passed to the _write_fct_
+                to write the data.
             scope (Optional[Scope^]): The scope of the Generic data node configuration.
                 The default value is `Scope.SCENARIO`.
             **properties (Dict[str, Any]): A keyworded variable length list of additional arguments.

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -11,7 +11,7 @@
 
 import json
 from copy import copy
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from taipy.config._config import _Config
 from taipy.config.common._config_blocker import _ConfigBlocker
@@ -537,8 +537,8 @@ class DataNodeConfig(Section):
         id: str,
         read_fct: Callable,
         write_fct: Callable,
-        read_fct_params: Optional[List] = None,
-        write_fct_params: Optional[List] = None,
+        read_fct_params: Optional[Union[List, Tuple]] = None,
+        write_fct_params: Optional[Union[List, Tuple]] = None,
         scope: Optional[Scope] = None,
         **properties,
     ):
@@ -549,8 +549,8 @@ class DataNodeConfig(Section):
             read_fct (Callable): The Python function called to read the data.
             write_fct (Callable): The Python function called to write the data.
                 The provided function must have at least one parameter that receives the data to be written.
-            read_fct_params (Optional[List]): The parameters that are passed to _read_fct_ to read the data.
-            write_fct_params (Optional[List]): The parameters that are passed to _write_fct_ to write the data.
+            read_fct_params (Optional[Union[List, Tuple]]): The parameters that are passed to _read_fct_ to read the data.
+            write_fct_params (Optional[Union[List, Tuple]]): The parameters that are passed to _write_fct_ to write the data.
             scope (Optional[Scope^]): The scope of the Generic data node configuration.
                 The default value is `Scope.SCENARIO`.
             **properties (Dict[str, Any]): A keyworded variable length list of additional arguments.
@@ -652,9 +652,9 @@ class DataNodeConfig(Section):
             db_engine (str): The database engine. Possible values are _"sqlite"_, _"mssql"_, _"mysql"_, or
                 _"postgresql"_.
             table_name (str): The name of the SQL table.
-            db_host (str): The database host. The default value is _"localhost"_.
-            db_port (int): The database port. The default value is 1433.
-            db_driver (str): The database driver. The default value is
+            db_host (Optional[str]): The database host. The default value is _"localhost"_.
+            db_port (Optional[int]): The database port. The default value is 1433.
+            db_driver (Optional[str]): The database driver. The default value is
                 _"ODBC Driver 17 for SQL Server"_.
             db_extra_args (Optional[Dict[str, Any]]): A dictionary of additional arguments to be passed into database
                 connection string.
@@ -720,9 +720,9 @@ class DataNodeConfig(Section):
             read_query (str): The SQL query string used to read the data from the database.
             write_query_builder (Callable): A callback function that takes the data as an input parameter
                 and returns a list of SQL queries.
-            db_host (str): The database host. The default value is _"localhost"_.
-            db_port (int): The database port. The default value is 1433.
-            db_driver (str): The database driver. The default value is _"ODBC Driver 17 for SQL Server"_.
+            db_host (Optional[str]): The database host. The default value is _"localhost"_.
+            db_port (Optional[int]): The database port. The default value is 1433.
+            db_driver (Optional[str]): The database driver. The default value is _"ODBC Driver 17 for SQL Server"_.
             db_extra_args (Optional[Dict[str, Any]]): A dictionary of additional arguments to be passed into database
                 connection string.
             exposed_type (Optional[str]): The exposed type of the data read from SQL query.

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -393,14 +393,15 @@ class TestDataNodeConfigChecker:
         config._sections[DataNodeConfig.name]["default"].properties = {
             "write_fct": print,
             "read_fct": print,
-            "write_fct_params": [],
+            "write_fct_params": "foo",
         }
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
         expected_error_message = (
-            "`write_fct_params` field of DataNodeConfig `default` must be populated with a" " Tuple value."
+            "`write_fct_params` field of DataNodeConfig `default` must be populated with a List or a Tuple."
+            ' Current value of property `write_fct_params` is "foo".'
         )
         assert expected_error_message in caplog.text
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
@@ -417,14 +418,15 @@ class TestDataNodeConfigChecker:
         config._sections[DataNodeConfig.name]["default"].properties = {
             "write_fct": print,
             "read_fct": print,
-            "read_fct_params": [],
+            "read_fct_params": 1,
         }
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
         expected_error_message = (
-            "`read_fct_params` field of DataNodeConfig `default` must be populated with a" " Tuple value."
+            "`read_fct_params` field of DataNodeConfig `default` must be populated with a List or a Tuple."
+            " Current value of property `read_fct_params` is 1."
         )
         assert expected_error_message in caplog.text
 
@@ -444,6 +446,17 @@ class TestDataNodeConfigChecker:
             "read_fct": print,
             "write_fct_params": tuple("foo"),
             "read_fct_params": tuple("foo"),
+        }
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["default"].properties = {
+            "write_fct": print,
+            "read_fct": print,
+            "write_fct_params": ["foo"],
+            "read_fct_params": ["foo"],
         }
         Config._collector = IssueCollector()
         Config.check()

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -13,7 +13,6 @@ from copy import copy
 
 import pytest
 
-from src.taipy.core.config.checkers._data_node_config_checker import _DataNodeConfigChecker
 from src.taipy.core.config.data_node_config import DataNodeConfig
 from taipy.config import Config
 from taipy.config.checker.issue_collector import IssueCollector
@@ -25,171 +24,221 @@ class MyCustomClass:
 
 
 class TestDataNodeConfigChecker:
-    def test_check_config_id(self):
-        collector = IssueCollector()
+    def test_check_config_id(self, caplog):
+        Config._collector = IssueCollector()
         config = Config._default_config
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
         config._sections[DataNodeConfig.name]["new"].id = None
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        assert "config_id of DataNodeConfig `None` is empty." in caplog.text
 
         config._sections[DataNodeConfig.name]["new"].id = "new"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
-    def test_check_if_entity_property_key_used_is_predefined(self):
-        collector = IssueCollector()
+    def test_check_if_entity_property_key_used_is_predefined(self, caplog):
+        Config._collector = IssueCollector()
         config = Config._default_config
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
         config._sections[DataNodeConfig.name]["new"]._properties["_entity_owner"] = None
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        assert "Properties of DataNodeConfig `default` cannot have `_entity_owner` as its property." in caplog.text
 
         config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
         config._sections[DataNodeConfig.name]["new"]._properties["_entity_owner"] = "entity_owner"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "Properties of DataNodeConfig `default` cannot have `_entity_owner` as its property."
+            ' Current value of property `_entity_owner` is "entity_owner".'
+        )
+        assert expected_error_message in caplog.text
 
-    def test_check_storage_type(self):
-        collector = IssueCollector()
+    def test_check_storage_type(self, caplog):
+        Config._collector = IssueCollector()
         config = Config._default_config
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "bar"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "`storage_type` field of DataNodeConfig `default` must be either csv, sql_table,"
+            " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory."
+            ' Current value of property `storage_type` is "bar".'
+        )
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "pickle"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "json"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "parquet"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "in_memory"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `read_fct` for type `generic`.",
+            "DataNodeConfig `default` is missing the required property `write_fct` for type `generic`.",
+        ]
+        assert all(message in caplog.text for message in expected_error_messages)
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "sql_table"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 5
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 5
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `db_username` for type `sql_table`.",
+            "DataNodeConfig `default` is missing the required property `db_password` for type `sql_table`.",
+            "DataNodeConfig `default` is missing the required property `db_name` for type `sql_table`.",
+            "DataNodeConfig `default` is missing the required property `db_engine` for type `sql_table`.",
+            "DataNodeConfig `default` is missing the required property `table_name` for type `sql_table`.",
+        ]
+        assert all(message in caplog.text for message in expected_error_messages)
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 6
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 6
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `db_username` for type `sql`.",
+            "DataNodeConfig `default` is missing the required property `db_password` for type `sql`.",
+            "DataNodeConfig `default` is missing the required property `db_name` for type `sql`.",
+            "DataNodeConfig `default` is missing the required property `db_engine` for type `sql`.",
+            "DataNodeConfig `default` is missing the required property `read_query` for type `sql`.",
+            "DataNodeConfig `default` is missing the required property `write_query_builder` for type `sql`.",
+        ]
+        assert all(message in caplog.text for message in expected_error_messages)
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "mongo_collection"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `db_name` for type `mongo_collection`.",
+            "DataNodeConfig `default` is missing the required property `collection_name` for type `mongo_collection`.",
+        ]
+        assert all(message in caplog.text for message in expected_error_messages)
 
-    def test_check_scope(self):
+    def test_check_scope(self, caplog):
         config = Config._default_config
 
         config._sections[DataNodeConfig.name]["default"].scope = "bar"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "`scope` field of DataNodeConfig `default` must be populated with a Scope"
+            ' value. Current value of property `scope` is "bar".'
+        )
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["default"].scope = 1
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "`scope` field of DataNodeConfig `default` must be populated with a Scope"
+            " value. Current value of property `scope` is 1."
+        )
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["default"].scope = Scope.GLOBAL
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].scope = Scope.CYCLE
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].scope = Scope.SCENARIO
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].scope = Scope.PIPELINE
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
-    def test_check_required_properties(self):
+    def test_check_required_properties(self, caplog):
         config = Config._default_config
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
         config._sections[DataNodeConfig.name]["default"].properties = {"has_header": True}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
         config._sections[DataNodeConfig.name]["default"].properties = {"path": "bar"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
-
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql_table"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 5
-
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 6
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         required_properties = ["db_username", "db_password", "db_name", "db_engine", "table_name"]
         config._sections[DataNodeConfig.name]["default"].storage_type = "sql_table"
         config._sections[DataNodeConfig.name]["default"].properties = {key: f"the_{key}" for key in required_properties}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         required_properties = [
             "db_username",
@@ -201,26 +250,32 @@ class TestDataNodeConfigChecker:
         ]
         config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
         config._sections[DataNodeConfig.name]["default"].properties = {key: f"the_{key}" for key in required_properties}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        config._sections[DataNodeConfig.name]["default"].storage_type = "mongo_collection"
+        config._sections[DataNodeConfig.name]["default"].properties = {"db_name": "foo", "collection_name": "bar"}
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
         config._sections[DataNodeConfig.name]["default"].properties = {"has_header": True}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
         config._sections[DataNodeConfig.name]["default"].properties = {"path": "bar"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
         config._sections[DataNodeConfig.name]["default"].properties = {
@@ -228,86 +283,111 @@ class TestDataNodeConfigChecker:
             "path": "bar",
             "sheet_name": ["sheet_name_1", "sheet_name_2"],
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"read_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "json"
         config._sections[DataNodeConfig.name]["default"].properties = {"default_path": "bar"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
-    def test_check_read_write_fct(self):
+    def test_check_read_write_fct(self, caplog):
         config = Config._default_config
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 12}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `read_fct` for type `generic`.",
+            "`write_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            " of property `write_fct` is 12.",
+        ]
+        assert all(message in caplog.text for message in expected_error_messages)
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"read_fct": 5}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
+        expected_error_messages = [
+            "DataNodeConfig `default` is missing the required property `write_fct` for type `generic`.",
+            "`read_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            " of property `read_fct` is 5.",
+        ]
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 9, "read_fct": 5}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 2
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
+        expected_error_messages = [
+            "`write_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            " of property `write_fct` is 9.",
+            "`read_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            " of property `read_fct` is 5.",
+        ]
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": 5}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 5, "read_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
-    def test_check_read_write_fct_params(self):
+    def test_check_read_write_fct_params(self, caplog):
         config = Config._default_config
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": print}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {
@@ -315,19 +395,23 @@ class TestDataNodeConfigChecker:
             "read_fct": print,
             "write_fct_params": [],
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
-
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "`write_fct_params` field of DataNodeConfig `default` must be populated with a" " Tuple value."
+        )
+        assert expected_error_message in caplog.text
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {
             "write_fct": print,
             "read_fct": print,
             "write_fct_params": tuple("foo"),
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {
@@ -335,9 +419,14 @@ class TestDataNodeConfigChecker:
             "read_fct": print,
             "read_fct_params": [],
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "`read_fct_params` field of DataNodeConfig `default` must be populated with a" " Tuple value."
+        )
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {
@@ -345,9 +434,9 @@ class TestDataNodeConfigChecker:
             "read_fct": print,
             "read_fct_params": tuple("foo"),
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["default"].properties = {
@@ -356,29 +445,35 @@ class TestDataNodeConfigChecker:
             "write_fct_params": tuple("foo"),
             "read_fct_params": tuple("foo"),
         }
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
-    def test_check_exposed_types(self):
+    def test_check_exposed_types(self, caplog):
         config = Config._default_config
 
         config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
         config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": "foo"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            'The `exposed_type` of DataNodeConfig `default` must be either "pandas", "modin"'
+            ', "numpy", or a custom type. Current value of property `exposed_type` is "foo".'
+        )
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": "pandas"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": "numpy"}
-        collector = IssueCollector()
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": MyCustomClass}
-        _DataNodeConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config.check()
+        assert len(Config._collector.errors) == 0

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -75,96 +75,98 @@ class TestDataNodeConfigChecker:
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "bar"
+        config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
+
+        config._sections[DataNodeConfig.name]["new"].storage_type = "bar"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
         expected_error_message = (
-            "`storage_type` field of DataNodeConfig `default` must be either csv, sql_table,"
+            "`storage_type` field of DataNodeConfig `new` must be either csv, sql_table,"
             " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory."
             ' Current value of property `storage_type` is "bar".'
         )
         assert expected_error_message in caplog.text
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "csv"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "excel"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "pickle"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "pickle"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "json"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "json"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "parquet"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "parquet"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "in_memory"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "in_memory"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `read_fct` for type `generic`.",
-            "DataNodeConfig `default` is missing the required property `write_fct` for type `generic`.",
+            "DataNodeConfig `new` is missing the required property `read_fct` for type `generic`.",
+            "DataNodeConfig `new` is missing the required property `write_fct` for type `generic`.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql_table"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "sql_table"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 5
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `db_username` for type `sql_table`.",
-            "DataNodeConfig `default` is missing the required property `db_password` for type `sql_table`.",
-            "DataNodeConfig `default` is missing the required property `db_name` for type `sql_table`.",
-            "DataNodeConfig `default` is missing the required property `db_engine` for type `sql_table`.",
-            "DataNodeConfig `default` is missing the required property `table_name` for type `sql_table`.",
+            "DataNodeConfig `new` is missing the required property `db_username` for type `sql_table`.",
+            "DataNodeConfig `new` is missing the required property `db_password` for type `sql_table`.",
+            "DataNodeConfig `new` is missing the required property `db_name` for type `sql_table`.",
+            "DataNodeConfig `new` is missing the required property `db_engine` for type `sql_table`.",
+            "DataNodeConfig `new` is missing the required property `table_name` for type `sql_table`.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "sql"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 6
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `db_username` for type `sql`.",
-            "DataNodeConfig `default` is missing the required property `db_password` for type `sql`.",
-            "DataNodeConfig `default` is missing the required property `db_name` for type `sql`.",
-            "DataNodeConfig `default` is missing the required property `db_engine` for type `sql`.",
-            "DataNodeConfig `default` is missing the required property `read_query` for type `sql`.",
-            "DataNodeConfig `default` is missing the required property `write_query_builder` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `db_username` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `db_password` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `db_name` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `db_engine` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `read_query` for type `sql`.",
+            "DataNodeConfig `new` is missing the required property `write_query_builder` for type `sql`.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "mongo_collection"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "mongo_collection"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `db_name` for type `mongo_collection`.",
-            "DataNodeConfig `default` is missing the required property `collection_name` for type `mongo_collection`.",
+            "DataNodeConfig `new` is missing the required property `db_name` for type `mongo_collection`.",
+            "DataNodeConfig `new` is missing the required property `collection_name` for type `mongo_collection`.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
@@ -215,33 +217,34 @@ class TestDataNodeConfigChecker:
 
     def test_check_required_properties(self, caplog):
         config = Config._default_config
+        config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "csv"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
-        config._sections[DataNodeConfig.name]["default"].properties = {"has_header": True}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "csv"
+        config._sections[DataNodeConfig.name]["new"].properties = {"has_header": True}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "csv"
-        config._sections[DataNodeConfig.name]["default"].properties = {"path": "bar"}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "csv"
+        config._sections[DataNodeConfig.name]["new"].properties = {"path": "bar"}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
         required_properties = ["db_username", "db_password", "db_name", "db_engine", "table_name"]
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql_table"
-        config._sections[DataNodeConfig.name]["default"].properties = {key: f"the_{key}" for key in required_properties}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "sql_table"
+        config._sections[DataNodeConfig.name]["new"].properties = {key: f"the_{key}" for key in required_properties}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
-        config._sections[DataNodeConfig.name]["default"].properties = {
+        config._sections[DataNodeConfig.name]["new"].storage_type = "sql"
+        config._sections[DataNodeConfig.name]["new"].properties = {
             "db_username": "foo",
             "db_password": "foo",
             "db_name": "foo",
@@ -253,31 +256,31 @@ class TestDataNodeConfigChecker:
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "mongo_collection"
-        config._sections[DataNodeConfig.name]["default"].properties = {"db_name": "foo", "collection_name": "bar"}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "mongo_collection"
+        config._sections[DataNodeConfig.name]["new"].properties = {"db_name": "foo", "collection_name": "bar"}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "excel"
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
-        config._sections[DataNodeConfig.name]["default"].properties = {"has_header": True}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "excel"
+        config._sections[DataNodeConfig.name]["new"].properties = {"has_header": True}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
-        config._sections[DataNodeConfig.name]["default"].properties = {"path": "bar"}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "excel"
+        config._sections[DataNodeConfig.name]["new"].properties = {"path": "bar"}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "excel"
-        config._sections[DataNodeConfig.name]["default"].properties = {
+        config._sections[DataNodeConfig.name]["new"].storage_type = "excel"
+        config._sections[DataNodeConfig.name]["new"].properties = {
             "has_header": True,
             "path": "bar",
             "sheet_name": ["sheet_name_1", "sheet_name_2"],
@@ -286,43 +289,60 @@ class TestDataNodeConfigChecker:
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"read_fct": print}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"read_fct": print}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": print}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": print}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": print, "read_fct": print}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "json"
-        config._sections[DataNodeConfig.name]["default"].properties = {"default_path": "bar"}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "json"
+        config._sections[DataNodeConfig.name]["new"].properties = {"default_path": "bar"}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0
+
+    def test_required_properties_on_default_only_raise_warning(self):
+        config = Config._default_config
+        config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
+
+        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+        assert len(Config._collector.warnings) == 2
+
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 2
 
     def test_check_callable_properties(self, caplog):
         config = Config._default_config
+        config._sections[DataNodeConfig.name]["new"] = copy(config._sections[DataNodeConfig.name]["default"])
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "sql"
-        config._sections[DataNodeConfig.name]["default"].properties = {
+        config._sections[DataNodeConfig.name]["new"].storage_type = "sql"
+        config._sections[DataNodeConfig.name]["new"].properties = {
             "db_username": "foo",
             "db_password": "foo",
             "db_name": "foo",
@@ -335,67 +355,67 @@ class TestDataNodeConfigChecker:
             Config.check()
         assert len(Config._collector.errors) == 1
         expected_error_message = (
-            "`write_query_builder` of DataNodeConfig `default` must be populated with a Callable function."
+            "`write_query_builder` of DataNodeConfig `new` must be populated with a Callable function."
             " Current value of property `write_query_builder` is 1."
         )
         assert expected_error_message in caplog.text
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 12}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": 12}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `read_fct` for type `generic`.",
-            "`write_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            "DataNodeConfig `new` is missing the required property `read_fct` for type `generic`.",
+            "`write_fct` of DataNodeConfig `new` must be populated with a Callable function. Current value"
             " of property `write_fct` is 12.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"read_fct": 5}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"read_fct": 5}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
         expected_error_messages = [
-            "DataNodeConfig `default` is missing the required property `write_fct` for type `generic`.",
-            "`read_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            "DataNodeConfig `new` is missing the required property `write_fct` for type `generic`.",
+            "`read_fct` of DataNodeConfig `new` must be populated with a Callable function. Current value"
             " of property `read_fct` is 5.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 9, "read_fct": 5}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": 9, "read_fct": 5}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 2
         expected_error_messages = [
-            "`write_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            "`write_fct` of DataNodeConfig `new` must be populated with a Callable function. Current value"
             " of property `write_fct` is 9.",
-            "`read_fct` of DataNodeConfig `default` must be populated with a Callable function. Current value"
+            "`read_fct` of DataNodeConfig `new` must be populated with a Callable function. Current value"
             " of property `read_fct` is 5.",
         ]
         assert all(message in caplog.text for message in expected_error_messages)
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": 5}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": print, "read_fct": 5}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": 5, "read_fct": print}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": 5, "read_fct": print}
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
         assert len(Config._collector.errors) == 1
 
-        config._sections[DataNodeConfig.name]["default"].storage_type = "generic"
-        config._sections[DataNodeConfig.name]["default"].properties = {"write_fct": print, "read_fct": print}
+        config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
+        config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": print, "read_fct": print}
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0

--- a/tests/core/config/checkers/test_job_config_checker.py
+++ b/tests/core/config/checkers/test_job_config_checker.py
@@ -9,32 +9,39 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from src.taipy.core.config.checkers._job_config_checker import _JobConfigChecker
+import pytest
+
 from src.taipy.core.config.job_config import JobConfig
 from taipy.config.checker.issue_collector import IssueCollector
 from taipy.config.config import Config
 
 
 class TestJobConfigChecker:
-    def test_check_standalone_mode(self):
-        collector = IssueCollector()
-        config = Config._python_config
-        _JobConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+    def test_check_standalone_mode(self, caplog):
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         Config.configure_data_node(id="foo", storage_type="in_memory")
 
         Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE, max_nb_of_workers=2)
-        collector = IssueCollector()
-        _JobConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 0
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
 
         Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=1)
-        collector = IssueCollector()
-        _JobConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
 
         Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
-        collector = IssueCollector()
-        _JobConfigChecker(config, collector)._check()
-        assert len(collector.errors) == 1
+        with pytest.raises(SystemExit):
+            Config._collector = IssueCollector()
+            Config.check()
+        assert len(Config._collector.errors) == 1
+        expected_error_message = (
+            "DataNode `foo`: In-memory storage type can ONLY be used in development mode. Current"
+            ' value of property `storage_type` is "in_memory".'
+        )
+        assert expected_error_message in caplog.text

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -20,10 +20,10 @@ from src.taipy.core.config import DataNodeConfig
 from src.taipy.core.config.job_config import JobConfig
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationIssueError, ConfigurationUpdateBlocked
+from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
-def test_data_node_config_check():
+def test_data_node_config_check(caplog):
     data_node_config = Config.configure_data_node("data_nodes1", "pickle")
     assert list(Config.data_nodes) == [DataNodeConfig._DEFAULT_KEY, data_node_config.id]
 
@@ -38,13 +38,24 @@ def test_data_node_config_check():
         data_node3_config.id,
     ]
 
-    with pytest.raises(ConfigurationIssueError):
+    with pytest.raises(SystemExit):
         Config.configure_data_node("data_nodes", storage_type="bar")
         Config.check()
+    expected_error_message = (
+        "`storage_type` field of DataNodeConfig `data_nodes` must be either csv, sql_table,"
+        " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory. Current"
+        ' value of property `storage_type` is "bar".'
+    )
+    assert expected_error_message in caplog.text
 
-    with pytest.raises(ConfigurationIssueError):
+    with pytest.raises(SystemExit):
         Config.configure_data_node("data_nodes", scope="bar")
         Config.check()
+    expected_error_message = (
+        "`scope` field of DataNodeConfig `data_nodes` must be populated with a Scope value."
+        ' Current value of property `scope` is "bar".'
+    )
+    assert expected_error_message in caplog.text
 
     with pytest.raises(TypeError):
         Config.configure_data_node("data_nodes", storage_type="sql")

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -17,14 +17,20 @@ from src.taipy.core._scheduler._scheduler import _Scheduler
 from src.taipy.core._scheduler._scheduler_factory import _SchedulerFactory
 from src.taipy.core.config.job_config import JobConfig
 from taipy.config import Config
-from taipy.config.exceptions.exceptions import ConfigurationIssueError, ConfigurationUpdateBlocked
+from taipy.config.exceptions.exceptions import ConfigurationUpdateBlocked
 
 
 class TestCore:
-    def test_run_core_trigger_config_check(self):
+    def test_run_core_trigger_config_check(self, caplog):
         Config.configure_data_node(id="d0", storage_type="toto")
-        with pytest.raises(ConfigurationIssueError):
+        with pytest.raises(SystemExit):
             Core().run()
+        expected_error_message = (
+            "`storage_type` field of DataNodeConfig `d0` must be either csv, sql_table,"
+            " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory."
+            ' Current value of property `storage_type` is "toto".'
+        )
+        assert expected_error_message in caplog.text
 
     def test_run_core_as_a_service_development_mode(self):
         _SchedulerFactory._dispatcher = None


### PR DESCRIPTION
This PR:
- Improve the error message of `Config.check()` and update the test cases for those.
- Fix a bug on GenericDataNodeConfig, where `read_fct_params` and `write_fct_params` are defined as List, but the Checker only accept Tuple. Now it accepts both.
- Fix `Config.check()` can not detect if the `write_query_builder` of SQLDataNodeConfig is not a function.
- Fix if there is a required property missing on `Config.configure_default_data_node()`, only raise a warning, not an error.

The tests are failing because https://github.com/Avaiga/taipy-config/pull/51 is not merged yet.