### PR TITLE
feat: Version Repository Interface

### DIFF
--- a/src/taipy/core/_version/_version_fs_repository_v2.py
+++ b/src/taipy/core/_version/_version_fs_repository_v2.py
@@ -18,9 +18,10 @@ from .._repository._v2._filesystem_repository import _FileSystemRepository
 from ..exceptions.exceptions import VersionIsNotProductionVersion
 from ._version_converter import _VersionConverter
 from ._version_model import _VersionModel
+from ._version_repository_interface import _VersionRepositoryInterface
 
 
-class _VersionFSRepository(_FileSystemRepository):
+class _VersionFSRepository(_FileSystemRepository, _VersionRepositoryInterface):
     _LATEST_VERSION_KEY = "latest_version"
     _DEVELOPMENT_VERSION_KEY = "development_version"
     _PRODUCTION_VERSION_KEY = "production_version"

--- a/src/taipy/core/_version/_version_repository_interface.py
+++ b/src/taipy/core/_version/_version_repository_interface.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from abc import ABC, abstractmethod
+
+
+class _VersionRepositoryInterface(ABC):
+    @abstractmethod
+    def _set_latest_version(self, version_number):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_latest_version(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _set_development_version(self, version_number):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_development_version(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _set_production_version(self, version_number):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_production_versions(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete_production_version(self, version_number):
+        raise NotImplementedError

--- a/src/taipy/core/_version/_version_sql_repository_v2.py
+++ b/src/taipy/core/_version/_version_sql_repository_v2.py
@@ -13,9 +13,10 @@ from .._repository._v2._sql_repository import _SQLRepository
 from ..exceptions.exceptions import ModelNotFound, VersionIsNotProductionVersion
 from ._version_converter import _VersionConverter
 from ._version_model import _VersionModel
+from ._version_repository_interface import _VersionRepositoryInterface
 
 
-class _VersionSQLRepository(_SQLRepository):
+class _VersionSQLRepository(_SQLRepository, _VersionRepositoryInterface):
     _LATEST_VERSION_KEY = "latest_version"
     _DEVELOPMENT_VERSION_KEY = "development_version"
     _PRODUCTION_VERSION_KEY = "production_version"

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -569,14 +569,6 @@ class TestDataNode:
                 dn.unlock_edition(datetime.now(), None)
                 unlock_edit.assert_called_once_with()
 
-    def test_scope_pipeline_deprecated(self):
-        dn = FakeDataNode("foo")
-        _DataManager._set(dn)
-        with pytest.warns(DeprecationWarning):
-            _DataManager._get(dn)
-        with pytest.warns(DeprecationWarning):
-            dn.scope
-
     def test_lock_edition_deprecated(self):
         dn = FakeDataNode("foo")
 


### PR DESCRIPTION
JR suggested that maybe some methods from VersionRepo could be in the manager, but the _set(latest, development, production) and _get(latest, development, production) specified in the version repos have in their core accesses and logic that are exclusively to each repository type, so I don't see a way to make them more generic at this momment. 

As a compromise, I've created an interface to be used on the version repositories to ensure that at least the methods signatures are the same across all of them. 

Let me know what do you think.