### PR TITLE
Fix/ Inconsistent failing CLI test on SQL repo

### DIFF
--- a/tests/core/test_core_cli_with_sql_repo.py
+++ b/tests/core/test_core_cli_with_sql_repo.py
@@ -551,10 +551,12 @@ def test_modify_job_configuration_dont_stop_application(caplog, tmp_sqlite):
 
     with patch("sys.argv", ["prog", "--experiment", "1.0"]):
         Config.configure_job_executions(mode="development")
-        Core().run(force_restart=True)
+        core = Core()
+        core.run(force_restart=True)
     scenario = _ScenarioManager._create(scenario_config)
     jobs = _ScenarioManager._submit(scenario)
     assert all([job.is_finished() for job in jobs])
+    core.stop()
 
     init_config()
     Config.configure_global_app(repository_type="sql", repository_properties={"db_location": tmp_sqlite})
@@ -563,7 +565,8 @@ def test_modify_job_configuration_dont_stop_application(caplog, tmp_sqlite):
 
     with patch("sys.argv", ["prog", "--experiment", "1.0"]):
         Config.configure_job_executions(mode="standalone", max_nb_of_workers=2)
-        Core().run(force_restart=True)
+        core = Core()
+        core.run(force_restart=True)
     scenario = _ScenarioManager._create(scenario_config)
 
     jobs = _ScenarioManager._submit(scenario)
@@ -571,6 +574,8 @@ def test_modify_job_configuration_dont_stop_application(caplog, tmp_sqlite):
     error_message = str(caplog.text)
     assert 'JOB "mode" was modified' in error_message
     assert 'JOB "max_nb_of_workers" was modified' in error_message
+    core.stop()
+    assert_true_after_time(lambda: core._dispatcher is None)
 
 
 def twice(a):


### PR DESCRIPTION
The problem was that in `test_modify_job_configuration_dont_stop_application()` test, child processes open SQL session.
And on the next `test_modify_config_properties_without_force()` test, trying to execute an SQL query sometimes can fail because the child processes are not killed yet.

In this PR:
- `test_modify_job_configuration_dont_stop_application()` is moved to be the last test.