### PR TITLE
bug/#619 added publish events for missing function

### DIFF
--- a/src/taipy/core/_entity/_properties.py
+++ b/src/taipy/core/_entity/_properties.py
@@ -11,20 +11,10 @@
 
 from collections import UserDict
 
-from ..notification import EventEntityType, EventOperation, _publish_event
+from ..notification import _ENTITY_TO_EVENT_ENTITY_TYPE, EventOperation, _publish_event
 
 
 class _Properties(UserDict):
-
-    __ENTITY_TO_EVENT_ENTITY_TYPE = {
-        "scenario": EventEntityType.SCENARIO,
-        "pipeline": EventEntityType.PIPELINE,
-        "task": EventEntityType.TASK,
-        "data": EventEntityType.DATA_NODE,
-        "job": EventEntityType.JOB,
-        "cycle": EventEntityType.CYCLE,
-    }
-
     def __init__(self, entity_owner, **kwargs):
         super().__init__(**kwargs)
         self._entity_owner = entity_owner
@@ -36,7 +26,7 @@ class _Properties(UserDict):
         if hasattr(self, "_entity_owner"):
             tp.set(self._entity_owner)
             _publish_event(
-                self.__ENTITY_TO_EVENT_ENTITY_TYPE[self._entity_owner._MANAGER_NAME],
+                _ENTITY_TO_EVENT_ENTITY_TYPE[self._entity_owner._MANAGER_NAME],
                 self._entity_owner.id,
                 EventOperation.UPDATE,
                 key,

--- a/src/taipy/core/_entity/_reload.py
+++ b/src/taipy/core/_entity/_reload.py
@@ -11,7 +11,7 @@
 
 import functools
 
-from ..notification import EventEntityType, EventOperation, _publish_event
+from ..notification import EventOperation, _publish_event
 
 
 @functools.lru_cache

--- a/src/taipy/core/common/_listattributes.py
+++ b/src/taipy/core/common/_listattributes.py
@@ -28,7 +28,6 @@ class _ListAttributes(UserList):
             tp.set(self._parent)
 
     def __add__(self, value):
-        # TODO: publish event of changing attributes
         if hasattr(value, "__iter__"):
             self.__add_iterable(value)
         else:

--- a/src/taipy/core/notification/__init__.py
+++ b/src/taipy/core/notification/__init__.py
@@ -11,5 +11,5 @@
 
 
 from .core_event_consumer import CoreEventConsumerBase
-from .event import EventEntityType, EventOperation
+from .event import _ENTITY_TO_EVENT_ENTITY_TYPE, EventEntityType, EventOperation
 from .notifier import _publish_event

--- a/src/taipy/core/notification/event.py
+++ b/src/taipy/core/notification/event.py
@@ -34,6 +34,14 @@ class EventEntityType(_ReprEnum):
 
 _NO_ATTRIBUTE_NAME_OPERATIONS = set([EventOperation.CREATION, EventOperation.DELETION, EventOperation.SUBMISSION])
 _UNSUBMITTABLE_ENTITY_TYPES = (EventEntityType.CYCLE, EventEntityType.DATA_NODE, EventEntityType.JOB)
+_ENTITY_TO_EVENT_ENTITY_TYPE = {
+    "scenario": EventEntityType.SCENARIO,
+    "pipeline": EventEntityType.PIPELINE,
+    "task": EventEntityType.TASK,
+    "data": EventEntityType.DATA_NODE,
+    "job": EventEntityType.JOB,
+    "cycle": EventEntityType.CYCLE,
+}
 
 
 class Event:

--- a/src/taipy/core/pipeline/_pipeline_manager.py
+++ b/src/taipy/core/pipeline/_pipeline_manager.py
@@ -70,12 +70,12 @@ class _PipelineManager(_Manager[Pipeline]):
     @classmethod
     def __add_subscriber(cls, callback, params, pipeline):
         pipeline._add_subscriber(callback, params)
-        cls._set(pipeline)
+        _publish_event(cls._EVENT_ENTITY_TYPE, pipeline.id, EventOperation.UPDATE, "subscribers")
 
     @classmethod
     def __remove_subscriber(cls, callback, params, pipeline):
         pipeline._remove_subscriber(callback, params)
-        cls._set(pipeline)
+        _publish_event(cls._EVENT_ENTITY_TYPE, pipeline.id, EventOperation.UPDATE, "subscribers")
 
     @classmethod
     def _get_or_create(

--- a/src/taipy/core/scenario/_scenario_manager.py
+++ b/src/taipy/core/scenario/_scenario_manager.py
@@ -82,12 +82,12 @@ class _ScenarioManager(_Manager[Scenario]):
     @classmethod
     def __add_subscriber(cls, callback, params, scenario):
         scenario._add_subscriber(callback, params)
-        cls._set(scenario)
+        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "subscribers")
 
     @classmethod
     def __remove_subscriber(cls, callback, params, scenario):
         scenario._remove_subscriber(callback, params)
-        cls._set(scenario)
+        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "subscribers")
 
     @classmethod
     def _create(
@@ -208,10 +208,8 @@ class _ScenarioManager(_Manager[Scenario]):
         if scenario.cycle:
             primary_scenario = cls._get_primary(scenario.cycle)
             if primary_scenario:
-                primary_scenario._primary_scenario = False
-                cls._set(primary_scenario)
-            scenario._primary_scenario = True
-            cls._set(scenario)
+                primary_scenario.is_primary = False  # type: ignore
+            scenario.is_primary = True  # type: ignore
         else:
             raise DoesNotBelongToACycle(
                 f"Can't set scenario {scenario.id} to primary because it doesn't belong to a cycle."
@@ -229,11 +227,13 @@ class _ScenarioManager(_Manager[Scenario]):
                 cls._set(old_tagged_scenario)
         scenario._add_tag(tag)
         cls._set(scenario)
+        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "tags")
 
     @classmethod
     def _untag(cls, scenario: Scenario, tag: str):
         scenario._remove_tag(tag)
         cls._set(scenario)
+        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "tags")
 
     @classmethod
     def _delete(cls, scenario_id: ScenarioId):

--- a/tests/core/notification/test_notifier.py
+++ b/tests/core/notification/test_notifier.py
@@ -285,32 +285,56 @@ def test_publish_event():
 
     # Test UPDATE Event
 
-    scenario.is_primary = True
+    scenario.is_primary = False
     assert registration_queue.qsize() == 1
 
-    scenario.properties["flag"] = "production"
+    tp.set_primary(scenario)
     assert registration_queue.qsize() == 2
 
-    scenario.name = "my_scenario"
+    tp.subscribe_scenario(print, None, scenario=scenario)
     assert registration_queue.qsize() == 3
 
-    cycle.name = "new cycle name"
+    tp.unsubscribe_scenario(print, None, scenario=scenario)
     assert registration_queue.qsize() == 4
 
-    cycle.properties["valid"] = True
+    tp.tag(scenario, "testing")
     assert registration_queue.qsize() == 5
 
-    task.skippable = True
+    tp.untag(scenario, "testing")
     assert registration_queue.qsize() == 6
 
-    task.properties["number_of_run"] = 2
+    scenario.properties["flag"] = "production"
     assert registration_queue.qsize() == 7
 
-    dn.name = "new datanode name"
+    scenario.name = "my_scenario"
     assert registration_queue.qsize() == 8
 
-    dn.properties["sorted"] = True
+    cycle.name = "new cycle name"
     assert registration_queue.qsize() == 9
+
+    cycle.properties["valid"] = True
+    assert registration_queue.qsize() == 10
+
+    pipeline.properties["name"] = "weather_forecast"
+    assert registration_queue.qsize() == 11
+
+    tp.subscribe_pipeline(print, None, pipeline)
+    assert registration_queue.qsize() == 12
+
+    tp.unsubscribe_pipeline(print, None, pipeline)
+    assert registration_queue.qsize() == 13
+
+    task.skippable = True
+    assert registration_queue.qsize() == 14
+
+    task.properties["number_of_run"] = 2
+    assert registration_queue.qsize() == 15
+
+    dn.name = "new datanode name"
+    assert registration_queue.qsize() == 16
+
+    dn.properties["sorted"] = True
+    assert registration_queue.qsize() == 17
 
     published_events = []
     while registration_queue.qsize() != 0:
@@ -320,8 +344,16 @@ def test_publish_event():
         EventEntityType.SCENARIO,
         EventEntityType.SCENARIO,
         EventEntityType.SCENARIO,
+        EventEntityType.SCENARIO,
+        EventEntityType.SCENARIO,
+        EventEntityType.SCENARIO,
+        EventEntityType.SCENARIO,
+        EventEntityType.SCENARIO,
         EventEntityType.CYCLE,
         EventEntityType.CYCLE,
+        EventEntityType.PIPELINE,
+        EventEntityType.PIPELINE,
+        EventEntityType.PIPELINE,
         EventEntityType.TASK,
         EventEntityType.TASK,
         EventEntityType.DATA_NODE,
@@ -329,10 +361,18 @@ def test_publish_event():
     ]
     expected_attribute_names = [
         "is_primary",
+        "is_primary",
+        "subscribers",
+        "subscribers",
+        "tags",
+        "tags",
         "flag",
         "name",
         "name",
         "valid",
+        "name",
+        "subscribers",
+        "subscribers",
         "skippable",
         "number_of_run",
         "name",
@@ -342,8 +382,16 @@ def test_publish_event():
         scenario.id,
         scenario.id,
         scenario.id,
+        scenario.id,
+        scenario.id,
+        scenario.id,
+        scenario.id,
+        scenario.id,
         cycle.id,
         cycle.id,
+        pipeline.id,
+        pipeline.id,
+        pipeline.id,
         task.id,
         task.id,
         dn.id,


### PR DESCRIPTION
Added publish event in:
- subscribe callbacks
- tags
- set primary

Note:
List attribute class still doesn't publish event when add or remove items. The reason is that we cannot determine with the code which attribute is having type ListAttributes (only "subscribers" but I don't have a way to pick that out in the code atm) and so we can't publish an update event without knowing the attribute. One possible solution is to use `vars` to look for attribute that have the same value as the list attribute object.