### PR TITLE
upd: update sqlalchemy to version 2.0.16

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ networkx = "==2.6"
 openpyxl = "==3.0.7"
 pyarrow = "==10.0.1"
 pymongo = "==4.2.0"
-sqlalchemy = "==1.4.18"
+sqlalchemy = "==2.0.16"
 toml = "==0.10"
 taipy-config = {git = "https://git@github.com/avaiga/taipy-config.git@develop"}
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
     "openpyxl>=3.0.7,<3.1",
     "modin[dask]>=0.16.2,<1.0",
     "pymongo>=4.2.0,<5.0",
-    "sqlalchemy>=1.4,<2.0",
+    "sqlalchemy>2.0",
     "toml>=0.10,<0.11",
     "taipy-config@git+https://git@github.com/Avaiga/taipy-config.git@develop",
 ]

--- a/src/taipy/core/data/abstract_sql.py
+++ b/src/taipy/core/data/abstract_sql.py
@@ -204,9 +204,10 @@ class _AbstractSQLDataNode(DataNode):
         return self._read_as_pandas_dataframe().to_numpy()
 
     def _read_as_pandas_dataframe(self, columns: Optional[List[str]] = None):
-        if columns:
-            return pd.read_sql_query(self._get_read_query(), con=self._get_engine())[columns]
-        return pd.read_sql_query(self._get_read_query(), con=self._get_engine())
+        with self._get_engine().connect() as conn:
+            if columns:
+                return pd.DataFrame(conn.execute(text(self._get_read_query())))[columns]
+            return pd.DataFrame(conn.execute(text(self._get_read_query())))
 
     def _read_as_modin_dataframe(self, columns: Optional[List[str]] = None):
         if columns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,12 +126,12 @@ def tmp_sqlite_db_file_path(tmpdir_factory):
     fn = tmpdir_factory.mktemp("data")
     db_name = "df"
     file_extension = ".db"
-
     db = create_engine("sqlite:///" + os.path.join(fn.strpath, f"{db_name}{file_extension}"))
     conn = db.connect()
     conn.execute(text("CREATE TABLE example (a int, b int, c int);"))
     conn.execute(text("INSERT INTO example (a, b, c) VALUES (1, 2, 3);"))
     conn.execute(text("INSERT INTO example (a, b, c) VALUES (4, 5, 6);"))
+    conn.commit()
     conn.close()
     db.dispose()
 
@@ -149,6 +149,7 @@ def tmp_sqlite_sqlite3_file_path(tmpdir_factory):
     conn.execute(text("CREATE TABLE example (a int, b int, c int);"))
     conn.execute(text("INSERT INTO example (a, b, c) VALUES (1, 2, 3);"))
     conn.execute(text("INSERT INTO example (a, b, c) VALUES (4, 5, 6);"))
+    conn.commit()
     conn.close()
     db.dispose()
 

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -277,5 +277,4 @@ class TestSQLDataNode:
 
         dn = SQLDataNode("sqlite_dn", Scope.PIPELINE, properties=properties)
         data = dn.read()
-
         assert data.equals(pd.DataFrame([{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]))


### PR DESCRIPTION
Because we are stuck in an older version of pandas, I had to change a little how we read the data from a SQL Table into a dataframe, because SQLAlchemy deprecated a form of connection in version 2 that is used by our version of pandas.  Otherwise should be the same performance and result as before, just maybe a little less readable.

Do you want to merge it into 2.3 or should we wait and do a 2.3.1 later?