### PR TITLE
Feat - Unblock JOB configuration on _ConfigComparator

### DIFF
--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -20,7 +20,6 @@ from ._scheduler._scheduler import _Scheduler
 from ._scheduler._scheduler_factory import _SchedulerFactory
 from ._version._version_cli import _VersioningCLI
 from ._version._version_manager_factory import _VersionManagerFactory
-from .exceptions.exceptions import VersionConflictWithPythonConfig
 from .taipy import clean_all_entities_by_version
 
 
@@ -95,10 +94,7 @@ class Core:
                 clean_all_entities_by_version(current_version_number)
                 _TaipyLogger._get_logger().info(f"Clean all entities of version {current_version_number}")
 
-            try:
-                version_setter[mode](current_version_number, force)
-            except VersionConflictWithPythonConfig as e:
-                raise SystemExit(e.message)
+            version_setter[mode](current_version_number, force)
 
         else:
             raise SystemExit(f"Undefined execution mode: {mode}.")

--- a/src/taipy/core/_scheduler/_dispatcher/_development_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_development_job_dispatcher.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config._toml_serializer import _TomlSerializer
+from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.config import Config
 
 from ...job.job import Job

--- a/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_job_dispatcher.py
@@ -13,7 +13,7 @@ import threading
 from abc import abstractmethod
 from typing import Any, Dict, List
 
-from taipy.config._toml_serializer import _TomlSerializer
+from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.config import Config
 from taipy.logger._taipy_logger import _TaipyLogger
 

--- a/src/taipy/core/_scheduler/_dispatcher/_standalone_job_dispatcher.py
+++ b/src/taipy/core/_scheduler/_dispatcher/_standalone_job_dispatcher.py
@@ -12,7 +12,7 @@
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 
-from taipy.config._toml_serializer import _TomlSerializer
+from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.config import Config
 
 from ...job.job import Job

--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -17,7 +17,7 @@ from taipy.config._config_comparator import _ConfigComparator
 from taipy.logger._taipy_logger import _TaipyLogger
 
 from .._manager._manager import _Manager
-from ..exceptions.exceptions import ModelNotFound, NonExistingVersion, VersionConflictWithPythonConfig
+from ..exceptions.exceptions import ModelNotFound, NonExistingVersion
 from ._version import _Version
 from ._version_repository_factory import _VersionRepositoryFactory
 
@@ -49,16 +49,26 @@ class _VersionManager(_Manager[_Version]):
     def _get_or_create(cls, id: str, force: bool) -> _Version:
         if version := cls._get(id):
             config_diff = _ConfigComparator(version.config, Config._applied_config)
-            if config_diff["added_items"] or config_diff["removed_items"] or config_diff["modified_items"]:
-                _TaipyLogger._get_logger().warning(
-                    f"The Configuration of version {id} is conflicted with the current Python Config."
-                )
+            if config_diff:
+                override_message = "To override these changes, run your application with --force option."
 
-                if force:
-                    _TaipyLogger._get_logger().warning(f"Overriding version {id} ...")
-                    version.config = Config._applied_config
-                else:
-                    raise VersionConflictWithPythonConfig(config_diff)
+                if config_diff.get(_ConfigComparator._UNBLOCKED_SECTION_KEY):
+                    _TaipyLogger._get_logger().info(
+                        f"There are unblocking changes between the current Configuration" f" and version {id}."
+                    )
+                    config_diff._log_unblocked_sections()
+                    _TaipyLogger._get_logger().info(override_message)
+
+                if config_diff.get(_ConfigComparator._BLOCKED_SECTION_KEY):
+                    _TaipyLogger._get_logger().error(f"The current Configuration is conflicted with version {id}.")
+                    config_diff._log_blocked_sections()
+                    _TaipyLogger._get_logger().error(override_message)
+
+                    if force:
+                        _TaipyLogger._get_logger().warning(f"Overriding version {id} ...")
+                        version.config = Config._applied_config
+                    else:
+                        raise SystemExit()
 
         else:
             version = _Version(id=id, config=Config._applied_config)
@@ -131,12 +141,25 @@ class _VersionManager(_Manager[_Version]):
 
             if version := cls._get(production_version):
                 config_diff = _ConfigComparator(version.config, Config._applied_config)
-                if config_diff["added_items"] or config_diff["removed_items"] or config_diff["modified_items"]:
-                    _TaipyLogger._get_logger().error(
-                        f"The Configuration of version {production_version} is conflicted with the current Python"
-                        " Config."
-                    )
-                    raise VersionConflictWithPythonConfig(config_diff)
+                if config_diff:
+                    override_message = "To override these changes, run your application with --force option."
+
+                    if config_diff.get(_ConfigComparator._UNBLOCKED_SECTION_KEY):
+                        _TaipyLogger._get_logger().info(
+                            f"There are unblocking changes between the current Configuration"
+                            f" and version {production_version}."
+                        )
+                        config_diff._log_unblocked_sections()
+                        _TaipyLogger._get_logger().info(override_message)
+
+                    if config_diff.get(_ConfigComparator._BLOCKED_SECTION_KEY):
+                        _TaipyLogger._get_logger().error(
+                            f"The current Configuration is conflicted with version {production_version}."
+                        )
+                        config_diff._log_blocked_sections()
+                        _TaipyLogger._get_logger().error(override_message)
+                        raise SystemExit()
+
             else:
                 raise NonExistingVersion(production_version)
 

--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -32,7 +32,7 @@ _inject_section(
     "job_config",
     JobConfig("development"),
     [("configure_job_executions", JobConfig._configure)],
-    add_to_unconlicted_section=True,
+    add_to_unconflicted_sections=True,
 )
 _inject_section(
     DataNodeConfig,

--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -10,7 +10,6 @@
 # specific language governing permissions and limitations under the License.
 
 from taipy.config import _inject_section
-from taipy.config._config_comparator import _ConfigComparator
 from taipy.config.checker._checker import _Checker
 from taipy.config.common.frequency import Frequency  # type: ignore
 from taipy.config.common.scope import Scope  # type: ignore
@@ -28,7 +27,13 @@ from .pipeline_config import PipelineConfig
 from .scenario_config import ScenarioConfig
 from .task_config import TaskConfig
 
-_inject_section(JobConfig, "job_config", JobConfig("development"), [("configure_job_executions", JobConfig._configure)])
+_inject_section(
+    JobConfig,
+    "job_config",
+    JobConfig("development"),
+    [("configure_job_executions", JobConfig._configure)],
+    add_to_unconlicted_section=True,
+)
 _inject_section(
     DataNodeConfig,
     "data_nodes",
@@ -79,5 +84,3 @@ _Checker.add_checker(_DataNodeConfigChecker)
 _Checker.add_checker(_TaskConfigChecker)
 _Checker.add_checker(_PipelineConfigChecker)
 _Checker.add_checker(_ScenarioConfigChecker)
-
-_ConfigComparator._unblock_section(JobConfig.name)

--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -8,7 +8,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
 from taipy.config import _inject_section
+from taipy.config._config_comparator import _ConfigComparator
 from taipy.config.checker._checker import _Checker
 from taipy.config.common.frequency import Frequency  # type: ignore
 from taipy.config.common.scope import Scope  # type: ignore
@@ -77,3 +79,5 @@ _Checker.add_checker(_DataNodeConfigChecker)
 _Checker.add_checker(_TaskConfigChecker)
 _Checker.add_checker(_PipelineConfigChecker)
 _Checker.add_checker(_ScenarioConfigChecker)
+
+_ConfigComparator._unblock_section(JobConfig.name)

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -240,55 +240,6 @@ class InvalidExportPath(Exception):
     """Raised if the export path is not valid."""
 
 
-class VersionConflictWithPythonConfig(Exception):
-    """Raised if the Config of the requested version is conflicted with the current Python Config."""
-
-    def __init__(self, config_diff):
-        message = ""
-        dq = '"'
-
-        if added_items := config_diff["added_items"]:
-            message += f"Added {'objects' if len(added_items) > 1 else 'object'}:\n"
-
-            for diff in added_items:
-                ((entity_name, entity_id, attribute), added_object) = diff
-                message += (
-                    f"\t{entity_name} {dq}{entity_id}{dq} "
-                    f"{f'has attribute {dq}{attribute}{dq}' if attribute else 'was'} added: {added_object}\n"
-                )
-
-            message += "\n"
-
-        if removed_items := config_diff["removed_items"]:
-            message += f"Removed {'objects' if len(removed_items) > 1 else 'object'}:\n"
-
-            for diff in removed_items:
-                ((entity_name, entity_id, attribute), removed_object) = diff
-                message += (
-                    f"\t{entity_name} {dq}{entity_id}{dq} "
-                    f"{f'has attribute {dq}{attribute}{dq}' if attribute else 'was'} removed\n"
-                )
-
-            message += "\n"
-
-        if modified_items := config_diff["modified_items"]:
-            message += f"Modified {'objects' if len(modified_items) > 1 else 'object'}:\n"
-
-            for diff in modified_items:
-                ((entity_name, entity_id, attribute), (old_value, new_value)) = diff
-                message += (
-                    f"\t{entity_name} {dq}{entity_id}{dq} "
-                    f"{f'has attribute {dq}{attribute}{dq}' if attribute else 'was'} modified: "
-                )
-                message += f"{old_value} -> {new_value}\n"
-
-            message += "\n"
-
-        message += "To override these changes, run your application with --force option."
-
-        self.message = message
-
-
 class NonExistingVersion(Exception):
     """Raised if request a Version that is not known by the Version Manager."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ def init_config():
     from src.taipy.core.config import _inject_section
 
     _inject_section(
-        JobConfig, "job_config", JobConfig("development"), [("configure_job_executions", JobConfig._configure)]
+        JobConfig, "job_config", JobConfig("development"), [("configure_job_executions", JobConfig._configure)], True
     )
     _inject_section(
         DataNodeConfig,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ from src.taipy.core.scenario.scenario import Scenario
 from src.taipy.core.task._task_manager_factory import _TaskManagerFactory
 from src.taipy.core.task.task import Task
 from taipy.config._config import _Config
-from taipy.config._toml_serializer import _TomlSerializer
+from taipy.config._serializer._toml_serializer import _TomlSerializer
 from taipy.config.checker._checker import _Checker
 from taipy.config.checker._checkers._gLobal_config_checker import _GlobalConfigChecker
 from taipy.config.checker.issue_collector import IssueCollector

--- a/tests/core/config/test_config_serialization.py
+++ b/tests/core/config/test_config_serialization.py
@@ -14,7 +14,7 @@ import json
 
 from src.taipy.core.config import DataNodeConfig, JobConfig, PipelineConfig, ScenarioConfig, TaskConfig
 from taipy.config import Config
-from taipy.config._json_serializer import _JsonSerializer
+from taipy.config._serializer._json_serializer import _JsonSerializer
 from taipy.config.common.frequency import Frequency
 from taipy.config.common.scope import Scope
 from tests.core.utils.named_temporary_file import NamedTemporaryFile


### PR DESCRIPTION
If there is a change on Job configuration, there will be INFO messages promted to the user. The application continues on.
```
[2023-03-06 14:47:14][Taipy][INFO] There are non-conflicting changes between the version 1.0 Configuration and the current Configuration:
	JOB "mode" was modified: development -> standalone
	JOB "max_nb_of_workers" was modified: 1:int -> 2:int
```

If there are a lot of changes, including the Job configuration, the INFO will be shown first and ERROR later.
The application will be stoped.
```
[2023-03-06 14:26:50][Taipy][INFO] There are non-conflicting changes between the version 1.0 Configuration and the current Configuration:
	JOB "mode" was modified: development -> standalone
	JOB "max_nb_of_workers" was modified: 1:int -> 2:int
[2023-03-06 14:26:50][Taipy][ERROR] The version 1.0 Configuration is conflicted with the current Configuration:
    DATA_NODE "d3" was added: {'storage_type': 'csv', 'scope': 'SCENARIO:SCOPE', 'default_path': 'baz.csv', 'has_header': 'False:bool', 'exposed_type': 'numpy'}
    Global Configuration "repository_properties" was added: {'foo': 'bar'}
    DATA_NODE "d0" was removed
    DATA_NODE "d1" has attribute "storage_type" modified: in_memory -> pickle
    DATA_NODE "d2" has attribute "default_path" modified: foo.csv -> bar.csv
...
    TASK "my_task" has attribute "outputs" modified: ['d2:SECTION'] -> ['d1:SECTION', 'd2:SECTION']
[2023-03-06 14:26:50][Taipy][ERROR] To override these changes, run your application with --force option.
The application is stopped. Please check the error log for more information.
```