### PR TITLE
fix modin exposed type checked

### DIFF
--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -72,11 +72,13 @@ class DataNodeConfig(Section):
 
     _EXPOSED_TYPE_KEY = "exposed_type"
     _EXPOSED_TYPE_PANDAS = "pandas"
+    _EXPOSED_TYPE_MODIN = "modin"
     _EXPOSED_TYPE_NUMPY = "numpy"
     _DEFAULT_EXPOSED_TYPE = _EXPOSED_TYPE_PANDAS
 
     _ALL_EXPOSED_TYPES = [
         _EXPOSED_TYPE_PANDAS,
+        _EXPOSED_TYPE_MODIN,
         _EXPOSED_TYPE_NUMPY,
     ]
     # Generic

--- a/src/taipy/core/version.json
+++ b/src/taipy/core/version.json
@@ -1,1 +1,1 @@
-{"major": 2, "minor": 1, "patch": 1}
+{"major": 2, "minor": 1, "patch": 2}

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -346,6 +346,11 @@ class TestDataNodeConfigChecker:
         _DataNodeConfigChecker(config, collector)._check()
         assert len(collector.errors) == 0
 
+        config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": "modin"}
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
         config._sections[DataNodeConfig.name]["default"].properties = {"exposed_type": "numpy"}
         collector = IssueCollector()
         _DataNodeConfigChecker(config, collector)._check()


### PR DESCRIPTION
(cherry picked from commit db774f569fda9d5caa99118b7293842f07924c43)

We forgot modin as an accepted exposed type value in the data_node_config. The result is that the config checker throw an error when using modin.

https://github.com/Avaiga/taipy-core/issues/508