### PR TITLE
feature/#605 added deprecation message for pipeline config

### DIFF
--- a/src/taipy/core/config/pipeline_config.py
+++ b/src/taipy/core/config/pipeline_config.py
@@ -17,6 +17,7 @@ from taipy.config.common._template_handler import _TemplateHandler as _tpl
 from taipy.config.config import Config
 from taipy.config.section import Section
 
+from ..common._warnings import _warn_deprecated
 from .task_config import TaskConfig
 
 
@@ -96,6 +97,7 @@ class PipelineConfig(Section):
         """
         section = PipelineConfig(id, task_configs, **properties)
         Config._register(section)
+        _warn_deprecated("PipelineConfig")
         return Config.sections[PipelineConfig.name][id]
 
     @staticmethod
@@ -116,4 +118,5 @@ class PipelineConfig(Section):
         """
         section = PipelineConfig(_Config.DEFAULT_KEY, task_configs, **properties)
         Config._register(section)
+        _warn_deprecated("PipelineConfig")
         return Config.sections[PipelineConfig.name][_Config.DEFAULT_KEY]

--- a/src/taipy/core/config/scenario_config.py
+++ b/src/taipy/core/config/scenario_config.py
@@ -20,6 +20,7 @@ from taipy.config.common.frequency import Frequency
 from taipy.config.config import Config
 from taipy.config.section import Section
 
+from ..common._warnings import _warn_deprecated
 from .pipeline_config import PipelineConfig
 from .task_config import TaskConfig
 
@@ -72,10 +73,12 @@ class ScenarioConfig(Section):
 
     @property
     def pipeline_configs(self) -> List[PipelineConfig]:
+        _warn_deprecated("PipelineConfig")
         return self._pipelines
 
     @property
     def pipelines(self) -> List[PipelineConfig]:
+        _warn_deprecated("PipelineConfig")
         return self._pipelines
 
     @classmethod

--- a/tests/core/config/test_pipeline_config.py
+++ b/tests/core/config/test_pipeline_config.py
@@ -12,6 +12,8 @@
 import os
 from unittest import mock
 
+import pytest
+
 from taipy.config.config import Config
 
 
@@ -69,3 +71,11 @@ def test_pipeline_config_with_env_variable_value():
         assert Config.pipelines["pipeline_name"].prop == "bar"
         assert Config.pipelines["pipeline_name"].properties["prop"] == "bar"
         assert Config.pipelines["pipeline_name"]._properties["prop"] == "ENV[FOO]"
+
+
+def test_pipeline_config_configure_deprecated():
+    with pytest.warns(DeprecationWarning):
+        Config.configure_pipeline("pipeline_id", [])
+
+    with pytest.warns(DeprecationWarning):
+        Config.configure_default_pipeline([])

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -12,6 +12,8 @@
 import os
 from unittest import mock
 
+import pytest
+
 from taipy.config.common.frequency import Frequency
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
@@ -134,3 +136,12 @@ def test_scenario_create_from_task_config():
         "s2", task_configs=[task_config_1, task_config_2], pipeline_id=pipeline_name
     )
     assert scenario_config_2.pipeline_configs[0].id == pipeline_name
+
+
+def test_pipeline_config_configure_deprecated():
+    pipeline_config = Config.configure_default_pipeline([])
+    scenario_config = Config.configure_scenario("scenario_id", pipeline_configs=[pipeline_config])
+    with pytest.warns(DeprecationWarning):
+        scenario_config.pipelines
+    with pytest.warns(DeprecationWarning):
+        scenario_config.pipeline_configs


### PR DESCRIPTION
#605
@jrobinAV This PR includes adding deprecation warning messages for pipeline configs. But unfortunately, we don't have anything to provide users as the "alternatives" at the moment! I'm afraid it might create some confusion with the "if not use pipeline config, what should we use?" question.
