### PR TITLE
Fix - Remove version setter from entities

### DIFF
--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -243,7 +243,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
             from taipy.logger._taipy_logger import _TaipyLogger
 
             _TaipyLogger._get_logger().warning(
-                f"Entity {entity.id} has automatically been assigned to version named " f"{entity.version}"
+                f"Entity {entity.id} has automatically been assigned to version named " f"{entity._version}"
             )
         return entity
 

--- a/src/taipy/core/_repository/_sql_repository.py
+++ b/src/taipy/core/_repository/_sql_repository.py
@@ -256,7 +256,7 @@ class _TaipyModelTable(_BaseSQLRepository[ModelType, Entity]):
             from taipy.logger._taipy_logger import _TaipyLogger
 
             _TaipyLogger._get_logger().warning(
-                f"Entity {entity.id} has automatically been assigned to version named " f"{entity.version}"
+                f"Entity {entity.id} has automatically been assigned to version named " f"{entity._version}"
             )
         return entity
 
@@ -385,7 +385,7 @@ class _TaipyVersionTable(_BaseSQLRepository[ModelType, Entity]):
             from taipy.logger._taipy_logger import _TaipyLogger
 
             _TaipyLogger._get_logger().warning(
-                f"Entity {entity.id} has automatically been assigned to version named " f"{entity.version}"
+                f"Entity {entity.id} has automatically been assigned to version named " f"{entity._version}"
             )
         return entity
 

--- a/src/taipy/core/_version/_utils.py
+++ b/src/taipy/core/_version/_utils.py
@@ -31,10 +31,10 @@ def _migrate_entity(entity):
     if (
         latest_version := _VersionManagerFactory._build_manager()._get_latest_version()
     ) in _VersionManagerFactory._build_manager()._get_production_versions():
-        if migration_fcts := MigrationConfig._get_migration_fcts_to_latest(entity.version, entity.config_id):
+        if migration_fcts := MigrationConfig._get_migration_fcts_to_latest(entity._version, entity.config_id):
             with _Reloader():
                 for fct in migration_fcts:
                     entity = fct(entity)
-                entity.version = latest_version
+                entity._version = latest_version
 
     return entity

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -225,10 +225,6 @@ class DataNode(_Entity, _Labeled):
     def version(self):
         return self._version
 
-    @version.setter
-    def version(self, val):
-        self._version = val
-
     @property
     def cacheable(self):
         """Deprecated. Use `skippable` attribute of a `Task^` instead."""

--- a/src/taipy/core/job/_job_converter.py
+++ b/src/taipy/core/job/_job_converter.py
@@ -33,7 +33,7 @@ class _JobConverter(_AbstractConverter):
             job._creation_date.isoformat(),
             cls._serialize_subscribers(job._subscribers),
             job._stacktrace,
-            version=job.version,
+            version=job._version,
         )
 
     @classmethod

--- a/src/taipy/core/job/job.py
+++ b/src/taipy/core/job/job.py
@@ -128,10 +128,6 @@ class Job(_Entity, _Labeled):
     def version(self):
         return self._version
 
-    @version.setter
-    def version(self, val):
-        self._version = val
-
     def __contains__(self, task: Task):
         return self.task.id == task.id
 
@@ -329,7 +325,7 @@ class Job(_Entity, _Labeled):
             entity._creation_date.isoformat(),
             cls._serialize_subscribers(entity._subscribers),
             entity._stacktrace,
-            version=entity.version,
+            version=entity._version,
         )
 
     @classmethod

--- a/src/taipy/core/pipeline/_pipeline_converter.py
+++ b/src/taipy/core/pipeline/_pipeline_converter.py
@@ -39,7 +39,7 @@ class _PipelineConverter(_AbstractConverter):
             pipeline._properties.data,
             cls.__to_task_ids(pipeline._tasks),
             _utils._fcts_to_dict(pipeline._subscribers),
-            pipeline.version,
+            pipeline._version,
         )
 
     @classmethod

--- a/src/taipy/core/pipeline/pipeline.py
+++ b/src/taipy/core/pipeline/pipeline.py
@@ -156,10 +156,6 @@ class Pipeline(_Entity, _Submittable, _Labeled):
     def version(self):
         return self._version
 
-    @version.setter
-    def version(self, val):
-        self._version = val
-
     @property
     def properties(self):
         self._properties = _Reloader()._reload("pipeline", self)._properties
@@ -296,7 +292,7 @@ class Pipeline(_Entity, _Submittable, _Labeled):
             pipeline._properties.data,
             cls.__to_task_ids(pipeline._tasks),
             _utils._fcts_to_dict(pipeline._subscribers),
-            pipeline.version,
+            pipeline._version,
         )
 
     @classmethod

--- a/src/taipy/core/scenario/_scenario_converter.py
+++ b/src/taipy/core/scenario/_scenario_converter.py
@@ -34,7 +34,7 @@ class _ScenarioConverter(_AbstractConverter):
             primary_scenario=scenario._primary_scenario,
             subscribers=_utils._fcts_to_dict(scenario._subscribers),
             tags=list(scenario._tags),
-            version=scenario.version,
+            version=scenario._version,
             cycle=scenario._cycle.id if scenario._cycle else None,
         )
 

--- a/src/taipy/core/scenario/scenario.py
+++ b/src/taipy/core/scenario/scenario.py
@@ -223,10 +223,6 @@ class Scenario(_Entity, _Submittable, _Labeled):
     def version(self):
         return self._version
 
-    @version.setter
-    def version(self, val):
-        self._version = val
-
     @property
     def owner_id(self):
         return self._cycle.id
@@ -405,7 +401,7 @@ class Scenario(_Entity, _Submittable, _Labeled):
             primary_scenario=entity._primary_scenario,
             subscribers=_utils._fcts_to_dict(entity._subscribers),
             tags=list(entity._tags),
-            version=entity.version,
+            version=entity._version,
             cycle=cls.__to_cycle_id(entity._cycle),
         )
 

--- a/src/taipy/core/task/_task_converter.py
+++ b/src/taipy/core/task/_task_converter.py
@@ -32,7 +32,7 @@ class _TaskConverter(_AbstractConverter):
             function_name=task._function.__name__,
             function_module=task._function.__module__,
             output_ids=cls.__to_ids(task.output.values()),
-            version=task.version,
+            version=task._version,
             skippable=task._skippable,
             properties=task._properties.data.copy(),
         )

--- a/src/taipy/core/task/task.py
+++ b/src/taipy/core/task/task.py
@@ -180,10 +180,6 @@ class Task(_Entity, _Labeled):
     def version(self):
         return self._version
 
-    @version.setter
-    def version(self, val):
-        self._version = val
-
     def submit(
         self,
         callbacks: Optional[List[Callable]] = None,
@@ -220,7 +216,7 @@ class Task(_Entity, _Labeled):
             function_name=task._function.__name__,
             function_module=task._function.__module__,
             output_ids=cls.__to_ids(task.output.values()),
-            version=task.version,
+            version=task._version,
             skippable=task._skippable,
             properties=task._properties.data.copy(),
         )

--- a/tests/core/_manager/test_manager.py
+++ b/tests/core/_manager/test_manager.py
@@ -42,15 +42,15 @@ class MockEntity:
         self.id = id
         self.name = name
         if version:
-            self.version = version
+            self._version = version
         else:
-            self.version = _VersionManager._get_latest_version()
+            self._version = _VersionManager._get_latest_version()
 
 
 class MockConverter(_AbstractConverter):
     @classmethod
     def _entity_to_model(cls, entity: MockEntity) -> MockModel:
-        return MockModel(id=entity.id, name=entity.name, version=entity.version)
+        return MockModel(id=entity.id, name=entity.name, version=entity._version)
 
     @classmethod
     def _model_to_entity(cls, model: MockModel) -> MockEntity:
@@ -62,7 +62,7 @@ class MockRepository(_AbstractRepository):  # type: ignore
         self.repo = _FileSystemRepository(**kwargs, converter=MockConverter)
 
     def _to_model(self, obj: MockEntity):
-        return MockModel(obj.id, obj.name, obj.version)
+        return MockModel(obj.id, obj.name, obj._version)
 
     def _from_model(self, model: MockModel):
         return MockEntity(model.id, model.name, model.version)

--- a/tests/core/repository/mocks.py
+++ b/tests/core/repository/mocks.py
@@ -39,9 +39,9 @@ class MockObj:
         self.id = id
         self.name = name
         if version:
-            self.version = version
+            self._version = version
         else:
-            self.version = _VersionManager._get_latest_version()
+            self._version = _VersionManager._get_latest_version()
 
 
 @dataclass
@@ -69,13 +69,13 @@ class MockModel(Base):  # type: ignore
 
     @classmethod
     def _from_entity(cls, entity: MockObj):
-        return MockModel(id=entity.id, name=entity.name, version=entity.version)
+        return MockModel(id=entity.id, name=entity.name, version=entity._version)
 
 
 class MockConverter(_AbstractConverter):
     @classmethod
     def _entity_to_model(cls, entity):
-        return MockModel(id=entity.id, name=entity.name, version=entity.version)
+        return MockModel(id=entity.id, name=entity.name, version=entity._version)
 
     @classmethod
     def _model_to_entity(cls, model):
@@ -88,7 +88,7 @@ class MockFSRepository(_FileSystemRepository):
         super().__init__(**kwargs)
 
     def _to_model(self, obj: MockObj):
-        return MockModel(obj.id, obj.name, obj.version)
+        return MockModel(obj.id, obj.name, obj._version)
 
     def _from_model(self, model: MockModel):
         return MockObj(model.id, model.name, model.version)
@@ -113,7 +113,7 @@ class MockSQLRepository(_SQLRepository):
         super().__init__(**kwargs)
 
     def _to_model(self, obj: MockObj):
-        return MockModel(obj.id, obj.name, obj.version)
+        return MockModel(obj.id, obj.name, obj._version)
 
     def _from_model(self, model: MockModel):
         return MockObj(model.id, model.name, model.version)


### PR DESCRIPTION
In https://github.com/Avaiga/taipy-core/pull/578, @jrobinAV said:
> Here you are exposing the possibility for a user to modify manually the version of an entity. Isn't it too risky? Can we keep it hidden or private?

This PR removes the version setter from all entities.