### PR TITLE
Hotfix 2.1/#530 - Rename `--force` to `--taipy-force`

### DIFF
--- a/src/taipy/core/_version/_version_cli.py
+++ b/src/taipy/core/_version/_version_cli.py
@@ -67,8 +67,7 @@ class _VersioningCLI:
         )
 
         core_parser.add_argument(
-            "--force",
-            "-f",
+            "--taipy-force",
             action="store_true",
             help="Force override the configuration of the version if existed. Default to False.",
         )
@@ -153,4 +152,4 @@ class _VersioningCLI:
             version_number = args.production
             mode = "production"
 
-        return mode, version_number, args.force, args.clean_entities
+        return mode, version_number, args.taipy_force, args.clean_entities

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -284,7 +284,7 @@ class VersionConflictWithPythonConfig(Exception):
 
             message += "\n"
 
-        message += "To override these changes, run your application with --force option."
+        message += "To override these changes, run your application with --taipy-force option."
 
         self.message = message
 

--- a/src/taipy/core/version.json
+++ b/src/taipy/core/version.json
@@ -1,1 +1,1 @@
-{"major": 2, "minor": 1, "patch": 3}
+{"major": 2, "minor": 1, "patch": 4}

--- a/tests/core/version/test_version_cli.py
+++ b/tests/core/version/test_version_cli.py
@@ -71,7 +71,7 @@ def test_version_cli_return_value():
     assert not force
     assert not clean_entities
 
-    with patch("sys.argv", ["prog", "--experiment", "2.1", "--force"]):
+    with patch("sys.argv", ["prog", "--experiment", "2.1", "--taipy-force"]):
         mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
     assert mode == "experiment"
     assert version_number == "2.1"
@@ -301,13 +301,13 @@ def test_force_override_experiment_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --force parameter, a SystemExit will be raised
+    # Without --taipy-force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--experiment", "1.0"]):
             Core().run()
 
-    # With --force parameter
-    with patch("sys.argv", ["prog", "--experiment", "1.0", "--force"]):
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--experiment", "1.0", "--taipy-force"]):
         Core().run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"
@@ -351,13 +351,13 @@ def test_force_override_production_version():
     Config.unblock_update()
     Config.configure_global_app(clean_entities_enabled=True)
 
-    # Without --force parameter, a SystemExit will be raised
+    # Without --taipy-force parameter, a SystemExit will be raised
     with pytest.raises(SystemExit):
         with patch("sys.argv", ["prog", "--production", "1.0"]):
             Core().run()
 
-    # With --force parameter
-    with patch("sys.argv", ["prog", "--production", "1.0", "--force"]):
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--production", "1.0", "--taipy-force"]):
         Core().run()
     ver_2 = _VersionManager._get_latest_version()
     assert ver_2 == "1.0"


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/530

Fix bug caused by the `--force` and `--force-run` option in Version CLI conflicted with vscode-jupyter package.