### PR TITLE
Rename CoreSection name from 'core' to 'CORE'

### DIFF
--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -19,6 +19,7 @@ from ._orchestrator._dispatcher._job_dispatcher import _JobDispatcher
 from ._orchestrator._orchestrator import _Orchestrator
 from ._orchestrator._orchestrator_factory import _OrchestratorFactory
 from ._version._version_manager_factory import _VersionManagerFactory
+from .config import CoreSection
 
 
 class Core:
@@ -63,7 +64,7 @@ class Core:
     @staticmethod
     def __update_and_check_config():
         _CoreCLI.create_parser()
-        Config._applied_config._unique_sections["core"]._update(_CoreCLI.parse_arguments())
+        Config._applied_config._unique_sections[CoreSection.name]._update(_CoreCLI.parse_arguments())
         Config.check()
         Config.block_update()
 

--- a/src/taipy/core/config/_core_section.py
+++ b/src/taipy/core/config/_core_section.py
@@ -18,7 +18,7 @@ from taipy.config.common._template_handler import _TemplateHandler as _tpl
 
 
 class CoreSection(UniqueSection):
-    name = "core"
+    name = "CORE"
     _MODE_KEY = "mode"
     _DEVELOPMENT_MODE = "development"
     _EXPERIMENT_MODE = "experiment"

--- a/tests/core/config/test_config_serialization.py
+++ b/tests/core/config/test_config_serialization.py
@@ -106,7 +106,7 @@ repository_type = "filesystem"
 mode = "development"
 max_nb_of_workers = "1:int"
 
-[core]
+[CORE]
 mode = "development"
 version_number = ""
 force = "False:bool"
@@ -248,7 +248,7 @@ def test_read_write_json_configuration_file():
 "mode": "development",
 "max_nb_of_workers": "1:int"
 },
-"core": {
+"CORE": {
 "mode": "development",
 "version_number": "",
 "force": "False:bool",

--- a/tests/core/config/test_core_section.py
+++ b/tests/core/config/test_core_section.py
@@ -38,7 +38,7 @@ def test_core_section():
         content="""
 [TAIPY]
 
-[core]
+[CORE]
 mode = "production"
 version_number = "test_num_2"
 force = "true:bool"

--- a/tests/core/config/test_file_config.py
+++ b/tests/core/config/test_file_config.py
@@ -31,7 +31,7 @@ repository_type = "filesystem"
 mode = "standalone"
 max_nb_of_workers = "2:int"
 
-[core]
+[CORE]
 mode = "development"
 version_number = ""
 force = "False:bool"


### PR DESCRIPTION
Simple rename of the CoreSection configuration section.