### PR TITLE
Fix/#697 - Performance issue when creating a new scenario

### DIFF
--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -19,7 +19,7 @@ from taipy.config.config import Config
 
 from ..common._utils import _retry_read_entity
 from ..common.typing import Converter, Entity, Json, ModelType
-from ..exceptions import InvalidExportPath, ModelNotFound
+from ..exceptions import FileCannotBeRead, InvalidExportPath, ModelNotFound
 from ._abstract_repository import _AbstractRepository
 from ._decoder import _Decoder
 from ._encoder import _Encoder
@@ -39,7 +39,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         dir_name (str): Folder that will hold the files for this dataclass model.
     """
 
-    __EXCEPTIONS_TO_RETRY = (json.JSONDecodeError,)
+    __EXCEPTIONS_TO_RETRY = (FileCannotBeRead,)
 
     def __init__(self, model_type: Type[ModelType], converter: Type[Converter], dir_name: str):
         self.model_type = model_type
@@ -57,6 +57,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     ###############################
     # ##   Inherited methods   ## #
     ###############################
+
     def _save(self, entity: Entity):
         self.__create_directory_if_not_exists()
         model = self.converter._entity_to_model(entity)  # type: ignore
@@ -67,16 +68,16 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     def _exists(self, entity_id: str) -> bool:
         return self.__get_path(entity_id).exists()
 
-    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def _load(self, entity_id: str) -> Entity:
+        path = pathlib.Path(self.__get_path(entity_id))
+
         try:
-            with pathlib.Path(self.__get_path(entity_id)).open(encoding="UTF-8") as source:
-                file_content = json.load(source)
-            return self.__file_content_to_entity(file_content)
-        except FileNotFoundError:
+            file_content = self.__read_file(path)
+        except (FileNotFoundError, FileCannotBeRead):
             raise ModelNotFound(str(self.dir_path), entity_id)
 
-    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
+        return self.__file_content_to_entity(file_content)
+
     def _load_all(self, filters: Optional[List[Dict]] = None) -> List[Entity]:
         entities = []
         try:
@@ -173,7 +174,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     #############################
     # ##   Private methods   ## #
     #############################
-    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
+
     def __filter_files_by_config_and_owner_id(
         self, config_id: str, owner_id: Optional[str], filters: Optional[List[Dict]] = None
     ):
@@ -192,7 +193,6 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
             pass
         return None
 
-    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def __match_file_and_get_entity(self, filepath, config_and_owner_ids, filters):
         if match := [(c, p) for c, p in config_and_owner_ids if c.id in filepath.name]:
             for config, owner_id in match:
@@ -222,17 +222,31 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         entity = self.converter._model_to_entity(model)
         return entity
 
-    def __filter_by(self, filepath: pathlib.Path, filters: Optional[List[Dict]]) -> Json:
+    def __filter_by(self, filepath: pathlib.Path, filters: Optional[List[Dict]]) -> Optional[Json]:
         if not filters:
             filters = [{}]
 
-        with open(filepath, "r") as f:
-            contents = f.read()
-            for _filter in filters:
-                conditions = [
-                    f'"{key}": "{value}"' if value is not None else f'"{key}": null' for key, value in _filter.items()
-                ]
-                if all(condition in contents for condition in conditions):
-                    return json.loads(contents, cls=_Decoder)
+        try:
+            file_content = self.__read_file(filepath)
+        except (FileNotFoundError, FileCannotBeRead):
+            return None
 
+        for _filter in filters:
+            conditions = [
+                f'"{key}": "{value}"' if value is not None else f'"{key}": null' for key, value in _filter.items()
+            ]
+            if all(condition in file_content for condition in conditions):
+                return json.loads(file_content, cls=_Decoder)
         return None
+
+    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
+    def __read_file(self, filepath: pathlib.Path) -> str:
+        if not filepath.is_file():
+            raise FileNotFoundError
+
+        try:
+            with filepath.open("r", encoding="UTF-8") as f:
+                file_content = f.read()
+            return file_content
+        except:
+            raise FileCannotBeRead(str(filepath))

--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -248,5 +248,5 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
             with filepath.open("r", encoding="UTF-8") as f:
                 file_content = f.read()
             return file_content
-        except:
+        except Exception:
             raise FileCannotBeRead(str(filepath))

--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -9,6 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import copy
 import json
 import pathlib
 import shutil
@@ -77,8 +78,6 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
 
     @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def _load_all(self, filters: Optional[List[Dict]] = None) -> List[Entity]:
-        if not filters:
-            filters = [{}]
         entities = []
         try:
             for f in self.dir_path.iterdir():
@@ -141,7 +140,9 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
 
         try:
             for f in self.dir_path.iterdir():
-                config_id, owner_id, entity = self.__match_file_and_get_entity(f, configs_and_owner_ids, filters)
+                config_id, owner_id, entity = self.__match_file_and_get_entity(
+                    f, configs_and_owner_ids, copy.deepcopy(filters)
+                )
 
                 if entity:
                     key = config_id, owner_id
@@ -161,8 +162,12 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     ) -> Optional[Entity]:
         if not filters:
             filters = [{}]
+        else:
+            filters = copy.deepcopy(filters)
+
         if owner_id is not None:
-            filters.append({"owner_id": owner_id})
+            for fil in filters:
+                fil.update({"owner_id": owner_id})
         return self.__filter_files_by_config_and_owner_id(config_id, owner_id, filters)
 
     #############################
@@ -189,24 +194,13 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
 
     @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def __match_file_and_get_entity(self, filepath, config_and_owner_ids, filters):
-        versions = [f'"version": "{item.get("version")}"' for item in filters if item.get("version")]
+        if match := [(c, p) for c, p in config_and_owner_ids if c.id in filepath.name]:
+            for config, owner_id in match:
+                for fil in filters:
+                    fil.update({"config_id": config.id, "owner_id": owner_id})
 
-        filename = filepath.name
-
-        if match := [(c, p) for c, p in config_and_owner_ids if c.id in filename]:
-            with open(filepath, "r") as f:
-                file_content = f.read()
-
-            for config_id, owner_id in match:
-                if not all(version in file_content for version in versions):
-                    continue
-
-                if owner_id and owner_id not in file_content:
-                    continue
-
-                entity = self.__file_content_to_entity(file_content)
-                if entity.owner_id == owner_id and entity.config_id == config_id.id:
-                    return config_id, owner_id, entity
+                if data := self.__filter_by(filepath, filters):
+                    return config, owner_id, self.__file_content_to_entity(data)
 
         return None, None, None
 
@@ -235,7 +229,10 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         with open(filepath, "r") as f:
             contents = f.read()
             for _filter in filters:
-                if all(f'"{key}": "{value}"' in contents for key, value in _filter.items()):
+                conditions = [
+                    f'"{key}": "{value}"' if value is not None else f'"{key}": null' for key, value in _filter.items()
+                ]
+                if all(condition in contents for condition in conditions):
                     return json.loads(contents, cls=_Decoder)
 
         return None

--- a/src/taipy/core/_repository/_filesystem_repository.py
+++ b/src/taipy/core/_repository/_filesystem_repository.py
@@ -38,6 +38,8 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         dir_name (str): Folder that will hold the files for this dataclass model.
     """
 
+    __EXCEPTIONS_TO_RETRY = (json.JSONDecodeError,)
+
     def __init__(self, model_type: Type[ModelType], converter: Type[Converter], dir_name: str):
         self.model_type = model_type
         self.converter = converter
@@ -64,7 +66,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     def _exists(self, entity_id: str) -> bool:
         return self.__get_path(entity_id).exists()
 
-    @_retry_read_entity((Exception,))
+    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def _load(self, entity_id: str) -> Entity:
         try:
             with pathlib.Path(self.__get_path(entity_id)).open(encoding="UTF-8") as source:
@@ -73,7 +75,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
         except FileNotFoundError:
             raise ModelNotFound(str(self.dir_path), entity_id)
 
-    @_retry_read_entity((Exception,))
+    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def _load_all(self, filters: Optional[List[Dict]] = None) -> List[Entity]:
         if not filters:
             filters = [{}]
@@ -166,7 +168,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
     #############################
     # ##   Private methods   ## #
     #############################
-    @_retry_read_entity((Exception,))
+    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def __filter_files_by_config_and_owner_id(
         self, config_id: str, owner_id: Optional[str], filters: Optional[List[Dict]] = None
     ):
@@ -185,7 +187,7 @@ class _FileSystemRepository(_AbstractRepository[ModelType, Entity]):
             pass
         return None
 
-    @_retry_read_entity((Exception,))
+    @_retry_read_entity(__EXCEPTIONS_TO_RETRY)
     def __match_file_and_get_entity(self, filepath, config_and_owner_ids, filters):
         versions = [f'"version": "{item.get("version")}"' for item in filters if item.get("version")]
 

--- a/src/taipy/core/common/_utils.py
+++ b/src/taipy/core/common/_utils.py
@@ -25,13 +25,15 @@ def _load_fct(module_name: str, fct_name: str) -> Callable:
     return attrgetter(fct_name)(module)
 
 
-def _retry_read_entity(exceptions: Tuple):
+def _retry_read_entity(exceptions: Tuple, sleep_time: float = 0.2):
     """
-    Retries the wrapped function/method `times` times if the exceptions listed
+    Retries the wrapped function/method if the exceptions listed
     in ``exceptions`` are thrown.
+    The number of retries is defined by Config.core.read_entity_retry.
 
     Parameters:
-        exceptions (tuple): Exceptions that trigger a retry attempt
+        exceptions (tuple): Tuple of exceptions that trigger a retry attempt.
+        sleep_time (float): Time to sleep between retries.
     """
 
     def decorator(func):
@@ -40,7 +42,7 @@ def _retry_read_entity(exceptions: Tuple):
                 try:
                     return func(*args, **kwargs)
                 except exceptions:
-                    time.sleep(0.5)
+                    time.sleep(sleep_time)
             return func(*args, **kwargs)
 
         return newfn

--- a/src/taipy/core/common/typing.py
+++ b/src/taipy/core/common/typing.py
@@ -17,4 +17,4 @@ from .._repository._base_taipy_model import _BaseModel
 ModelType = TypeVar("ModelType", bound=_BaseModel)
 Entity = TypeVar("Entity")
 Converter = TypeVar("Converter", bound=_AbstractConverter)
-Json = Union[dict, list, str, int, float, bool, None]
+Json = Union[dict, list, str, int, float, bool]

--- a/src/taipy/core/config/core_section.py
+++ b/src/taipy/core/config/core_section.py
@@ -59,7 +59,7 @@ class CoreSection(UniqueSection):
     _DEFAULT_REPOSITORY_PROPERTIES: Dict = dict()
 
     _READ_ENTITY_RETRY_KEY = "read_entity_retry"
-    _DEFAULT_READ_ENTITY_RETRY = 3
+    _DEFAULT_READ_ENTITY_RETRY = 1
 
     _MODE_KEY = "mode"
     _DEVELOPMENT_MODE = "development"

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -255,10 +255,6 @@ class ConflictedConfigurationError(Exception):
     """Conflicts have been detected between the current and previous Configurations."""
 
 
-class _SuspiciousFileOperation(Exception):
-    pass
-
-
 class InvalidEventAttributeName(Exception):
     """
     Raised if the attribute doesn't exist or an attribute name is provided
@@ -268,3 +264,11 @@ class InvalidEventAttributeName(Exception):
 
 class InvalidEventOperation(Exception):
     """Raised when operation doesn't belong to the entity"""
+
+
+class FileCannotBeRead(Exception):
+    """Raised when a file cannot be read."""
+
+
+class _SuspiciousFileOperation(Exception):
+    pass

--- a/tests/core/test_core_cli_with_sql_repo.py
+++ b/tests/core/test_core_cli_with_sql_repo.py
@@ -105,7 +105,6 @@ def test_core_cli_production_mode(init_sql_repo):
 
 
 def test_dev_mode_clean_all_entities_of_the_latest_version(init_sql_repo):
-
     scenario_config = config_scenario()
 
     # Create a scenario in development mode
@@ -193,7 +192,7 @@ def twice_doppelganger(a):
     return a * 2
 
 
-def test_dev_mode_clean_all_entities_when_config_is_alternated():
+def test_dev_mode_clean_all_entities_when_config_is_alternated(init_sql_repo):
     data_node_1_config = Config.configure_data_node(
         id="d1", storage_type="pickle", default_data="abc", scope=Scope.SCENARIO
     )

--- a/tests/core/version/test_production_version_migration.py
+++ b/tests/core/version/test_production_version_migration.py
@@ -15,7 +15,6 @@ from unittest.mock import patch
 from src.taipy.core import Core, taipy
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.scenario._scenario_manager import _ScenarioManager
-from taipy.config.common.scope import Scope
 from taipy.config.config import Config
 from tests.core.utils import assert_true_after_time
 
@@ -297,7 +296,7 @@ def submit_v2():
 
 
 def config_scenario_v1():
-    dn1 = Config.configure_pickle_data_node(id="d1", default_data=1, scope=Scope.GLOBAL)
+    dn1 = Config.configure_pickle_data_node(id="d1", default_data=1)
     dn2 = Config.configure_pickle_data_node(id="d2")
     task_cfg = Config.configure_task("my_task", twice, dn1, dn2)
     pipeline_cfg = Config.configure_pipeline("my_pipeline", task_cfg)
@@ -306,7 +305,7 @@ def config_scenario_v1():
 
 
 def config_scenario_v2():
-    dn1 = Config.configure_pickle_data_node(id="d1", default_data=2, scope=Scope.GLOBAL)
+    dn1 = Config.configure_pickle_data_node(id="d1", default_data=2)
     dn2 = Config.configure_pickle_data_node(id="d2")
     task_cfg = Config.configure_task("my_task", triple, dn1, dn2)
     pipeline_cfg = Config.configure_pipeline("my_pipeline", task_cfg)


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/697

The issue is that when creating the first scenario on FS repository, several necessary files are not created yet, which makes the `_load()` method raises the `ModelNotFound` exception.

And since the default `read_entity_retry` value is 3, it would take about 2-3 seconds to finish creating the scenario, based on how many exception raised.

However, when creating the second scenario, it will be just fine.

Test code:
```python
from taipy import Scope, Config, Frequency
from src.taipy.core import taipy as tp
from src.taipy.core import Core
import time


def replace(input_msg, template, name):
    return input_msg.replace(template, name)


input_msg_cfg = Config.configure_data_node(id="input_msg", scope=Scope.GLOBAL, default_data="Hello, today it's <TPL>!")
template_cfg = Config.configure_data_node(id="template", scope=Scope.GLOBAL, default_data="<TPL>")
date_cfg = Config.configure_data_node(id="date")
message_cfg = Config.configure_data_node(id="msg")

replace_template_cfg = Config.configure_task("replace", replace, [input_msg_cfg, template_cfg, date_cfg], message_cfg)
scenario_daily_cfg = Config.configure_scenario_from_tasks(
    id="scenario_daily_cfg", task_configs=[replace_template_cfg], frequency=Frequency.DAILY
)
scenario_cfg = Config.configure_scenario_from_tasks(id="scenario_cfg", task_configs=[replace_template_cfg])

Core().run()

start = time.time()
scenario = tp.create_scenario(scenario_cfg)
print(f"Create scenario time: {time.time() - start}")
start = time.time()
tp.submit(scenario)
print(f"Submit scenario time: {time.time() - start}")

start = time.time()
scenario_2 = tp.create_scenario(scenario_cfg)
print(f"Create scenario 2 time: {time.time() - start}")
start = time.time()
tp.submit(scenario_2)
print(f"Submit scenario 2 time: {time.time() - start}")
```

Result:
```console
[2023-07-25 11:36:35][Taipy][INFO] Development mode: Clean all entities of version a4b4a09f-ecad-465b-bbdf-ceda3077f2f4
[2023-07-25 11:36:38][Taipy][ERROR] DataNode not found: DATANODE_input_msg_c9ca66fe-5a3e-46cc-a7ef-379c5dff64e5
[2023-07-25 11:36:40][Taipy][ERROR] DataNode not found: DATANODE_template_a544c333-bf3c-42a3-b8ea-06414ebb5183
Create scenario time: 3.0631818771362305
[2023-07-25 11:36:40][Taipy][WARNING] DATANODE_date_a6bf9c3f-697a-402a-a825-d00245cfe784 cannot be read because it has never been written. Hint: The data node may refer to a wrong path : .data/pickles/DATANODE_date_a6bf9c3f-697a-402a-a825-d00245cfe784.p 
Submit scenario time: 0.0188140869140625
Create scenario 2 time: 0.03878903388977051
[2023-07-25 11:36:40][Taipy][WARNING] DATANODE_date_3fee7bdd-300f-4edd-94dd-4564bd339ed3 cannot be read because it has never been written. Hint: The data node may refer to a wrong path : .data/pickles/DATANODE_date_3fee7bdd-300f-4edd-94dd-4564bd339ed3.p 
Submit scenario 2 time: 0.014927148818969727
```

You can see that in the result, the time to create scenario_2 is 0.03 second, which is just fine.

There are 2 possible solutions that I can think of.
1. Instead of retry on all Exception, we only retry on `json.JSONDecodeError`, which was raised by Fred a while ago.
(The exception that is causing the performance issue is `ModelNotFound`, which is catch at the `_Manager._get()` method).
This is also what I implemented.
2. Reduce the default `read_entity_retry` to 1, and maybe reduce the sleep time (0.5s maybe too long, idk).
This will let the creation performance of the first scenario be worse than the next.
It won't be too long anyway.