### PR TITLE
Fix/#530 - Rename `--force-run` to `--taipy-force`

### DIFF
--- a/src/taipy/core/_version/_version_cli.py
+++ b/src/taipy/core/_version/_version_cli.py
@@ -59,7 +59,7 @@ class _VersioningCLI:
         )
 
         core_parser.add_argument(
-            "--force-run",
+            "--taipy-force",
             action="store_true",
             help="Force override the configuration of the version if existed and run the application."
             " Default to False.",
@@ -151,4 +151,4 @@ class _VersioningCLI:
             version_number = args.production
             mode = "production"
 
-        return mode, version_number, args.force_run, args.clean_entities
+        return mode, version_number, args.taipy_force, args.clean_entities

--- a/tests/core/version/test_version_cli.py
+++ b/tests/core/version/test_version_cli.py
@@ -64,7 +64,7 @@ def test_version_cli_return_value():
     assert not force
     assert not clean_entities
 
-    with patch("sys.argv", ["prog", "--experiment", "2.1", "--force-run"]):
+    with patch("sys.argv", ["prog", "--experiment", "2.1", "--taipy-force"]):
         mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
     assert mode == "experiment"
     assert version_number == "2.1"
@@ -294,13 +294,13 @@ def test_force_override_experiment_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --force-run parameter, a SystemExit will be raised
+    # Without --taipy-force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--experiment", "1.0"]):
             Core().run()
 
-    # With --force-run parameter
-    with patch("sys.argv", ["prog", "--experiment", "1.0", "--force-run"]):
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--experiment", "1.0", "--taipy-force"]):
         Core().run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"
@@ -344,13 +344,13 @@ def test_force_override_production_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --force-run parameter, a SystemExit will be raised
+    # Without --taipy-force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--production", "1.0"]):
             Core().run()
 
-    # With --force-run parameter
-    with patch("sys.argv", ["prog", "--production", "1.0", "--force-run"]):
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--production", "1.0", "--taipy-force"]):
         Core().run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/530

The `--force-run` option in Version CLI is conflicted with vscode-jupyter package.