### PR TITLE
Fix - Absolute link in reference manual

### DIFF
--- a/src/taipy/core/_backup/_backup.py
+++ b/src/taipy/core/_backup/_backup.py
@@ -11,18 +11,17 @@
 
 
 import os
-import pathlib
 
 __BACKUP_FILE_PATH_ENVIRONMENT_VARIABLE_NAME = "TAIPY_BACKUP_FILE_PATH"
 
 
-def append_to_backup_file(new_file_path: str):
+def _append_to_backup_file(new_file_path: str):
     if preserve_file_path := os.getenv(__BACKUP_FILE_PATH_ENVIRONMENT_VARIABLE_NAME):
         with open(preserve_file_path, "a") as f:
             f.write(f"{new_file_path}\n")
 
 
-def remove_from_backup_file(to_remove_file_path: str):
+def _remove_from_backup_file(to_remove_file_path: str):
     preserve_file_path = os.getenv(__BACKUP_FILE_PATH_ENVIRONMENT_VARIABLE_NAME, None)
     if preserve_file_path:
         try:
@@ -45,6 +44,6 @@ def remove_from_backup_file(to_remove_file_path: str):
             pass
 
 
-def replace_in_backup_file(old_file_path: str, new_file_path: str):
-    remove_from_backup_file(old_file_path)
-    append_to_backup_file(new_file_path)
+def _replace_in_backup_file(old_file_path: str, new_file_path: str):
+    _remove_from_backup_file(old_file_path)
+    _append_to_backup_file(new_file_path)

--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -16,7 +16,7 @@ from taipy.config._config import _Config
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 
-from .._backup._backup import append_to_backup_file, remove_from_backup_file
+from .._backup._backup import _append_to_backup_file, _remove_from_backup_file
 from .._manager._manager import _Manager
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..config.data_node_config import DataNodeConfig
@@ -74,7 +74,7 @@ class _DataManager(_Manager[DataNode]):
         data_node = cls.__create(data_node_config, owner_id, parent_ids)
         cls._set(data_node)
         if isinstance(data_node, _AbstractFileDataNode):
-            append_to_backup_file(new_file_path=data_node._path)
+            _append_to_backup_file(new_file_path=data_node._path)
         _publish_event(cls._EVENT_ENTITY_TYPE, data_node.id, EventOperation.CREATION, None)
         return data_node
 
@@ -119,13 +119,13 @@ class _DataManager(_Manager[DataNode]):
     @classmethod
     def _remove_dn_file_path_in_backup_file(cls, data_node: DataNode):
         if isinstance(data_node, _AbstractFileDataNode):
-            remove_from_backup_file(to_remove_file_path=data_node.path)
+            _remove_from_backup_file(to_remove_file_path=data_node.path)
 
     @classmethod
     def _remove_dn_file_paths_in_backup_file(cls, data_nodes: Iterable[DataNode]):
         for data_node in data_nodes:
             if isinstance(data_node, _AbstractFileDataNode):
-                remove_from_backup_file(to_remove_file_path=data_node.path)
+                _remove_from_backup_file(to_remove_file_path=data_node.path)
 
     @classmethod
     def _delete(cls, data_node_id: DataNodeId):

--- a/src/taipy/core/data/csv.py
+++ b/src/taipy/core/data/csv.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from taipy.config.common.scope import Scope
 
-from .._backup._backup import replace_in_backup_file
+from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import InvalidExposedType
@@ -138,7 +138,7 @@ class CSVDataNode(DataNode, _AbstractFileDataNode):
         tmp_old_path = self._path
         self._path = value
         self.properties[self.__PATH_KEY] = value
-        replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
+        _replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
 
     def _check_exposed_type(self, exposed_type):
         if isinstance(exposed_type, str) and exposed_type not in self.__VALID_STRING_EXPOSED_TYPES:

--- a/src/taipy/core/data/csv.py
+++ b/src/taipy/core/data/csv.py
@@ -48,7 +48,7 @@ class CSVDataNode(DataNode, _AbstractFileDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -67,7 +67,7 @@ class DataNode(_Entity, _Labeled):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if the data node is locked for modification. False
             otherwise.

--- a/src/taipy/core/data/excel.py
+++ b/src/taipy/core/data/excel.py
@@ -52,7 +52,7 @@ class ExcelDataNode(DataNode, _AbstractFileDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/excel.py
+++ b/src/taipy/core/data/excel.py
@@ -21,7 +21,7 @@ from openpyxl import load_workbook
 
 from taipy.config.common.scope import Scope
 
-from .._backup._backup import replace_in_backup_file
+from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import ExposedTypeLengthMismatch, InvalidExposedType, NonExistingExcelSheet
@@ -144,7 +144,7 @@ class ExcelDataNode(DataNode, _AbstractFileDataNode):
         tmp_old_path = self._path
         self._path = value
         self.properties[self.__PATH_KEY] = value
-        replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
+        _replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
 
     @classmethod
     def storage_type(cls) -> str:

--- a/src/taipy/core/data/generic.py
+++ b/src/taipy/core/data/generic.py
@@ -41,7 +41,7 @@ class GenericDataNode(DataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/in_memory.py
+++ b/src/taipy/core/data/in_memory.py
@@ -45,7 +45,7 @@ class InMemoryDataNode(DataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -46,7 +46,7 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from taipy.config.common.scope import Scope
 
-from .._backup._backup import replace_in_backup_file
+from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from .abstract_file import _AbstractFileDataNode
@@ -127,7 +127,7 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         tmp_old_path = self._path
         self._path = value
         self.properties[self.__PATH_KEY] = value
-        replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
+        _replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
 
     @property  # type: ignore
     @_self_reload(DataNode._MANAGER_NAME)

--- a/src/taipy/core/data/mongo.py
+++ b/src/taipy/core/data/mongo.py
@@ -42,7 +42,7 @@ class MongoCollectionDataNode(DataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 from taipy.config.common.scope import Scope
 
-from .._backup._backup import replace_in_backup_file
+from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..exceptions.exceptions import InvalidExposedType, UnknownCompressionAlgorithm, UnknownParquetEngine
@@ -180,7 +180,7 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode):
         tmp_old_path = self._path
         self._path = value
         self.properties[self.__PATH_KEY] = value
-        replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
+        _replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
 
     def _check_exposed_type(self, exposed_type):
         if isinstance(exposed_type, str) and exposed_type not in self.__VALID_STRING_EXPOSED_TYPES:

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -47,7 +47,7 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/pickle.py
+++ b/src/taipy/core/data/pickle.py
@@ -45,7 +45,7 @@ class PickleDataNode(DataNode, _AbstractFileDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/pickle.py
+++ b/src/taipy/core/data/pickle.py
@@ -18,7 +18,7 @@ import modin.pandas as pd
 
 from taipy.config.common.scope import Scope
 
-from .._backup._backup import replace_in_backup_file
+from .._backup._backup import _replace_in_backup_file
 from .._entity._reload import _self_reload
 from .._version._version_manager_factory import _VersionManagerFactory
 from .abstract_file import _AbstractFileDataNode
@@ -123,7 +123,7 @@ class PickleDataNode(DataNode, _AbstractFileDataNode):
         self._path = value
         self.properties[self.__PATH_KEY] = value
         self.properties[self.__IS_GENERATED_KEY] = False
-        replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
+        _replace_in_backup_file(old_file_path=tmp_old_path, new_file_path=self._path)
 
     @property  # type: ignore
     @_self_reload(DataNode._MANAGER_NAME)

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -39,7 +39,7 @@ class SQLDataNode(_AbstractSQLDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -44,7 +44,7 @@ class SQLTableDataNode(_AbstractSQLDataNode):
         validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
             which the data node can be considered up-to-date. Once the validity period has passed, the data node is
             considered stale and relevant tasks will run even if they are skippable (see the
-            [Task management page](https://docs.taipy.io/en/latest/manuals/core/entities/task-mgt) for more details).
+            [Task management page](../core/entities/task-mgt.md) for more details).
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.


### PR DESCRIPTION
In this PR:
- The absolute links in the docstring are replaced by the relative link.
- Somehow the `replace_in_backup_file()` method appears in the Reference Manual when built, so I make it internal. @toan-quach Please let me know if it's ok.