### PR TITLE
Hotfix2.2.2/#544 - Remove default value of "db_driver" on SQLDataNode

### DIFF
--- a/src/taipy/core/config/config.schema.json
+++ b/src/taipy/core/config/config.schema.json
@@ -93,7 +93,7 @@
             "type": "string"
           },
           "db_driver": {
-            "description": "storage_type: sql, sql_table specific. The default value of db_driver is \"ODBC Driver 17 for SQL Server\".",
+            "description": "storage_type: sql, sql_table specific.",
             "type": "string"
           },
           "db_extra_args": {

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -593,7 +593,7 @@ class DataNodeConfig(Section):
         table_name: str = None,
         db_port: int = 1433,
         db_host: str = "localhost",
-        db_driver: str = "ODBC Driver 17 for SQL Server",
+        db_driver: str = "",
         db_extra_args: Dict[str, Any] = None,
         exposed_type=_EXPOSED_TYPE_PANDAS,
         scope: Scope = _DEFAULT_SCOPE,
@@ -609,8 +609,7 @@ class DataNodeConfig(Section):
             db_host (str): The database host. The default value is _"localhost"_.
             db_engine (str): The database engine. Possible values are _"sqlite"_, _"mssql"_, _"mysql"_, or
                 _"postgresql"_.
-            db_driver (str): The database driver. The default value is
-                _"ODBC Driver 17 for SQL Server"_.
+            db_driver (str): The database driver.
             db_port (int): The database port. The default value is 1433.
             db_extra_args (Dict[str, Any]): A dictionary of additional arguments to be passed into database
                 connection string.
@@ -651,7 +650,7 @@ class DataNodeConfig(Section):
         db_engine: str,
         db_port: int = 1433,
         db_host: str = "localhost",
-        db_driver: str = "ODBC Driver 17 for SQL Server",
+        db_driver: str = "",
         db_extra_args: Dict[str, Any] = None,
         read_query: str = None,
         write_query_builder: Callable = None,
@@ -670,8 +669,7 @@ class DataNodeConfig(Section):
                 _"postgresql"_.
             db_port (int): The database port. The default value is 1433.
             db_host (str): The database host. The default value is _"localhost"_.
-            db_driver (str): The database driver. The default value is
-                _"ODBC Driver 17 for SQL Server"_.
+            db_driver (str): The database driver.
             db_extra_args (Dict[str, Any]): A dictionary of additional arguments to be passed into database
                 connection string.
             read_query (str): The SQL query string used to read the data from the database.

--- a/src/taipy/core/data/abstract_sql.py
+++ b/src/taipy/core/data/abstract_sql.py
@@ -62,7 +62,7 @@ class _AbstractSQLDataNode(DataNode):
 
     __DB_HOST_DEFAULT = "localhost"
     __DB_PORT_DEFAULT = 1433
-    __DB_DRIVER_DEFAULT = "ODBC Driver 17 for SQL Server"
+    __DB_DRIVER_DEFAULT = ""
 
     __ENGINE_MSSQL = "mssql"
     __ENGINE_SQLITE = "sqlite"
@@ -162,7 +162,8 @@ class _AbstractSQLDataNode(DataNode):
         driver = self.properties.get(self.__DB_DRIVER_KEY, self.__DB_DRIVER_DEFAULT)
         extra_args = self.properties.get(self.__DB_EXTRA_ARGS_KEY, {})
 
-        extra_args = {**extra_args, "driver": driver}
+        if driver:
+            extra_args = {**extra_args, "driver": driver}
         for k, v in extra_args.items():
             extra_args[k] = re.sub(r"\s+", "+", v)
         extra_args_str = "&".join(f"{k}={str(v)}" for k, v in extra_args.items())

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -52,7 +52,7 @@ class SQLDataNode(_AbstractSQLDataNode):
                 _"postgresql"_.
             - _"db_port"_ `(int)`: The database port. The default value is 1433.
             - _"db_host"_ `(str)`: The database host. The default value is _"localhost"_.
-            - _"db_driver"_ `(str)`: The database driver. The default value is _"ODBC Driver 17 for SQL Server"_.
+            - _"db_driver"_ `(str)`: The database driver.
             - _"db_extra_args"_ `(Dict[str, Any])`: A dictionary of additional arguments to be passed into database
                 connection string.
             - _"read_query"_ `(str)`: The SQL query string used to read the data from the database.

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -56,7 +56,7 @@ class SQLTableDataNode(_AbstractSQLDataNode):
             - _"db_host"_ `(str)`: The database host. The default value is _"localhost"_.
             - _"db_engine"_ `(str)`: The database engine. For now, the accepted values are _"sqlite"_, _"mssql"_,
                 _"mysql"_, or _"postgresql"_.
-            - _"db_driver"_ `(str)`: The database driver. The default value is _"ODBC Driver 17 for SQL Server"_.
+            - _"db_driver"_ `(str)`: The database driver.
             - _"db_port"_ `(int)`: The database port. The default value is 1433.
             - _"db_extra_args"_ `(Dict[str, Any])`: A dictionary of additional arguments to be passed into database
                 connection string.

--- a/src/taipy/core/version.json
+++ b/src/taipy/core/version.json
@@ -1,1 +1,1 @@
-{"major": 2, "minor": 2, "patch": 1}
+{"major": 2, "minor": 2, "patch": 2}


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/544