### PR TITLE
[Refactor Repositories] FileSystemRepository base class

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ 'develop', 'dev/3.0' ]
 
 jobs:
   linter:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ 'develop', 'dev/3.0' ]
 
 jobs:
   backend:

--- a/src/taipy/core/_repository/_v2/__init__.py
+++ b/src/taipy/core/_repository/_v2/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from src.taipy.core.common.typing import Json
+from ...common.typing import Json
 
 ModelType = TypeVar("ModelType")
 Entity = TypeVar("Entity")

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -15,9 +15,12 @@ import re
 from abc import abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, Generic, Iterable, List, Optional, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from src.taipy.core.common.typing import Entity, Json, ModelType
+from src.taipy.core.common.typing import Json
+
+ModelType = TypeVar("ModelType")
+Entity = TypeVar("Entity")
 
 
 class _AbstractRepository(Generic[ModelType, Entity]):  # type: ignore

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -36,7 +36,7 @@ class _AbstractRepository(Generic[ModelType, Entity]):
         raise NotImplementedError
 
     @abstractmethod
-    def load(self, model_id: str) -> Entity:
+    def _load(self, model_id: str) -> Entity:
         """
         Retrieve the entity data from the repository.
 
@@ -153,7 +153,7 @@ def _str_to_timedelta(timedelta_str: str) -> timedelta:
     return timedelta(**time_params)  # type: ignore
 
 
-class _CustomEncoder(json.JSONEncoder):
+class _Encoder(json.JSONEncoder):
     def default(self, o: Any) -> Json:
         if isinstance(o, Enum):
             result = o.value
@@ -166,7 +166,7 @@ class _CustomEncoder(json.JSONEncoder):
         return result
 
 
-class _CustomDecoder(json.JSONDecoder):
+class _Decoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
 

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -23,7 +23,7 @@ ModelType = TypeVar("ModelType")
 Entity = TypeVar("Entity")
 
 
-class _AbstractRepository(Generic[ModelType, Entity]):  # type: ignore
+class _AbstractRepository(Generic[ModelType, Entity]):
     @abstractmethod
     def _save(self, entity: Entity):
         """

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -15,15 +15,12 @@ import re
 from abc import abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, Union
 
-Json = Union[dict, list, str, int, float, bool, None]
-
-ModelType = TypeVar("ModelType")
-Entity = TypeVar("Entity")
+from src.taipy.core.common.typing import Entity, Json, ModelType
 
 
-class _AbstractRepository(Generic[ModelType, Entity]):
+class _AbstractRepository(Generic[ModelType, Entity]):  # type: ignore
     @abstractmethod
     def _save(self, entity: Entity):
         """
@@ -85,7 +82,7 @@ class _AbstractRepository(Generic[ModelType, Entity]):
         raise NotImplementedError
 
     @abstractmethod
-    def _search(self, attribute: str, value: Any) -> Optional[Entity]:
+    def _search(self, attribute: str, value: Any, filters: List[Dict]) -> Optional[Entity]:
         """
         Args:
             attribute: The entity property that is the key to the search.

--- a/src/taipy/core/_repository/_v2/_abstract_repository.py
+++ b/src/taipy/core/_repository/_v2/_abstract_repository.py
@@ -15,7 +15,7 @@ import re
 from abc import abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Generic, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
 Json = Union[dict, list, str, int, float, bool, None]
 
@@ -50,23 +50,12 @@ class _AbstractRepository(Generic[ModelType, Entity]):
         raise NotImplementedError
 
     @abstractmethod
-    def _load_all(self, version_number: Optional[str]) -> List[Entity]:
+    def _load_all(self, filters: Optional[List[Dict]] = None) -> List[Entity]:
         """
-        Retrieve all the entities' data from the repository of a specific version.
+        Retrieve all the entities' data from the repository taking any passed filter into account.
 
         Returns:
             A list of entities.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def _load_all_by(self, by, version_number: Optional[str]) -> List[Entity]:
-        """
-        Retrieve all the entities' data from the repository of a specific version
-        based on a criteria.
-
-        Returns:
-            The list of all entities matching the criteria.
         """
         raise NotImplementedError
 
@@ -96,12 +85,11 @@ class _AbstractRepository(Generic[ModelType, Entity]):
         raise NotImplementedError
 
     @abstractmethod
-    def _search(self, attribute: str, value: Any, version_number: Optional[str]) -> Optional[Entity]:
+    def _search(self, attribute: str, value: Any) -> Optional[Entity]:
         """
         Args:
             attribute: The entity property that is the key to the search.
             value: The value of the attribute that are being searched.
-            version_number (Optional[str]): The version to search from.
 
         Returns:
             A list of entities

--- a/src/taipy/core/_repository/_v2/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_v2/_filesystem_repository.py
@@ -1,0 +1,101 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import json
+import pathlib
+from typing import Any, Iterable, List, Optional, Type, Union
+
+from src.taipy.core.common.typing import Entity, Json, ModelType
+from taipy.config.config import Config
+
+from ...exceptions import ModelNotFound
+from ._repository import _AbstractRepository, _CustomDecoder, _CustomEncoder
+
+
+class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
+    """
+    Holds common methods to be used and extended when the need for saving
+    dataclasses as JSON files in local storage emerges.
+
+    Some lines have type: ignore because MyPy won't recognize some generic attributes. This
+    should be revised in the future.
+
+    Attributes:
+        model (ModelType): Generic dataclass.
+        dir_name (str): Folder that will hold the files for this dataclass model.
+    """
+
+    def __init__(self, model: Type[ModelType], dir_name: str):
+        self.model = model
+        self._dir_name = dir_name
+
+    @property
+    def dir_path(self):
+        return self._storage_folder / self._dir_name
+
+    @property
+    def _storage_folder(self) -> pathlib.Path:
+        return pathlib.Path(Config.global_config.storage_folder)
+
+    def _save(self, entity: Entity):
+        self.__create_directory_if_not_exists()
+
+        # TODO: implement __from_entity on models
+        model = self.model.__from_entity(entity)
+        self._get_model_filepath(model.id).write_text(
+            json.dumps(model.to_dict(), ensure_ascii=False, indent=0, cls=_CustomEncoder, check_circular=False)
+        )
+
+    def _get(self, filepath: pathlib.Path) -> Json:
+        with pathlib.Path(filepath).open(encoding="UTF-8") as source:
+            return json.load(source)
+
+    def load(self, model_id: str) -> Entity:
+        try:
+            model = self.model(**self._get(self._get_model_filepath(model_id)))
+            return model.__to_entity()
+        except FileNotFoundError:
+            raise ModelNotFound(str(self.dir_path), model_id)
+
+    def _load_all(self, version_number: Optional[str]) -> List[Entity]:
+        """
+        Load all entities from a specific version.
+        """
+        from ..._version._version_manager_factory import _VersionManagerFactory
+
+        version_number = _VersionManagerFactory._build_manager()._replace_version_number(version_number)
+
+        r = []
+        return r
+
+    def _load_all_by(self, by, version_number: Optional[str]) -> List[Entity]:
+        pass
+
+    def _delete(self, entity_id: str):
+        pass
+
+    def _delete_all(self):
+        pass
+
+    def _delete_many(self, ids: Iterable[str]):
+        pass
+
+    def _search(self, attribute: str, value: Any, version_number: Optional[str]) -> Optional[Entity]:
+        pass
+
+    def _export(self, entity_id: str, folder_path: Union[str, pathlib.Path]):
+        pass
+
+    def __create_directory_if_not_exists(self):
+        self.dir_path.mkdir(parents=True, exist_ok=True)
+
+    def _get_model_filepath(self, model_id) -> pathlib.Path:
+        return self.dir_path / f"{model_id}.json"

--- a/src/taipy/core/_repository/_v2/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_v2/_filesystem_repository.py
@@ -14,6 +14,7 @@ import pathlib
 import shutil
 from typing import Any, Iterable, Iterator, List, Optional, Type, Union
 
+from src.taipy.core.common._utils import _retry
 from src.taipy.core.common.typing import Entity, Json, ModelType
 from taipy.config.config import Config
 
@@ -58,6 +59,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         with pathlib.Path(filepath).open(encoding="UTF-8") as source:
             return json.load(source)
 
+    @_retry(Config.global_config.read_entity_retry or 0, (Exception,))
     def load(self, model_id: str) -> Entity:
         try:
             model = self.model(**self._get(self.__get_model_filepath(model_id)))
@@ -65,6 +67,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         except FileNotFoundError:
             raise ModelNotFound(str(self.dir_path), model_id)
 
+    @_retry(Config.global_config.read_entity_retry or 0, (Exception,))
     def _load_all(self, version_number: Optional[str] = None) -> List[Entity]:
         """
         Load all entities from a specific version.
@@ -83,6 +86,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
             pass
         return r
 
+    @_retry(Config.global_config.read_entity_retry or 0, (Exception,))
     def _load_all_by(self, by, version_number: Optional[str]) -> List[Entity]:
         from ..._version._version_manager_factory import _VersionManagerFactory
 

--- a/src/taipy/core/_repository/_v2/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_v2/_filesystem_repository.py
@@ -18,7 +18,7 @@ from src.taipy.core.common.typing import Entity, Json, ModelType
 from taipy.config.config import Config
 
 from ...exceptions import InvalidExportPath, ModelNotFound
-from ._repository import _AbstractRepository, _CustomDecoder, _CustomEncoder
+from .._v2._abstract_repository import _AbstractRepository, _Decoder, _Encoder
 
 
 class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
@@ -51,7 +51,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         # TODO: implement _from_entity on models
         model = self.model._from_entity(entity)
         self.__get_model_filepath(model.id).write_text(
-            json.dumps(model.to_dict(), ensure_ascii=False, indent=0, cls=_CustomEncoder, check_circular=False)
+            json.dumps(model.to_dict(), ensure_ascii=False, indent=0, cls=_Encoder, check_circular=False)
         )
 
     def _get(self, filepath: pathlib.Path) -> Json:

--- a/src/taipy/core/_repository/_v2/_repository.py
+++ b/src/taipy/core/_repository/_v2/_repository.py
@@ -1,0 +1,179 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import json
+import pathlib
+import re
+from abc import abstractmethod
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Generic, Iterable, List, Optional, TypeVar, Union
+
+Json = Union[dict, list, str, int, float, bool, None]
+
+ModelType = TypeVar("ModelType")
+Entity = TypeVar("Entity")
+
+
+class _AbstractRepository(Generic[ModelType, Entity]):
+    @abstractmethod
+    def _save(self, entity: Entity):
+        """
+        Save an entity in the repository.
+
+        Args:
+            entity: The data from an object
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def load(self, model_id: str) -> Entity:
+        """
+        Retrieve the entity data from the repository.
+
+        Args:
+            model_id: The entity id, i.e., its primary key.
+
+        Returns:
+            An entity.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _load_all(self, version_number: Optional[str]) -> List[Entity]:
+        """
+        Retrieve all the entities' data from the repository of a specific version.
+
+        Returns:
+            A list of entities.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _load_all_by(self, by, version_number: Optional[str]) -> List[Entity]:
+        """
+        Retrieve all the entities' data from the repository of a specific version
+        based on a criteria.
+
+        Returns:
+            The list of all entities matching the criteria.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete(self, entity_id: str):
+        """
+        Delete an entity in the repository.
+
+        Args:
+            entity_id: The id of the entity to be deleted.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete_all(self):
+        """
+        Delete all entities from the repository.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete_many(self, ids: Iterable[str]):
+        """
+        Delete all entities from the list of ids from the repository.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _search(self, attribute: str, value: Any, version_number: Optional[str]) -> Optional[Entity]:
+        """
+        Args:
+            attribute: The entity property that is the key to the search.
+            value: The value of the attribute that are being searched.
+            version_number (Optional[str]): The version to search from.
+
+        Returns:
+            A list of entities
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _export(self, entity_id: str, folder_path: Union[str, pathlib.Path]):
+        """
+        Export an entity from the repository.
+
+        Args:
+            entity_id (str): The id of the entity to be exported.
+            folder_path (Union[str, pathlib.Path]): The folder path to export the entity to.
+
+        """
+        raise NotImplementedError
+
+
+def _timedelta_to_str(obj: timedelta) -> str:
+    total_seconds = obj.total_seconds()
+    return (
+        f"{int(total_seconds // 86400)}d"
+        f"{int(total_seconds % 86400 // 3600)}h"
+        f"{int(total_seconds % 3600 // 60)}m"
+        f"{int(total_seconds % 60)}s"
+    )
+
+
+def _str_to_timedelta(timedelta_str: str) -> timedelta:
+    """
+    Parse a time string e.g. (2h13m) into a timedelta object.
+
+    :param timedelta_str: A string identifying a duration.  (eg. 2h13m)
+    :return datetime.timedelta: A datetime.timedelta object
+    """
+    regex = re.compile(
+        r"^((?P<days>[\.\d]+?)d)? *"
+        r"((?P<hours>[\.\d]+?)h)? *"
+        r"((?P<minutes>[\.\d]+?)m)? *"
+        r"((?P<seconds>[\.\d]+?)s)?$"
+    )
+    parts = regex.match(timedelta_str)
+    if not parts:
+        raise TypeError("Can not deserialize string into timedelta")
+    time_params = {name: float(param) for name, param in parts.groupdict().items() if param}
+    # mypy has an issue with dynamic keyword parameters, hence the type ignore on the line bellow.
+    return timedelta(**time_params)  # type: ignore
+
+
+class _CustomEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Json:
+        if isinstance(o, Enum):
+            result = o.value
+        elif isinstance(o, datetime):
+            result = {"__type__": "Datetime", "__value__": o.isoformat()}
+        elif isinstance(o, timedelta):
+            result = {"__type__": "Timedelta", "__value__": _timedelta_to_str(o)}
+        else:
+            result = json.JSONEncoder.default(self, o)
+        return result
+
+
+class _CustomDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, source):
+        if source.get("__type__") == "Datetime":
+            return datetime.fromisoformat(source.get("__value__"))
+        if source.get("__type__") == "Timedelta":
+            return _str_to_timedelta(source.get("__value__"))
+        else:
+            return source

--- a/src/taipy/core/common/_utils.py
+++ b/src/taipy/core/common/_utils.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 import functools
+import time
 from collections import namedtuple
 from importlib import import_module
 from operator import attrgetter
@@ -20,6 +21,31 @@ from typing import Callable, Optional
 def _load_fct(module_name: str, fct_name: str) -> Callable:
     module = import_module(module_name)
     return attrgetter(fct_name)(module)
+
+
+def _retry(times, exceptions):
+    """
+    Retry Decorator
+    Retries the wrapped function/method `times` times if the exceptions listed
+    in ``exceptions`` are thrown
+    :param times: The number of times to repeat the wrapped function/method
+    :type times: Int
+    :param exceptions: Lists of exceptions that trigger a retry attempt
+    :type exceptions: Tuple of Exceptions
+    """
+
+    def decorator(func):
+        def newfn(*args, **kwargs):
+            for _ in range(times):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions:
+                    time.sleep(0.5)
+            return func(*args, **kwargs)
+
+        return newfn
+
+    return decorator
 
 
 @functools.lru_cache

--- a/src/taipy/core/common/typing.py
+++ b/src/taipy/core/common/typing.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from typing import TypeVar, Union
+
+ModelType = TypeVar("ModelType")
+Entity = TypeVar("Entity")
+Json = Union[dict, list, str, int, float, bool, None]

--- a/tests/core/common/test_retry.py
+++ b/tests/core/common/test_retry.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import pytest
+
+from src.taipy.core.common._utils import _retry
+
+
+def test_retry_decorator(mocker):
+    func = mocker.Mock(side_effect=Exception())
+
+    @_retry(3, (Exception,))
+    def decorated_func():
+        func()
+
+    with pytest.raises(Exception):
+        decorated_func()
+    # Called once in the normal flow and 3 more times on the retry flow
+    assert func.call_count == 4
+
+
+def test_retry_decorator_exception_not_in_list(mocker):
+    func = mocker.Mock(side_effect=KeyError())
+
+    @_retry(3, (Exception,))
+    def decorated_func():
+        func()
+
+    with pytest.raises(KeyError):
+        decorated_func()
+    # Called only on the first time and not trigger retry because KeyError is not on the exceptions list
+    assert func.called == 1

--- a/tests/core/repository/mocks.py
+++ b/tests/core/repository/mocks.py
@@ -15,8 +15,20 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from src.taipy.core._repository import _FileSystemRepository, _SQLRepository
+from src.taipy.core._repository._v2._filesystem_repository import _FileSystemRepository as _FileSystemRepositoryV2
 from src.taipy.core._version._version_manager import _VersionManager
 from taipy.config.config import Config
+
+
+@dataclass
+class MockObj:
+    def __init__(self, id: str, name: str, version: str = None) -> None:
+        self.id = id
+        self.name = name
+        if version:
+            self.version = version
+        else:
+            self.version = _VersionManager._get_latest_version()
 
 
 @dataclass
@@ -32,16 +44,12 @@ class MockModel:
     def from_dict(data: Dict[str, Any]):
         return MockModel(id=data["id"], name=data["name"], version=data["version"])
 
+    def _to_entity(self):
+        return MockObj(id=self.id, name=self.name, version=self.version)
 
-@dataclass
-class MockObj:
-    def __init__(self, id: str, name: str, version: str = None) -> None:
-        self.id = id
-        self.name = name
-        if version:
-            self.version = version
-        else:
-            self.version = _VersionManager._get_latest_version()
+    @classmethod
+    def _from_entity(cls, entity: MockObj):
+        return MockModel(id=entity.id, name=entity.name, version=entity.version)
 
 
 class MockFSRepository(_FileSystemRepository):
@@ -54,6 +62,15 @@ class MockFSRepository(_FileSystemRepository):
 
     def _from_model(self, model: MockModel):
         return MockObj(model.id, model.name, model.version)
+
+    @property
+    def _storage_folder(self) -> pathlib.Path:
+        return pathlib.Path(Config.global_config.storage_folder)  # type: ignore
+
+
+class MockFSRepositoryV2(_FileSystemRepositoryV2):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     @property
     def _storage_folder(self) -> pathlib.Path:

--- a/tests/core/repository/test_fs_repository_v2.py
+++ b/tests/core/repository/test_fs_repository_v2.py
@@ -136,7 +136,7 @@ class TestRepositoriesStorage:
         r._export("uuid", export_path)
         assert pathlib.Path(os.path.join(export_path, "mock_model/uuid.json")).exists()
         with open(os.path.join(export_path, "mock_model/uuid.json"), "r") as exported_file:
-            exported_data = json._load(exported_file)
+            exported_data = json.load(exported_file)
             assert exported_data["id"] == "uuid"
             assert exported_data["name"] == "foo"
 

--- a/tests/core/repository/test_fs_repository_v2.py
+++ b/tests/core/repository/test_fs_repository_v2.py
@@ -34,7 +34,7 @@ class TestRepositoriesStorage:
         m = MockObj("uuid", "foo")
         r._save(m)
 
-        fetched_model = r.load(m.id)
+        fetched_model = r._load(m.id)
         assert m == fetched_model
 
     @pytest.mark.parametrize(
@@ -136,7 +136,7 @@ class TestRepositoriesStorage:
         r._export("uuid", export_path)
         assert pathlib.Path(os.path.join(export_path, "mock_model/uuid.json")).exists()
         with open(os.path.join(export_path, "mock_model/uuid.json"), "r") as exported_file:
-            exported_data = json.load(exported_file)
+            exported_data = json._load(exported_file)
             assert exported_data["id"] == "uuid"
             assert exported_data["name"] == "foo"
 

--- a/tests/core/repository/test_fs_repository_v2.py
+++ b/tests/core/repository/test_fs_repository_v2.py
@@ -1,0 +1,151 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import json
+import os
+import pathlib
+import shutil
+
+import pytest
+
+from src.taipy.core.exceptions.exceptions import InvalidExportPath
+from taipy.config.config import Config
+
+from .mocks import MockFSRepositoryV2, MockModel, MockObj
+
+
+class TestRepositoriesStorage:
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    def test_save_and_fetch_model(self, mock_repo, params):
+        r = mock_repo(**params)
+        m = MockObj("uuid", "foo")
+        r._save(m)
+
+        fetched_model = r.load(m.id)
+        assert m == fetched_model
+
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    def test_get_all(self, mock_repo, params):
+        objs = []
+        r = mock_repo(**params)
+        r._delete_all()
+
+        for i in range(5):
+            m = MockObj(f"uuid-{i}", f"Foo{i}")
+            objs.append(m)
+            r._save(m)
+        _objs = r._load_all()
+
+        assert len(_objs) == 5
+
+        for obj in _objs:
+            assert isinstance(obj, MockObj)
+        assert sorted(objs, key=lambda o: o.id) == sorted(_objs, key=lambda o: o.id)
+
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    def test_delete_all(self, mock_repo, params):
+        r = mock_repo(**params)
+        r._delete_all()
+
+        for i in range(5):
+            m = MockObj(f"uuid-{i}", f"Foo{i}")
+            r._save(m)
+
+        _models = r._load_all()
+        assert len(_models) == 5
+
+        r._delete_all()
+        _models = r._load_all()
+        assert len(_models) == 0
+
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    def test_delete_many(self, mock_repo, params):
+        r = mock_repo(**params)
+        r._delete_all()
+
+        for i in range(5):
+            m = MockObj(f"uuid-{i}", f"Foo{i}")
+            r._save(m)
+
+        _models = r._load_all()
+        assert len(_models) == 5
+        r._delete_many(["uuid-0", "uuid-1"])
+        _models = r._load_all()
+        assert len(_models) == 3
+
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    def test_search(self, mock_repo, params):
+        r = mock_repo(**params)
+        r._delete_all()
+
+        m = MockObj("uuid", "foo")
+        r._save(m)
+
+        m1 = r._search("name", "bar")
+        m2 = r._search("name", "foo")
+
+        assert m1 is None
+        assert m == m2
+
+    @pytest.mark.parametrize(
+        "mock_repo,params",
+        [
+            (MockFSRepositoryV2, {"model": MockModel, "dir_name": "mock_model"}),
+        ],
+    )
+    @pytest.mark.parametrize("export_path", ["tmp"])
+    def test_export(self, mock_repo, params, tmp_sqlite, export_path):
+        r = mock_repo(**params)
+
+        m = MockObj("uuid", "foo")
+        r._save(m)
+
+        r._export("uuid", export_path)
+        assert pathlib.Path(os.path.join(export_path, "mock_model/uuid.json")).exists()
+        with open(os.path.join(export_path, "mock_model/uuid.json"), "r") as exported_file:
+            exported_data = json.load(exported_file)
+            assert exported_data["id"] == "uuid"
+            assert exported_data["name"] == "foo"
+
+        # Export to same location again should work
+        r._export("uuid", export_path)
+        assert pathlib.Path(os.path.join(export_path, "mock_model/uuid.json")).exists()
+
+        if mock_repo == MockFSRepositoryV2:
+            with pytest.raises(InvalidExportPath):
+                r._export("uuid", Config.global_config.storage_folder)
+
+        shutil.rmtree(export_path, ignore_errors=True)


### PR DESCRIPTION
So the objective was to keep the class as simple as possible, just having the responsability of writing and reading data from the database backend, in this case the File System. I've kept most of the version system logic that we have on the current version, but that can be also revisitated on future tasks. Some things I've removed maybe need to be kept, like the retry parameter that was on the old __to_entity method, which has been changed in this PR. Let me know if retry is still needed, I don't think we do in the other repositories.

_to_entity and _from_entity have been moved to the respective model class, I think it makes sense to use the model as the bridge between the taipy objects and the data in the database. Of course this can be changed. You can treat this PR as a proposal, and we can and should continue to propose better changes as we go futher into the repository refactoring.