### PR TITLE
migrate jobs 

### DIFF
--- a/src/taipy/core/_orchestrator/utils.py
+++ b/src/taipy/core/_orchestrator/utils.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+def migrate_subscriber(fct_module, fct_name):
+    """Rename scheduler by orchestrator on old jobs. Used to migrate from <=2.2 to >=2.3 version."""
+
+    if fct_module == "taipy.core._scheduler._scheduler":
+        fct_module = fct_module.replace("_scheduler", "_orchestrator")
+        fct_name = fct_name.replace("_Scheduler", "_Orchestrator")
+    return fct_module, fct_name

--- a/tests/core/job/test_utils.py
+++ b/tests/core/job/test_utils.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from src.taipy.core._orchestrator.utils import migrate_subscriber
+
+
+def test_migrate_subscriber():
+    assert migrate_subscriber("", "") == ("", "")
+    assert migrate_subscriber("foo.bar", "baz") == ("foo.bar", "baz")
+    assert migrate_subscriber("taipy.core._scheduler._scheduler", "_Scheduler._on_status_change") == (
+        "taipy.core._orchestrator._orchestrator",
+        "_Orchestrator._on_status_change",
+    )
+    assert migrate_subscriber("taipy.core._orchestrator._orchestrator", "_Orchestrator._on_status_change") == (
+        "taipy.core._orchestrator._orchestrator",
+        "_Orchestrator._on_status_change",
+    )


### PR DESCRIPTION
When renaming scheduler to orchestrator we did not realize that the scheduler module path was stored in some jobs in the subscribers attribute.

This is a migration path