### PR TITLE
chore: configure repository dispatch to trigger performance benchmark

### DIFF
--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -1,0 +1,16 @@
+name: Benchmark on taipy-integration-testing
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger taipy-integration-testing
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{secrets.ACTIONS_TOKEN}}
+          repository: avaiga/taipy-integration-testing
+          event-type: benchmark
+          client-payload: '{"repo": "taipy-core", "commitSHA": "${{ github.sha }}"}'


### PR DESCRIPTION
This comes with another PR on taipy-integration-testing, triggering the repository dispatch. It should enable us to run the benchmarks after every push on taipy-core develop.