### PR TITLE
Hotfix[2.3.2]/#470 - Rename configure_default_..() methods to set_default_..()

### DIFF
--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -44,6 +44,7 @@ _inject_section(
     [
         ("configure_data_node", DataNodeConfig._configure),
         ("configure_default_data_node", DataNodeConfig._configure_default),
+        ("set_default_data_node_configuration", DataNodeConfig._set_default_configuration),
         ("configure_csv_data_node", DataNodeConfig._configure_csv),
         ("configure_json_data_node", DataNodeConfig._configure_json),
         ("configure_parquet_data_node", DataNodeConfig._configure_parquet),
@@ -60,7 +61,11 @@ _inject_section(
     TaskConfig,
     "tasks",
     TaskConfig.default_config(),
-    [("configure_task", TaskConfig._configure), ("configure_default_task", TaskConfig._configure_default)],
+    [
+        ("configure_task", TaskConfig._configure),
+        ("configure_default_task", TaskConfig._configure_default),
+        ("set_default_task_configuration", TaskConfig._set_default_configuration),
+    ],
 )
 _inject_section(
     PipelineConfig,
@@ -69,6 +74,7 @@ _inject_section(
     [
         ("configure_pipeline", PipelineConfig._configure),
         ("configure_default_pipeline", PipelineConfig._configure_default),
+        ("set_default_pipeline_configuration", PipelineConfig._set_default_configuration),
     ],
 )
 _inject_section(
@@ -78,6 +84,7 @@ _inject_section(
     [
         ("configure_scenario", ScenarioConfig._configure),
         ("configure_default_scenario", ScenarioConfig._configure_default),
+        ("set_default_scenario_configuration", ScenarioConfig._set_default_configuration),
         ("configure_scenario_from_tasks", ScenarioConfig._configure_from_tasks),
     ],
 )

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -362,7 +362,7 @@ class DataNodeConfig(Section):
         storage_type: str, scope: Optional[Scope] = None, validity_period: Optional[timedelta] = None, **properties
     ) -> "DataNodeConfig":
         """
-        Deprecated. Use set_default_data_node_configuration instead.
+        Deprecated since taipy version 2.3.2. Use set_default_data_node_configuration instead.
         """
         _warn_deprecated("configure_default_data_node", suggest="set_default_data_node_configuration")
         return DataNodeConfig._set_default_configuration(storage_type, scope, validity_period, **properties)

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -361,7 +361,17 @@ class DataNodeConfig(Section):
     def _configure_default(
         storage_type: str, scope: Optional[Scope] = None, validity_period: Optional[timedelta] = None, **properties
     ) -> "DataNodeConfig":
-        """Configure the default values for data node configurations.
+        """
+        Deprecated. Use set_default_data_node_configuration instead.
+        """
+        _warn_deprecated("configure_default_data_node", suggest="set_default_data_node_configuration")
+        return DataNodeConfig._set_default_configuration(storage_type, scope, validity_period, **properties)
+
+    @staticmethod
+    def _set_default_configuration(
+        storage_type: str, scope: Optional[Scope] = None, validity_period: Optional[timedelta] = None, **properties
+    ) -> "DataNodeConfig":
+        """Set the default values for data node configurations.
 
         This function creates the _default data node configuration_ object,
         where all data node configuration objects will find their default
@@ -404,12 +414,12 @@ class DataNodeConfig(Section):
             storage_type (Optional[str]): The data node configuration storage type. The possible values
                 are None (which is the default value of *"pickle"*, unless it has been overloaded by the
                 *storage_type* value set in the default data node configuration
-                (see `(Config.)configure_default_data_node()^`)), *"pickle"*, *"csv"*, *"excel"*,
+                (see `(Config.)set_default_data_node_configuration()^`)), *"pickle"*, *"csv"*, *"excel"*,
                 *"sql_table"*, *"sql"*, *"json"*, *"parquet"*, *"mongo_collection"*, *"in_memory"*, or
                 *"generic"*.
             scope (Optional[Scope^]): The scope of the data node configuration.<br/>
                 The default value is `Scope.SCENARIO` (or the one specified in
-                `(Config.)configure_default_data_node()^`).
+                `(Config.)set_default_data_node_configuration()^`).
             validity_period (Optional[timedelta]): The duration since the last edit date for which the data node can be
                 considered up-to-date. Once the validity period has passed, the data node is considered stale and
                 relevant tasks will run even if they are skippable (see the

--- a/src/taipy/core/config/pipeline_config.py
+++ b/src/taipy/core/config/pipeline_config.py
@@ -106,7 +106,15 @@ class PipelineConfig(Section):
 
     @staticmethod
     def _configure_default(task_configs: Union[TaskConfig, List[TaskConfig]], **properties) -> "PipelineConfig":
-        """Configure the default values for pipeline configurations.
+        """
+        Deprecated. Use set_default_pipeline_configuration() instead.
+        """
+        _warn_deprecated("configure_default_pipeline", suggest="set_default_pipeline_configuration")
+        return PipelineConfig._set_default_configuration(task_configs, **properties)
+
+    @staticmethod
+    def _set_default_configuration(task_configs: Union[TaskConfig, List[TaskConfig]], **properties) -> "PipelineConfig":
+        """Set the default values for pipeline configurations.
 
         This function creates the *default pipeline configuration* object,
         where all pipeline configuration objects will find their default

--- a/src/taipy/core/config/pipeline_config.py
+++ b/src/taipy/core/config/pipeline_config.py
@@ -107,7 +107,7 @@ class PipelineConfig(Section):
     @staticmethod
     def _configure_default(task_configs: Union[TaskConfig, List[TaskConfig]], **properties) -> "PipelineConfig":
         """
-        Deprecated. Use set_default_pipeline_configuration() instead.
+        Deprecated since taipy version 2.3.2. Use set_default_pipeline_configuration() instead.
         """
         _warn_deprecated("configure_default_pipeline", suggest="set_default_pipeline_configuration")
         return PipelineConfig._set_default_configuration(task_configs, **properties)

--- a/src/taipy/core/config/scenario_config.py
+++ b/src/taipy/core/config/scenario_config.py
@@ -215,7 +215,20 @@ class ScenarioConfig(Section):
         comparators: Optional[Dict[str, Union[List[Callable], Callable]]] = None,
         **properties,
     ) -> "ScenarioConfig":
-        """Configure the default values for scenario configurations.
+        """
+        Deprecated. Use set_default_scenario_configuration() instead.
+        """
+        _warn_deprecated("configure_default_scenario", suggest="set_default_scenario_configuration")
+        return ScenarioConfig._set_default_configuration(pipeline_configs, frequency, comparators, **properties)
+
+    @staticmethod
+    def _set_default_configuration(
+        pipeline_configs: List[PipelineConfig],
+        frequency: Optional[Frequency] = None,
+        comparators: Optional[Dict[str, Union[List[Callable], Callable]]] = None,
+        **properties,
+    ) -> "ScenarioConfig":
+        """Set the default values for scenario configurations.
 
         This function creates the *default scenario configuration* object,
         where all scenario configuration objects will find their default

--- a/src/taipy/core/config/scenario_config.py
+++ b/src/taipy/core/config/scenario_config.py
@@ -216,7 +216,7 @@ class ScenarioConfig(Section):
         **properties,
     ) -> "ScenarioConfig":
         """
-        Deprecated. Use set_default_scenario_configuration() instead.
+        Deprecated since taipy version 2.3.2. Use set_default_scenario_configuration() instead.
         """
         _warn_deprecated("configure_default_scenario", suggest="set_default_scenario_configuration")
         return ScenarioConfig._set_default_configuration(pipeline_configs, frequency, comparators, **properties)

--- a/src/taipy/core/config/task_config.py
+++ b/src/taipy/core/config/task_config.py
@@ -193,7 +193,7 @@ class TaskConfig(Section):
         **properties,
     ) -> "TaskConfig":
         """
-        Deprecated. Use set_default_task_configuration() instead.
+        Deprecated since taipy version 2.3.2. Use set_default_task_configuration() instead.
         """
         _warn_deprecated("configure_default_task", suggest="set_default_task_configuration")
         return TaskConfig._set_default_configuration(function, input, output, skippable, **properties)

--- a/src/taipy/core/config/task_config.py
+++ b/src/taipy/core/config/task_config.py
@@ -192,7 +192,21 @@ class TaskConfig(Section):
         skippable: Optional[bool] = False,
         **properties,
     ) -> "TaskConfig":
-        """Configure the default values for task configurations.
+        """
+        Deprecated. Use set_default_task_configuration() instead.
+        """
+        _warn_deprecated("configure_default_task", suggest="set_default_task_configuration")
+        return TaskConfig._set_default_configuration(function, input, output, skippable, **properties)
+
+    @staticmethod
+    def _set_default_configuration(
+        function,
+        input: Optional[Union[DataNodeConfig, List[DataNodeConfig]]] = None,
+        output: Optional[Union[DataNodeConfig, List[DataNodeConfig]]] = None,
+        skippable: Optional[bool] = False,
+        **properties,
+    ) -> "TaskConfig":
+        """Sets the default values for task configurations.
 
         This function creates the *default task configuration* object,
         where all task configuration objects will find their default

--- a/src/taipy/core/version.json
+++ b/src/taipy/core/version.json
@@ -1,1 +1,1 @@
-{"major": 2, "minor": 3, "patch": 1}
+{"major": 2, "minor": 3, "patch": 2}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,7 @@ def init_config():
         [
             ("configure_data_node", DataNodeConfig._configure),
             ("configure_default_data_node", DataNodeConfig._configure_default),
+            ("set_default_data_node_configuration", DataNodeConfig._set_default_configuration),
             ("configure_csv_data_node", DataNodeConfig._configure_csv),
             ("configure_json_data_node", DataNodeConfig._configure_json),
             ("configure_sql_table_data_node", DataNodeConfig._configure_sql_table),
@@ -348,7 +349,11 @@ def init_config():
         TaskConfig,
         "tasks",
         TaskConfig.default_config(),
-        [("configure_task", TaskConfig._configure), ("configure_default_task", TaskConfig._configure_default)],
+        [
+            ("configure_task", TaskConfig._configure),
+            ("configure_default_task", TaskConfig._configure_default),
+            ("set_default_task_configuration", TaskConfig._set_default_configuration),
+        ],
     )
     _inject_section(
         PipelineConfig,
@@ -357,6 +362,7 @@ def init_config():
         [
             ("configure_pipeline", PipelineConfig._configure),
             ("configure_default_pipeline", PipelineConfig._configure_default),
+            ("set_default_pipeline_configuration", PipelineConfig._set_default_configuration),
         ],
     )
     _inject_section(
@@ -366,6 +372,7 @@ def init_config():
         [
             ("configure_scenario", ScenarioConfig._configure),
             ("configure_default_scenario", ScenarioConfig._configure_default),
+            ("set_default_scenario_configuration", ScenarioConfig._set_default_configuration),
             ("configure_scenario_from_tasks", ScenarioConfig._configure_from_tasks),
         ],
     )

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -12,38 +12,40 @@
 import json
 from datetime import timedelta
 
+import pytest
+
 from src.taipy.core.common.default_custom_document import DefaultCustomDocument
 from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 
 
-def test_configure_default_data_node():
+def test_set_default_data_node_configuration():
     data_node1 = Config.configure_data_node(id="input_data1")
     assert data_node1.storage_type == "pickle"
     assert data_node1.scope == Scope.SCENARIO
     assert data_node1.validity_period is None
 
-    Config.configure_default_data_node("in_memory", scope=Scope.GLOBAL)
+    Config.set_default_data_node_configuration("in_memory", scope=Scope.GLOBAL)
     data_node2 = Config.configure_data_node(id="input_data2")
     assert data_node2.storage_type == "in_memory"
     assert data_node2.scope == Scope.GLOBAL
     assert data_node2.validity_period is None
 
-    Config.configure_default_data_node("csv")
+    Config.set_default_data_node_configuration("csv")
     data_node3 = Config.configure_data_node(id="input_data3")
     assert data_node3.storage_type == "csv"
     assert data_node3.scope == Scope.SCENARIO
     assert data_node3.validity_period is None
 
-    Config.configure_default_data_node("json", validity_period=timedelta(1))
+    Config.set_default_data_node_configuration("json", validity_period=timedelta(1))
     data_node4 = Config.configure_data_node(id="input_data4")
     assert data_node4.storage_type == "json"
     assert data_node4.scope == Scope.SCENARIO
     assert data_node4.validity_period == timedelta(1)
 
 
-def test_configure_default_data_node_replace_old_default_config():
-    Config.configure_default_data_node(
+def test_set_default_data_node_configuration_replace_old_default_config():
+    Config.set_default_data_node_configuration(
         "in_memory",
         prop1="1",
         prop2="2",
@@ -52,7 +54,7 @@ def test_configure_default_data_node_replace_old_default_config():
     dn1 = Config.configure_data_node(id="dn1")
     assert len(dn1.properties) == 3
 
-    Config.configure_default_data_node(
+    Config.set_default_data_node_configuration(
         "csv",
         prop4="4",
         prop5="5",
@@ -70,7 +72,7 @@ def test_configure_default_data_node_replace_old_default_config():
 
 
 def test_config_storage_type_different_from_default_data_node():
-    Config.configure_default_data_node(
+    Config.set_default_data_node_configuration(
         storage_type="pickle",
         custom_property={"foo": "bar"},
         scope=Scope.GLOBAL,
@@ -84,8 +86,8 @@ def test_config_storage_type_different_from_default_data_node():
     assert csv_dn.scope == Scope.SCENARIO
 
 
-def test_configure_default_csv_data_node():
-    Config.configure_default_data_node(
+def test_set_default_csv_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="csv",
         default_path="default.csv",
         has_header=False,
@@ -131,14 +133,14 @@ def test_configure_default_csv_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_json_data_node():
+def test_set_default_json_data_node_configuration():
     class MyCustomEncoder(json.JSONEncoder):
         ...
 
     class MyCustomDecoder(json.JSONDecoder):
         ...
 
-    Config.configure_default_data_node(
+    Config.set_default_data_node_configuration(
         storage_type="json",
         default_path="default.json",
         encoder=MyCustomEncoder,
@@ -183,8 +185,8 @@ def test_configure_default_json_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_parquet_data_node():
-    Config.configure_default_data_node(
+def test_set_default_parquet_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="parquet",
         default_path="default.parquet",
         compression="gzip",
@@ -244,8 +246,8 @@ def test_configure_default_parquet_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_excel_data_node():
-    Config.configure_default_data_node(
+def test_set_default_excel_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="excel",
         default_path="default.xlsx",
         has_header=False,
@@ -294,8 +296,8 @@ def test_configure_default_excel_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_pickle_data_node():
-    Config.configure_default_data_node(
+def test_set_default_pickle_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="pickle",
         default_data=1,
         exposed_type="numpy",
@@ -340,8 +342,8 @@ def test_configure_default_pickle_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_sql_table_data_node():
-    Config.configure_default_data_node(
+def test_set_default_sql_table_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="sql_table",
         db_username="default_user",
         db_password="default_pwd",
@@ -419,11 +421,11 @@ def test_configure_default_sql_table_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_sql_data_node():
+def test_set_default_sql_data_node_configuration():
     def query_builder():
         ...
 
-    Config.configure_default_data_node(
+    Config.set_default_data_node_configuration(
         storage_type="sql",
         db_username="default_user",
         db_password="default_pwd",
@@ -503,8 +505,8 @@ def test_configure_default_sql_data_node():
     assert dn3.validity_period == timedelta(1)
 
 
-def test_configure_default_mongo_collection_data_node():
-    Config.configure_default_data_node(
+def test_set_default_mongo_collection_data_node_configuration():
+    Config.set_default_data_node_configuration(
         storage_type="mongo_collection",
         db_name="default_db_name",
         collection_name="default_collection",
@@ -574,3 +576,17 @@ def test_configure_default_mongo_collection_data_node():
     assert dn3.db_extra_args == {"default": "default"}
     assert dn3.scope == Scope.GLOBAL
     assert dn3.validity_period == timedelta(1)
+
+
+def test_configure_default_deprecated():
+    with pytest.warns(DeprecationWarning):
+        Config.configure_default_data_node("in_memory", scope=Scope.GLOBAL)
+
+    with pytest.warns(DeprecationWarning):
+        Config.configure_default_task(print)
+
+    with pytest.warns(DeprecationWarning):
+        Config.configure_default_pipeline([])
+
+    with pytest.warns(DeprecationWarning):
+        Config.configure_default_scenario([])

--- a/tests/core/config/test_file_config.py
+++ b/tests/core/config/test_file_config.py
@@ -100,7 +100,7 @@ owner = "Raymond Kopa"
     ):
         Config.configure_global_app(clean_entities_enabled=True)
         Config.configure_job_executions(mode="standalone", max_nb_of_workers=2)
-        Config.configure_default_data_node(
+        Config.set_default_data_node_configuration(
             storage_type="in_memory",
             custom="default_custom_prop",
             validity_period=timedelta(1),
@@ -121,7 +121,7 @@ owner = "Raymond Kopa"
         assert dn2_cfg_v2.scope == Scope.SCENARIO
         t1_cfg_v2 = Config.configure_task("t1", print, dn1_cfg_v2, dn2_cfg_v2, description="t1 description")
         p1_cfg_v2 = Config.configure_pipeline("p1", t1_cfg_v2, cron="daily")
-        Config.configure_default_scenario([], Frequency.QUARTERLY, owner="Michel Platini")
+        Config.set_default_scenario_configuration([], Frequency.QUARTERLY, owner="Michel Platini")
         Config.configure_scenario("s1", p1_cfg_v2, frequency=Frequency.QUARTERLY, owner="Raymond Kopa")
         Config.backup(tf.filename)
         actual_config = tf.read().strip()

--- a/tests/core/config/test_pipeline_config.py
+++ b/tests/core/config/test_pipeline_config.py
@@ -100,4 +100,4 @@ def test_pipeline_config_configure_deprecated():
         Config.configure_pipeline("pipeline_id", [])
 
     with pytest.warns(DeprecationWarning):
-        Config.configure_default_pipeline([])
+        Config.set_default_pipeline_configuration([])

--- a/tests/core/config/test_scenario_config.py
+++ b/tests/core/config/test_scenario_config.py
@@ -167,7 +167,7 @@ def test_clean_config():
 
 
 def test_pipeline_config_configure_deprecated():
-    pipeline_config = Config.configure_default_pipeline([])
+    pipeline_config = Config.set_default_pipeline_configuration([])
     scenario_config = Config.configure_scenario("scenario_id", pipeline_configs=[pipeline_config])
     with pytest.warns(DeprecationWarning):
         scenario_config.pipelines

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -555,7 +555,7 @@ class TestDataManager:
         from src.taipy import core as tp
 
         Config.load(file_config.filename)
-        Config.configure_default_data_node(storage_type="csv")
+        Config.set_default_data_node_configuration(storage_type="csv")
         scenario = tp.create_scenario(Config.scenarios["my_scenario"])
 
         # assert isinstance(scenario.input, CSVDataNode) TODO Replace the next line by the commented one.


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/470

In this PR:
- `configure_default_data_node()` is deprecated and renamed to `set_default_data_node_configuration()`
- `configure_default_task()` is deprecated and renamed to `set_default_task_configuration()`
- `configure_default_pipeline()` is deprecated and renamed to `set_default_pipeline_configuration()`
- `configure_default_scenario()` is deprecated and renamed to `set_default_scenario_configuration()`