### PR TITLE
Fix/#432 - Remove bare try except and fix bugs on Version SQL repo

### DIFF
--- a/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
+++ b/src/taipy/core/_orchestrator/_dispatcher/_job_dispatcher.py
@@ -62,7 +62,7 @@ class _JobDispatcher(threading.Thread):
                     with self.lock:
                         job = self.orchestrator.jobs_to_run.get(block=True, timeout=0.1)
                     self._execute_job(job)
-            except:  # In case the last job of the queue has been removed.  # noqa: E722
+            except Exception:  # In case the last job of the queue has been removed.
                 pass
 
     def _can_execute(self) -> bool:
@@ -85,7 +85,7 @@ class _JobDispatcher(threading.Thread):
             with self.lock:
                 try:
                     job = self.orchestrator.jobs_to_run.get()
-                except:  # In case the last job of the queue has been removed.  # noqa: E722
+                except Exception:  # In case the last job of the queue has been removed.
                     self.__logger.warning(f"{job.id} is no longer in the list of jobs to run.")
             self._execute_job(job)
 

--- a/src/taipy/core/_repository/_sql_repository.py
+++ b/src/taipy/core/_repository/_sql_repository.py
@@ -391,7 +391,7 @@ class _TaipyVersionTable(_BaseSQLRepository[ModelType, Entity]):
     def _get_latest_version(self):
         if latest := self.session.query(self._table).filter_by(is_latest=True).first():
             return latest.id
-        return ""
+        raise ModelNotFound(self.model, "")
 
     def _set_development_version(self, version_number):
         if old_development := self.session.query(self._table).filter_by(is_development=True).first():
@@ -407,7 +407,7 @@ class _TaipyVersionTable(_BaseSQLRepository[ModelType, Entity]):
     def _get_development_version(self):
         if development := self.session.query(self._table).filter_by(is_development=True).first():
             return development.id
-        raise ModelNotFound
+        raise ModelNotFound(self.model, "")
 
     def _set_production_version(self, version_number):
         version = self.__get_by_id(version_number)
@@ -420,7 +420,7 @@ class _TaipyVersionTable(_BaseSQLRepository[ModelType, Entity]):
     def _get_production_versions(self):
         if productions := self.session.query(self._table).filter_by(is_production=True).all():
             return [p.id for p in productions]
-        return []
+        raise ModelNotFound(self.model, "")
 
     def _delete_production_version(self, version_number):
         version = self.__get_by_id(version_number)

--- a/src/taipy/core/_repository/_sql_repository.py
+++ b/src/taipy/core/_repository/_sql_repository.py
@@ -14,9 +14,9 @@ import pathlib
 from abc import abstractmethod
 from typing import Any, Callable, Iterable, List, Optional, Type, TypeVar, Union
 
-from sqlalchemy import create_engine, delete
+from sqlalchemy import create_engine, delete, or_
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Query, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from taipy.config.config import Config
@@ -132,9 +132,8 @@ class _TaipyModelTable(_BaseSQLRepository[ModelType, Entity]):
         self.session.commit()
 
     def _delete_by(self, attribute: str, value: str, version_number: Optional[str] = None):
-        entries = self._search(attribute, value, version_number)
-        if entries:
-            self._delete_many([e.id for e in entries])  # type: ignore
+        while entity := self._search(attribute, value, version_number):
+            self._delete(entity.id)  # type: ignore
 
     def _delete_all(self):
         self.session.query(self._table).filter_by(model_name=self.model_name).delete()
@@ -223,13 +222,18 @@ class _TaipyModelTable(_BaseSQLRepository[ModelType, Entity]):
     def __to_entity(self, entry: _TaipyModel) -> Entity:
         return self.__model_to_entity(entry.document) if entry else None
 
-    def __filter_by_version(self, query, version_number):
+    def __filter_by_version(self, query: Query, version_number: Optional[str]):
         from .._version._version_manager_factory import _VersionManagerFactory
 
         version_number = _VersionManagerFactory._build_manager()._replace_version_number(version_number)
 
+        if not isinstance(version_number, List):
+            version_number = [version_number] if version_number else []  # type: ignore
+
         if version_number:
-            query = query.filter(self._table.document.contains(f'"version": "{version_number}"'))
+            version_query = list(map(lambda version: f'"version": "{version}"', version_number))
+            search_args = [self._table.document.contains(query) for query in version_query]
+            query = query.filter(or_(*search_args))
         return query
 
     def __model_to_entity(self, file_content):
@@ -354,7 +358,7 @@ class _TaipyVersionTable(_BaseSQLRepository[ModelType, Entity]):
         self.session.commit()
 
     def __update_entry(self, entry, model):
-        entry.config = Config._to_json(model.config)
+        entry.config = model.config
         self.session.commit()
 
     def __to_entity(self, entry: _TaipyVersion) -> Entity:

--- a/src/taipy/core/_version/_version_manager.py
+++ b/src/taipy/core/_version/_version_manager.py
@@ -87,7 +87,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_development_version(cls) -> str:
         try:
             return cls._repository._get_development_version()
-        except:  # noqa: E722
+        except (FileNotFoundError, ModelNotFound):
             return cls._set_development_version(str(uuid.uuid4()))
 
     @classmethod
@@ -112,7 +112,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_latest_version(cls) -> str:
         try:
             return cls._repository._get_latest_version()
-        except:  # noqa: E722
+        except (FileNotFoundError, ModelNotFound):
             # If there is no version in the system yet, create a new version as development version
             # This set the default versioning behavior on Jupyter notebook to Development mode
             return cls._set_development_version(str(uuid.uuid4()))
@@ -147,7 +147,7 @@ class _VersionManager(_Manager[_Version]):
     def _get_production_versions(cls) -> List[str]:
         try:
             return cls._repository._get_production_versions()
-        except:  # noqa: E722
+        except (FileNotFoundError, ModelNotFound):
             return []
 
     @classmethod
@@ -155,7 +155,7 @@ class _VersionManager(_Manager[_Version]):
         return cls._repository._delete_production_version(version_number)
 
     @classmethod
-    def _replace_version_number(cls, version_number):
+    def _replace_version_number(cls, version_number: Optional[str]):
         if version_number is None:
             version_number = cls._replace_version_number(cls.__DEFAULT_VERSION)
 

--- a/src/taipy/core/data/abstract_sql.py
+++ b/src/taipy/core/data/abstract_sql.py
@@ -228,9 +228,9 @@ class _AbstractSQLDataNode(DataNode):
             with connection.begin() as transaction:
                 try:
                     self._do_write(data, engine, connection)
-                except:  # noqa: E722
+                except Exception as e:
                     transaction.rollback()
-                    raise
+                    raise e
                 else:
                     transaction.commit()
 

--- a/tests/core/version/test_core_cli_with_sql_repo.py
+++ b/tests/core/version/test_core_cli_with_sql_repo.py
@@ -1,0 +1,573 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from src.taipy.core import Core
+from src.taipy.core._version._version_cli import _VersioningCLI
+from src.taipy.core._version._version_manager import _VersionManager
+from src.taipy.core.cycle._cycle_manager import _CycleManager
+from src.taipy.core.data._data_manager import _DataManager
+from src.taipy.core.exceptions.exceptions import NonExistingVersion
+from src.taipy.core.job._job_manager import _JobManager
+from src.taipy.core.pipeline._pipeline_manager import _PipelineManager
+from src.taipy.core.scenario._scenario_manager import _ScenarioManager
+from src.taipy.core.task._task_manager import _TaskManager
+from taipy.config.common.frequency import Frequency
+from taipy.config.common.scope import Scope
+from taipy.config.config import Config
+from tests.core.utils import assert_true_after_time
+
+from ...conftest import init_config
+
+
+def test_handle_core_cli_arguments(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    # Test default cli values
+    # Test default cli values
+    _VersioningCLI._create_parser()
+    mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "development"
+    assert version_number == ""
+    assert not force
+
+    # Test Dev mode
+    with patch("sys.argv", ["prog", "--development"]):
+        mode, _, _, _ = _VersioningCLI._parse_arguments()
+    assert mode == "development"
+
+    with patch("sys.argv", ["prog", "-dev"]):
+        mode, _, _, _ = _VersioningCLI._parse_arguments()
+    assert mode == "development"
+
+    # Test Experiment mode
+    with patch("sys.argv", ["prog", "--experiment"]):
+        mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "experiment"
+    assert version_number == ""
+    assert not force
+    assert not clean_entities
+
+    with patch("sys.argv", ["prog", "--experiment", "2.1"]):
+        mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "experiment"
+    assert version_number == "2.1"
+    assert not force
+    assert not clean_entities
+
+    with patch("sys.argv", ["prog", "--experiment", "2.1", "--taipy-force"]):
+        mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "experiment"
+    assert version_number == "2.1"
+    assert force
+    assert not clean_entities
+
+    with patch("sys.argv", ["prog", "--experiment", "2.1", "--clean-entities"]):
+        mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "experiment"
+    assert version_number == "2.1"
+    assert not force
+    assert clean_entities
+
+    # Test Production mode
+    with patch("sys.argv", ["prog", "--production"]):
+        mode, version_number, force, clean_entities = _VersioningCLI._parse_arguments()
+    assert mode == "production"
+    assert version_number == ""
+    assert not force
+
+
+def test_dev_mode_clean_all_entities_of_the_latest_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    # Create a scenario in development mode
+    with patch("sys.argv", ["prog"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    # Initial assertion
+    assert len(_DataManager._get_all(version_number="all")) == 2
+    assert len(_TaskManager._get_all(version_number="all")) == 1
+    assert len(_PipelineManager._get_all(version_number="all")) == 1
+    assert len(_ScenarioManager._get_all(version_number="all")) == 1
+    assert len(_CycleManager._get_all(version_number="all")) == 1
+    assert len(_JobManager._get_all(version_number="all")) == 1
+
+    # Create a new scenario in experiment mode
+    with patch("sys.argv", ["prog", "--experiment"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    # Assert number of entities in 2nd version
+    assert len(_DataManager._get_all(version_number="all")) == 4
+    assert len(_TaskManager._get_all(version_number="all")) == 2
+    assert len(_PipelineManager._get_all(version_number="all")) == 2
+    assert len(_ScenarioManager._get_all(version_number="all")) == 2
+    assert (
+        len(_CycleManager._get_all(version_number="all")) == 1
+    )  # No new cycle is created since old dev version use the same cycle
+    assert len(_JobManager._get_all(version_number="all")) == 2
+
+    # Run development mode again
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+
+    # The 1st dev version should be deleted run with development mode
+    assert len(_DataManager._get_all(version_number="all")) == 2
+    assert len(_TaskManager._get_all(version_number="all")) == 1
+    assert len(_PipelineManager._get_all(version_number="all")) == 1
+    assert len(_ScenarioManager._get_all(version_number="all")) == 1
+    assert len(_CycleManager._get_all(version_number="all")) == 1
+    assert len(_JobManager._get_all(version_number="all")) == 1
+
+    # Submit new dev version
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    # Assert number of entities with 1 dev version and 1 exp version
+    assert len(_DataManager._get_all(version_number="all")) == 4
+    assert len(_TaskManager._get_all(version_number="all")) == 2
+    assert len(_PipelineManager._get_all(version_number="all")) == 2
+    assert len(_ScenarioManager._get_all(version_number="all")) == 2
+    assert len(_CycleManager._get_all(version_number="all")) == 1
+    assert len(_JobManager._get_all(version_number="all")) == 2
+
+    # Assert number of entities of the latest version only
+    assert len(_DataManager._get_all(version_number="latest")) == 2
+    assert len(_TaskManager._get_all(version_number="latest")) == 1
+    assert len(_PipelineManager._get_all(version_number="latest")) == 1
+    assert len(_ScenarioManager._get_all(version_number="latest")) == 1
+    assert len(_JobManager._get_all(version_number="latest")) == 1
+
+    # Assert number of entities of the development version only
+    assert len(_DataManager._get_all(version_number="development")) == 2
+    assert len(_TaskManager._get_all(version_number="development")) == 1
+    assert len(_PipelineManager._get_all(version_number="development")) == 1
+    assert len(_ScenarioManager._get_all(version_number="development")) == 1
+    assert len(_JobManager._get_all(version_number="development")) == 1
+
+    # Assert number of entities of an unknown version
+    with pytest.raises(NonExistingVersion):
+        assert _DataManager._get_all(version_number="foo")
+    with pytest.raises(NonExistingVersion):
+        assert _TaskManager._get_all(version_number="foo")
+    with pytest.raises(NonExistingVersion):
+        assert _PipelineManager._get_all(version_number="foo")
+    with pytest.raises(NonExistingVersion):
+        assert _ScenarioManager._get_all(version_number="foo")
+    with pytest.raises(NonExistingVersion):
+        assert _JobManager._get_all(version_number="foo")
+
+
+def test_version_number_when_switching_mode(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+    ver_1 = _VersionManager._get_latest_version()
+    ver_dev = _VersionManager._get_development_version()
+    assert ver_1 == ver_dev
+    assert len(_VersionManager._get_all()) == 1
+
+    # Run with dev mode, the version number is the same
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+    ver_2 = _VersionManager._get_latest_version()
+    assert ver_2 == ver_dev
+    assert len(_VersionManager._get_all()) == 1
+
+    # When run with experiment mode, a new version is created
+    with patch("sys.argv", ["prog", "--experiment"]):
+        Core().run()
+    ver_3 = _VersionManager._get_latest_version()
+    assert ver_3 != ver_dev
+    assert len(_VersionManager._get_all()) == 2
+
+    with patch("sys.argv", ["prog", "--experiment", "2.1"]):
+        Core().run()
+    ver_4 = _VersionManager._get_latest_version()
+    assert ver_4 == "2.1"
+    assert len(_VersionManager._get_all()) == 3
+
+    with patch("sys.argv", ["prog", "--experiment"]):
+        Core().run()
+    ver_5 = _VersionManager._get_latest_version()
+    assert ver_5 != ver_3
+    assert ver_5 != ver_4
+    assert ver_5 != ver_dev
+    assert len(_VersionManager._get_all()) == 4
+
+    # When run with production mode, the latest version is used as production
+    with patch("sys.argv", ["prog", "--production"]):
+        Core().run()
+    ver_6 = _VersionManager._get_latest_version()
+    production_versions = _VersionManager._get_production_versions()
+    assert ver_6 == ver_5
+    assert production_versions == [ver_6]
+    assert len(_VersionManager._get_all()) == 4
+
+    # When run with production mode, the "2.1" version is used as production
+    with patch("sys.argv", ["prog", "--production", "2.1"]):
+        Core().run()
+    ver_7 = _VersionManager._get_latest_version()
+    production_versions = _VersionManager._get_production_versions()
+    assert ver_7 == "2.1"
+    assert production_versions == [ver_7, ver_6]
+    assert len(_VersionManager._get_all()) == 4
+
+    # Run with dev mode, the version number is the same as the first dev version to overide it
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+    ver_7 = _VersionManager._get_latest_version()
+    assert ver_1 == ver_7
+    assert len(_VersionManager._get_all()) == 4
+
+
+def test_production_mode_load_all_entities_from_previous_production_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--production"]):
+        Core().run()
+    production_ver_1 = _VersionManager._get_latest_version()
+    assert _VersionManager._get_production_versions() == [production_ver_1]
+    # When run production mode on a new app, a dev version is created alongside
+    assert _VersionManager._get_development_version() not in _VersionManager._get_production_versions()
+    assert len(_VersionManager._get_all()) == 2
+
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+    with patch("sys.argv", ["prog", "--production", "2.0"]):
+        Core().run()
+    production_ver_2 = _VersionManager._get_latest_version()
+    assert _VersionManager._get_production_versions() == [production_ver_1, production_ver_2]
+    assert len(_VersionManager._get_all()) == 3
+
+    # All entities from previous production version should be saved
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 4
+    assert len(_TaskManager._get_all()) == 2
+    assert len(_PipelineManager._get_all()) == 2
+    assert len(_ScenarioManager._get_all()) == 2
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 2
+
+
+def test_force_override_experiment_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Core().run()
+    ver_1 = _VersionManager._get_latest_version()
+    assert ver_1 == "1.0"
+    # When create new experiment version, a development version entity is also created as a placeholder
+    assert len(_VersionManager._get_all()) == 2  # 2 version include 1 experiment 1 development
+
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+    # Update Config singleton to simulate conflict Config between versions
+    Config.unblock_update()
+    Config.configure_global_app(clean_entities_enabled=True)
+
+    # Without --taipy-force parameter, a SystemExit will be raised
+    with pytest.raises(SystemExit):
+        with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+            Core().run()
+
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--experiment", "1.0", "--taipy-force"]):
+        Core().run()
+    ver_2 = _VersionManager._get_latest_version()
+    assert ver_2 == "1.0"
+    assert len(_VersionManager._get_all()) == 2  # 2 version include 1 experiment 1 development
+
+    # All entities from previous submit should be saved
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 4
+    assert len(_TaskManager._get_all()) == 2
+    assert len(_PipelineManager._get_all()) == 2
+    assert len(_ScenarioManager._get_all()) == 2
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 2
+
+
+def test_force_override_production_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--production", "1.0"]):
+        Core().run()
+    ver_1 = _VersionManager._get_latest_version()
+    production_versions = _VersionManager._get_production_versions()
+    assert ver_1 == "1.0"
+    assert production_versions == ["1.0"]
+    # When create new production version, a development version entity is also created as a placeholder
+    assert len(_VersionManager._get_all()) == 2  # 2 version include 1 production 1 development
+
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+    # Update Config singleton to simulate conflict Config between versions
+    Config.unblock_update()
+    Config.configure_global_app(clean_entities_enabled=True)
+
+    # Without --taipy-force parameter, a SystemExit will be raised
+    with pytest.raises(SystemExit):
+        with patch("sys.argv", ["prog", "--production", "1.0"]):
+            Core().run()
+
+    # With --taipy-force parameter
+    with patch("sys.argv", ["prog", "--production", "1.0", "--taipy-force"]):
+        Core().run()
+    ver_2 = _VersionManager._get_latest_version()
+    assert ver_2 == "1.0"
+    assert len(_VersionManager._get_all()) == 2  # 2 version include 1 production 1 development
+
+    # All entities from previous submit should be saved
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 4
+    assert len(_TaskManager._get_all()) == 2
+    assert len(_PipelineManager._get_all()) == 2
+    assert len(_ScenarioManager._get_all()) == 2
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 2
+
+
+def test_clean_experiment_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Core().run()
+
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0", "--clean-entities"]):
+        Core().run()
+
+    # All entities from previous submit should be cleaned and re-created
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+
+def test_clean_production_version(tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--production", "1.0"]):
+        Core().run()
+
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+    with patch("sys.argv", ["prog", "--production", "1.0", "--clean-entities"]):
+        Core().run()
+
+    # All entities from previous submit should be cleaned and re-created
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    assert len(_DataManager._get_all()) == 2
+    assert len(_TaskManager._get_all()) == 1
+    assert len(_PipelineManager._get_all()) == 1
+    assert len(_ScenarioManager._get_all()) == 1
+    assert len(_CycleManager._get_all()) == 1
+    assert len(_JobManager._get_all()) == 1
+
+
+def test_modify_job_configuration_dont_stop_application(caplog, tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Config.configure_job_executions(mode="development")
+        Core().run(force_restart=True)
+    scenario = _ScenarioManager._create(scenario_config)
+    jobs = _ScenarioManager._submit(scenario)
+    assert all([job.is_finished() for job in jobs])
+
+    init_config()
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Config.configure_job_executions(mode="standalone", max_nb_of_workers=5)
+        Core().run(force_restart=True)
+    scenario = _ScenarioManager._create(scenario_config)
+
+    jobs = _ScenarioManager._submit(scenario)
+    assert_true_after_time(lambda: all(job.is_finished() for job in jobs))
+    error_message = str(caplog.text)
+    assert 'JOB "mode" was modified' in error_message
+    assert 'JOB "max_nb_of_workers" was modified' in error_message
+
+
+def test_modify_config_properties_without_force(caplog, tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Core().run()
+        scenario = _ScenarioManager._create(scenario_config)
+        _ScenarioManager._submit(scenario)
+
+    init_config()
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config_2 = config_scenario_2()
+
+    with pytest.raises(SystemExit):
+        with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+            Core().run()
+            scenario = _ScenarioManager._create(scenario_config_2)
+            _ScenarioManager._submit(scenario)
+    error_message = str(caplog.text)
+
+    print(error_message)
+
+    assert 'DATA_NODE "d3" was added' in error_message
+
+    assert 'DATA_NODE "d0" was removed' in error_message
+
+    assert 'DATA_NODE "d2" has attribute "default_path" modified' in error_message
+    assert 'Global Configuration "root_folder" was modified' in error_message
+    assert 'Global Configuration "clean_entities_enabled" was modified' in error_message
+    assert 'JOB "mode" was modified' in error_message
+    assert 'JOB "max_nb_of_workers" was modified' in error_message
+    assert 'PIPELINE "my_pipeline" has attribute "tasks" modified' in error_message
+    assert 'SCENARIO "my_scenario" has attribute "frequency" modified' in error_message
+    assert 'SCENARIO "my_scenario" has attribute "pipelines" modified' in error_message
+    assert 'TASK "my_task" has attribute "inputs" modified' in error_message
+    assert 'TASK "my_task" has attribute "function" modified' in error_message
+    assert 'TASK "my_task" has attribute "outputs" modified' in error_message
+    assert 'DATA_NODE "d2" has attribute "has_header" modified' in error_message
+    assert 'DATA_NODE "d2" has attribute "exposed_type" modified' in error_message
+
+
+def twice(a):
+    return a * 2
+
+
+def config_scenario():
+    Config.configure_data_node(id="d0")
+    data_node_1_config = Config.configure_data_node(
+        id="d1", storage_type="pickle", default_data="abc", scope=Scope.SCENARIO
+    )
+    data_node_2_config = Config.configure_data_node(id="d2", storage_type="csv", default_path="foo.csv")
+    task_config = Config.configure_task("my_task", twice, data_node_1_config, data_node_2_config)
+    pipeline_config = Config.configure_pipeline("my_pipeline", task_config)
+    scenario_config = Config.configure_scenario("my_scenario", pipeline_config, frequency=Frequency.DAILY)
+
+    return scenario_config
+
+
+def double_twice(a):
+    return a * 2, a * 2
+
+
+def config_scenario_2():
+    Config.configure_global_app(
+        root_folder="foo_root",
+        # Changing the "storage_folder" will fail since older versions are stored in older folder
+        # storage_folder="foo_storage",
+        clean_entities_enabled=True,
+    )
+    Config.configure_job_executions(mode="standalone", max_nb_of_workers=5)
+    data_node_1_config = Config.configure_data_node(
+        id="d1", storage_type="pickle", default_data="abc", scope=Scope.SCENARIO
+    )
+    # Modify properties of "d2"
+    data_node_2_config = Config.configure_data_node(
+        id="d2", storage_type="csv", default_path="bar.csv", has_header=False, exposed_type="numpy"
+    )
+    # Add new data node "d3"
+    data_node_3_config = Config.configure_data_node(
+        id="d3", storage_type="csv", default_path="baz.csv", has_header=False, exposed_type="numpy"
+    )
+    # Modify properties of "my_task", including the function and outputs list
+    task_config = Config.configure_task(
+        "my_task", double_twice, data_node_3_config, [data_node_1_config, data_node_2_config]
+    )
+    # Modify properties of "my_pipeline", where tasks is now a list
+    pipeline_config = Config.configure_pipeline("my_pipeline", [task_config, task_config])
+    # Modify properties of "my_scenario", where pipelines is now a list
+    scenario_config = Config.configure_scenario(
+        "my_scenario", [pipeline_config, pipeline_config], frequency=Frequency.MONTHLY
+    )
+
+    return scenario_config

--- a/tests/core/version/test_version_cli_with_sql_repo.py
+++ b/tests/core/version/test_version_cli_with_sql_repo.py
@@ -1,0 +1,146 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from time import sleep
+from unittest.mock import patch
+
+import pytest
+
+from src.taipy.core import Core
+from src.taipy.core._version._version_manager import _VersionManager
+from src.taipy.core.scenario._scenario_manager import _ScenarioManager
+from taipy.config.common.frequency import Frequency
+from taipy.config.common.scope import Scope
+from taipy.config.config import Config
+
+
+def test_delete_version(caplog, tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    scenario_config = config_scenario()
+
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    with patch("sys.argv", ["prog", "--experiment", "1.1"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    with patch("sys.argv", ["prog", "--production", "1.1"]):
+        Core().run()
+
+    with patch("sys.argv", ["prog", "--experiment", "2.0"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    with patch("sys.argv", ["prog", "--experiment", "2.1"]):
+        Core().run()
+    scenario = _ScenarioManager._create(scenario_config)
+    _ScenarioManager._submit(scenario)
+
+    with patch("sys.argv", ["prog", "--production", "2.1"]):
+        Core().run()
+
+    all_versions = [version.id for version in _VersionManager._get_all()]
+    production_version = _VersionManager._get_production_versions()
+    assert len(all_versions) == 5
+    assert len(production_version) == 2
+    assert "1.0" in all_versions
+    assert "1.1" in all_versions and "1.1" in production_version
+    assert "2.0" in all_versions
+    assert "2.1" in all_versions and "2.1" in production_version
+
+    with pytest.raises(SystemExit) as e:
+        with patch("sys.argv", ["prog", "--delete-version", "1.0"]):
+            Core().run()
+    assert str(e.value) == "Successfully delete version 1.0."
+    all_versions = [version.id for version in _VersionManager._get_all()]
+    assert len(all_versions) == 4
+    assert "1.0" not in all_versions
+
+    # Test delete production version will change the version from production to experiment
+    with pytest.raises(SystemExit) as e:
+        with patch("sys.argv", ["prog", "--delete-production-version", "1.1"]):
+            Core().run()
+    assert str(e.value) == "Successfully delete version 1.1 from production version list."
+    all_versions = [version.id for version in _VersionManager._get_all()]
+    production_version = _VersionManager._get_production_versions()
+    assert len(all_versions) == 4
+    assert "1.1" in all_versions and "1.1" not in production_version
+
+    # Test delete a wrong production version
+    with pytest.raises(SystemExit) as e:
+        with patch("sys.argv", ["prog", "--delete-production-version", "non_exist_version"]):
+            Core().run()
+    assert str(e.value) == "Version non_exist_version is not a production version."
+
+
+def test_list_version(capsys, tmp_sqlite):
+    Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
+
+    with patch("sys.argv", ["prog", "--development"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--experiment", "1.0"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--experiment", "1.1"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--production", "1.1"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--experiment", "2.0"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--experiment", "2.1"]):
+        Core().run()
+    sleep(0.05)
+    with patch("sys.argv", ["prog", "--production", "2.1"]):
+        Core().run()
+
+    with pytest.raises(SystemExit) as e:
+        with patch("sys.argv", ["prog", "--list-versions"]):
+            Core().run()
+
+    version_list = str(e.value).strip().split("\n")
+    assert len(version_list) == 6  # 5 versions with the header
+    assert all(column in version_list[0] for column in ["Version number", "Mode", "Creation date"])
+    assert all(column in version_list[1] for column in ["2.1", "Production", "latest"])
+    assert all(column in version_list[2] for column in ["2.0", "Experiment"]) and "latest" not in version_list[2]
+    assert all(column in version_list[3] for column in ["1.1", "Production"]) and "latest" not in version_list[3]
+    assert all(column in version_list[4] for column in ["1.0", "Experiment"]) and "latest" not in version_list[4]
+    assert "Development" in version_list[5] and "latest" not in version_list[5]
+
+
+def twice(a):
+    return a * 2
+
+
+def config_scenario():
+    data_node_1_config = Config.configure_data_node(
+        id="d1", storage_type="pickle", default_data="abc", scope=Scope.SCENARIO
+    )
+    data_node_2_config = Config.configure_data_node(id="d2", storage_type="csv", default_path="foo.csv")
+    task_config = Config.configure_task("my_task", twice, data_node_1_config, data_node_2_config)
+    pipeline_config = Config.configure_pipeline("my_pipeline", task_config)
+    scenario_config = Config.configure_scenario("my_scenario", pipeline_config, frequency=Frequency.DAILY)
+
+    return scenario_config

--- a/tests/core/version/test_version_sql_repository.py
+++ b/tests/core/version/test_version_sql_repository.py
@@ -14,7 +14,7 @@ import pytest
 from src.taipy.core._repository import _sql_repository
 from src.taipy.core._version._version import _Version
 from src.taipy.core._version._version_sql_repository import _VersionSQLRepository
-from src.taipy.core.exceptions import VersionIsNotProductionVersion
+from src.taipy.core.exceptions import ModelNotFound, VersionIsNotProductionVersion
 from taipy.config.config import Config
 
 
@@ -119,5 +119,5 @@ class TestVersionSQLRepository:
         assert len(repo._get_production_versions()) == 1
 
         repo._delete_production_version(version.id)
-
-        assert len(repo._get_production_versions()) == 0
+        with pytest.raises(ModelNotFound):
+            repo._get_production_versions()


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/432

In this PR:
- Remove `# noqa: E722` comments on some bare try except.
- Add tests for managing version on SQL repo and fix some bugs:
  - `_delete_by()` method did not delete all entities but just the first one.
  - `__filter_by_version()` method fail when the `version_number` is a list of production versions.