### PR TITLE
Feature/#732 - Add encoding option to CSV and JSON DataNode

### DIFF
--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -82,6 +82,10 @@ class DataNodeConfig(Section):
         _EXPOSED_TYPE_MODIN,
         _EXPOSED_TYPE_NUMPY,
     ]
+
+    _ENCODING_TYPE_KEY = "encoding"
+    _DEFAULT_ENCODING_TYPE = "utf-8"
+
     # Generic
     _OPTIONAL_READ_FUNCTION_GENERIC_PROPERTY = "read_fct"
     _OPTIONAL_READ_FUNCTION_ARGS_GENERIC_PROPERTY = "read_fct_args"
@@ -174,6 +178,7 @@ class DataNodeConfig(Section):
         },
         _STORAGE_TYPE_VALUE_CSV: {
             _OPTIONAL_DEFAULT_PATH_CSV_PROPERTY: None,
+            _ENCODING_TYPE_KEY: _DEFAULT_ENCODING_TYPE,
             _OPTIONAL_HAS_HEADER_CSV_PROPERTY: True,
             _OPTIONAL_EXPOSED_TYPE_CSV_PROPERTY: _DEFAULT_EXPOSED_TYPE,
         },
@@ -220,6 +225,7 @@ class DataNodeConfig(Section):
         },
         _STORAGE_TYPE_VALUE_JSON: {
             _OPTIONAL_DEFAULT_PATH_PICKLE_PROPERTY: None,
+            _ENCODING_TYPE_KEY: _DEFAULT_ENCODING_TYPE,
             _OPTIONAL_ENCODER_JSON_PROPERTY: None,
             _OPTIONAL_DECODER_JSON_PROPERTY: None,
         },
@@ -467,6 +473,7 @@ class DataNodeConfig(Section):
         cls,
         id: str,
         default_path: Optional[str] = None,
+        encoding: Optional[str] = None,
         has_header: Optional[bool] = None,
         exposed_type: Optional[str] = None,
         scope: Optional[Scope] = None,
@@ -478,6 +485,7 @@ class DataNodeConfig(Section):
         Parameters:
             id (str): The unique identifier of the new CSV data node configuration.
             default_path (Optional[str]): The default path of the CSV file.
+            encoding (Optional[str]): The encoding of the CSV file.
             has_header (Optional[bool]): If True, indicates that the CSV file has a header.
             exposed_type (Optional[str]): The exposed type of the data read from CSV file.<br/>
                 The default value is `pandas`.
@@ -495,6 +503,8 @@ class DataNodeConfig(Section):
         """
         if default_path is not None:
             properties[cls._OPTIONAL_DEFAULT_PATH_CSV_PROPERTY] = default_path
+        if encoding is not None:
+            properties[cls._ENCODING_TYPE_KEY] = encoding
         if has_header is not None:
             properties[cls._OPTIONAL_HAS_HEADER_CSV_PROPERTY] = has_header
         if exposed_type is not None:
@@ -507,6 +517,7 @@ class DataNodeConfig(Section):
         cls,
         id: str,
         default_path: Optional[str] = None,
+        encoding: Optional[str] = None,
         encoder: Optional[json.JSONEncoder] = None,
         decoder: Optional[json.JSONDecoder] = None,
         scope: Optional[Scope] = None,
@@ -518,6 +529,7 @@ class DataNodeConfig(Section):
         Parameters:
             id (str): The unique identifier of the new JSON data node configuration.
             default_path (Optional[str]): The default path of the JSON file.
+            encoding (Optional[str]): The encoding of the JSON file.
             encoder (Optional[json.JSONEncoder]): The JSON encoder used to write data into the JSON file.
             decoder (Optional[json.JSONDecoder]): The JSON decoder used to read data from the JSON file.
             scope (Optional[Scope^]): The scope of the JSON data node configuration.<br/>
@@ -533,6 +545,8 @@ class DataNodeConfig(Section):
         """
         if default_path is not None:
             properties[cls._OPTIONAL_DEFAULT_PATH_JSON_PROPERTY] = default_path
+        if encoding is not None:
+            properties[cls._ENCODING_TYPE_KEY] = encoding
         if encoder is not None:
             properties[cls._OPTIONAL_ENCODER_JSON_PROPERTY] = encoder
         if decoder is not None:

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -83,8 +83,8 @@ class DataNodeConfig(Section):
         _EXPOSED_TYPE_NUMPY,
     ]
 
-    _ENCODING_TYPE_KEY = "encoding"
-    _DEFAULT_ENCODING_TYPE = "utf-8"
+    _OPTIONAL_ENCODING_PROPERTY = "encoding"
+    _DEFAULT_ENCODING_VALUE = "utf-8"
 
     # Generic
     _OPTIONAL_READ_FUNCTION_GENERIC_PROPERTY = "read_fct"
@@ -178,7 +178,7 @@ class DataNodeConfig(Section):
         },
         _STORAGE_TYPE_VALUE_CSV: {
             _OPTIONAL_DEFAULT_PATH_CSV_PROPERTY: None,
-            _ENCODING_TYPE_KEY: _DEFAULT_ENCODING_TYPE,
+            _OPTIONAL_ENCODING_PROPERTY: _DEFAULT_ENCODING_VALUE,
             _OPTIONAL_HAS_HEADER_CSV_PROPERTY: True,
             _OPTIONAL_EXPOSED_TYPE_CSV_PROPERTY: _DEFAULT_EXPOSED_TYPE,
         },
@@ -225,7 +225,7 @@ class DataNodeConfig(Section):
         },
         _STORAGE_TYPE_VALUE_JSON: {
             _OPTIONAL_DEFAULT_PATH_PICKLE_PROPERTY: None,
-            _ENCODING_TYPE_KEY: _DEFAULT_ENCODING_TYPE,
+            _OPTIONAL_ENCODING_PROPERTY: _DEFAULT_ENCODING_VALUE,
             _OPTIONAL_ENCODER_JSON_PROPERTY: None,
             _OPTIONAL_DECODER_JSON_PROPERTY: None,
         },
@@ -504,7 +504,7 @@ class DataNodeConfig(Section):
         if default_path is not None:
             properties[cls._OPTIONAL_DEFAULT_PATH_CSV_PROPERTY] = default_path
         if encoding is not None:
-            properties[cls._ENCODING_TYPE_KEY] = encoding
+            properties[cls._OPTIONAL_ENCODING_PROPERTY] = encoding
         if has_header is not None:
             properties[cls._OPTIONAL_HAS_HEADER_CSV_PROPERTY] = has_header
         if exposed_type is not None:
@@ -546,7 +546,7 @@ class DataNodeConfig(Section):
         if default_path is not None:
             properties[cls._OPTIONAL_DEFAULT_PATH_JSON_PROPERTY] = default_path
         if encoding is not None:
-            properties[cls._ENCODING_TYPE_KEY] = encoding
+            properties[cls._OPTIONAL_ENCODING_PROPERTY] = encoding
         if encoder is not None:
             properties[cls._OPTIONAL_ENCODER_JSON_PROPERTY] = encoder
         if decoder is not None:

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -54,13 +54,18 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         encoder (json.JSONEncoder): The JSON encoder that is used to write into the JSON file.
         decoder (json.JSONDecoder): The JSON decoder that is used to read from the JSON file.
         properties (dict[str, Any]): A dictionary of additional properties. The _properties_
-            must have a _"default_path"_ or _"path"_ entry with the path of the JSON file.
+            must have a _"default_path"_ or _"path"_ entry with the path of the JSON file:
+
+            - _"default_path"_ `(str)`: The default path of the CSV file.\n
+            - _"encoding"_ `(str)`: The encoding of the CSV file. The default value is `utf-8`.\n
+            - _"default_data"_: The default data of the data nodes instantiated from this json data node.\n
     """
 
     __STORAGE_TYPE = "json"
     __DEFAULT_DATA_KEY = "default_data"
     __DEFAULT_PATH_KEY = "default_path"
     __PATH_KEY = "path"
+    __ENCODING_KEY = "encoding"
     _ENCODER_KEY = "encoder"
     _DECODER_KEY = "decoder"
     _REQUIRED_PROPERTIES: List[str] = []
@@ -74,16 +79,19 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         owner_id: Optional[str] = None,
         parent_ids: Optional[Set[str]] = None,
         last_edit_date: Optional[datetime] = None,
-        edits: List[Edit] = None,
-        version: str = None,
+        edits: Optional[List[Edit]] = None,
+        version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
-        properties: Dict = None,
+        properties: Optional[Dict] = None,
     ):
         if properties is None:
             properties = {}
 
         default_value = properties.pop(self.__DEFAULT_DATA_KEY, None)
+
+        if self.__ENCODING_KEY not in properties.keys():
+            properties[self.__ENCODING_KEY] = "utf-8"
 
         super().__init__(
             config_id,
@@ -117,6 +125,7 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
             {
                 self.__PATH_KEY,
                 self.__DEFAULT_PATH_KEY,
+                self.__ENCODING_KEY,
                 self.__DEFAULT_DATA_KEY,
                 self._ENCODER_KEY,
                 self._DECODER_KEY,
@@ -158,11 +167,11 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         self.properties[self._DECODER_KEY] = decoder
 
     def _read(self):
-        with open(self._path, "r") as f:
+        with open(self._path, "r", encoding=self.properties[self.__ENCODING_KEY]) as f:
             return json.load(f, cls=self._decoder)
 
     def _write(self, data: Any):
-        with open(self._path, "w") as f:  # type: ignore
+        with open(self._path, "w", encoding=self.properties[self.__ENCODING_KEY]) as f:  # type: ignore
             json.dump(data, f, indent=4, cls=self._encoder)
 
 

--- a/tests/core/config/test_config_serialization.py
+++ b/tests/core/config/test_config_serialization.py
@@ -143,6 +143,7 @@ scope = "GLOBAL:SCOPE"
 validity_period = "1d0h0m0s:timedelta"
 path = "./test.csv"
 exposed_type = "tests.core.config.test_config_serialization.CustomClass:class"
+encoding = "utf-8"
 has_header = "True:bool"
 
 [DATA_NODE.test_json_dn]
@@ -151,6 +152,7 @@ scope = "SCENARIO:SCOPE"
 default_path = "./test.json"
 encoder = "tests.core.config.test_config_serialization.CustomEncoder:class"
 decoder = "tests.core.config.test_config_serialization.CustomDecoder:class"
+encoding = "utf-8"
 
 [DATA_NODE.test_pickle_dn]
 storage_type = "pickle"
@@ -230,10 +232,12 @@ sequence1 = [ "test_task:SECTION",]
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].validity_period == datetime.timedelta(1)
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].has_header is True
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].path == "./test.csv"
+    assert Config.sections[DataNodeConfig.name]["test_csv_dn"].encoding == "utf-8"
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].exposed_type == CustomClass
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].storage_type == "json"
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].scope == Scope.SCENARIO
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].default_path == "./test.json"
+    assert Config.sections[DataNodeConfig.name]["test_json_dn"].encoding == "utf-8"
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].encoder == CustomEncoder
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].decoder == CustomDecoder
     assert Config.sections[DataNodeConfig.name]["test_pickle_dn"].storage_type == "pickle"
@@ -321,6 +325,7 @@ def test_read_write_json_configuration_file():
 "validity_period": "1d0h0m0s:timedelta",
 "path": "./test.csv",
 "exposed_type": "tests.core.config.test_config_serialization.CustomClass:class",
+"encoding": "utf-8",
 "has_header": "True:bool"
 },
 "test_json_dn": {
@@ -328,7 +333,8 @@ def test_read_write_json_configuration_file():
 "scope": "SCENARIO:SCOPE",
 "default_path": "./test.json",
 "encoder": "tests.core.config.test_config_serialization.CustomEncoder:class",
-"decoder": "tests.core.config.test_config_serialization.CustomDecoder:class"
+"decoder": "tests.core.config.test_config_serialization.CustomDecoder:class",
+"encoding": "utf-8"
 },
 "test_pickle_dn": {
 "storage_type": "pickle",
@@ -427,10 +433,12 @@ def test_read_write_json_configuration_file():
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].validity_period == datetime.timedelta(1)
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].has_header is True
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].path == "./test.csv"
+    assert Config.sections[DataNodeConfig.name]["test_csv_dn"].encoding == "utf-8"
     assert Config.sections[DataNodeConfig.name]["test_csv_dn"].exposed_type == CustomClass
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].storage_type == "json"
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].scope == Scope.SCENARIO
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].default_path == "./test.json"
+    assert Config.sections[DataNodeConfig.name]["test_json_dn"].encoding == "utf-8"
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].encoder == CustomEncoder
     assert Config.sections[DataNodeConfig.name]["test_json_dn"].decoder == CustomDecoder
     assert Config.sections[DataNodeConfig.name]["test_pickle_dn"].storage_type == "pickle"

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -60,7 +60,7 @@ def test_set_default_data_node_configuration_replace_old_default_config():
     )
     dn2 = Config.configure_data_node(id="dn2")
     assert dn2.storage_type == "csv"
-    assert len(dn2.properties) == 5  # exposed_type and has_header too
+    assert len(dn2.properties) == 6  # encoding, exposed_type, and has_header too
     assert dn2.prop4 == "4"
     assert dn2.prop5 == "5"
     assert dn2.prop6 == "6"
@@ -79,7 +79,7 @@ def test_config_storage_type_different_from_default_data_node():
     # Config a datanode with specific "storage_type" different than "pickle"
     # should ignore the default datanode
     csv_dn = Config.configure_data_node(id="csv_dn", storage_type="csv")
-    assert len(csv_dn.properties) == 2
+    assert len(csv_dn.properties) == 3  # encoding, exposed_type, and has_header
     assert csv_dn.properties.get("custom_property") is None
     assert csv_dn.scope == Scope.SCENARIO
 

--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -218,6 +218,24 @@ class TestCSVDataNode:
         csv_dn.write(None)
         assert len(csv_dn.read()) == 0
 
+    def test_write_with_different_encoding(self, csv_file):
+        data = pd.DataFrame([{"≥a": 1, "b": 2}])
+
+        utf8_dn = CSVDataNode("utf8_dn", Scope.SCENARIO, properties={"default_path": csv_file})
+        utf16_dn = CSVDataNode("utf16_dn", Scope.SCENARIO, properties={"default_path": csv_file, "encoding": "utf-16"})
+
+        # If a file is written with utf-8 encoding, it can only be read with utf-8, not utf-16 encoding
+        utf8_dn.write(data)
+        assert np.array_equal(utf8_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf16_dn.read()
+
+        # If a file is written with utf-16 encoding, it can only be read with utf-16, not utf-8 encoding
+        utf16_dn.write(data)
+        assert np.array_equal(utf16_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf8_dn.read()
+
     @pytest.mark.parametrize(
         "content,columns",
         [
@@ -240,6 +258,26 @@ class TestCSVDataNode:
 
         csv_dn.write(None)
         assert len(csv_dn.read()) == 0
+
+    def test_write_modin_with_different_encoding(self, csv_file):
+        data = pd.DataFrame([{"≥a": 1, "b": 2}])
+
+        utf8_dn = CSVDataNode("utf8_dn", Scope.SCENARIO, properties={"path": csv_file, "exposed_type": "modin"})
+        utf16_dn = CSVDataNode(
+            "utf16_dn", Scope.SCENARIO, properties={"path": csv_file, "exposed_type": "modin", "encoding": "utf-16"}
+        )
+
+        # If a file is written with utf-8 encoding, it can only be read with utf-8, not utf-16 encoding
+        utf8_dn.write(data)
+        assert np.array_equal(utf8_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf16_dn.read()
+
+        # If a file is written with utf-16 encoding, it can only be read with utf-16, not utf-8 encoding
+        utf16_dn.write(data)
+        assert np.array_equal(utf16_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf8_dn.read()
 
     def test_set_path(self):
         dn = CSVDataNode("foo", Scope.SCENARIO, properties={"default_path": "foo.csv"})

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -73,8 +73,9 @@ class TestDataManager:
         assert _DataManager._get(csv_dn.id).job_ids == csv_dn.job_ids
         assert not _DataManager._get(csv_dn.id).is_ready_for_reading
         assert _DataManager._get(csv_dn.id).is_ready_for_reading == csv_dn.is_ready_for_reading
-        assert len(_DataManager._get(csv_dn.id).properties) == 3
+        assert len(_DataManager._get(csv_dn.id).properties) == 4
         assert _DataManager._get(csv_dn.id).properties.get("path") == "bar"
+        assert _DataManager._get(csv_dn.id).properties.get("encoding") == "utf-8"
         assert _DataManager._get(csv_dn.id).properties.get("has_header") is True
         assert _DataManager._get(csv_dn.id).properties.get("exposed_type") == "pandas"
         assert _DataManager._get(csv_dn.id).properties == csv_dn.properties
@@ -95,8 +96,9 @@ class TestDataManager:
         assert _DataManager._get(csv_dn).job_ids == csv_dn.job_ids
         assert not _DataManager._get(csv_dn).is_ready_for_reading
         assert _DataManager._get(csv_dn).is_ready_for_reading == csv_dn.is_ready_for_reading
-        assert len(_DataManager._get(csv_dn).properties) == 3
+        assert len(_DataManager._get(csv_dn).properties) == 4
         assert _DataManager._get(csv_dn).properties.get("path") == "bar"
+        assert _DataManager._get(csv_dn).properties.get("encoding") == "utf-8"
         assert _DataManager._get(csv_dn).properties.get("has_header") is True
         assert _DataManager._get(csv_dn.id).properties.get("exposed_type") == "pandas"
         assert _DataManager._get(csv_dn).properties == csv_dn.properties

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -177,6 +177,26 @@ class TestJSONDataNode:
         json_dn.write(data)
         assert np.array_equal(json_dn.read(), data)
 
+    def test_write_with_different_encoding(self, json_file):
+        data = {"≥a": 1, "b": 2}
+
+        utf8_dn = JSONDataNode("utf8_dn", Scope.SCENARIO, properties={"default_path": json_file})
+        utf16_dn = JSONDataNode(
+            "utf16_dn", Scope.SCENARIO, properties={"default_path": json_file, "encoding": "utf-16"}
+        )
+
+        # If a file is written with utf-8 encoding, it can only be read with utf-8, not utf-16 encoding
+        utf8_dn.write(data)
+        assert np.array_equal(utf8_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf16_dn.read()
+
+        # If a file is written with utf-16 encoding, it can only be read with utf-16, not utf-8 encoding
+        utf16_dn.write(data)
+        assert np.array_equal(utf16_dn.read(), data)
+        with pytest.raises(UnicodeError):
+            utf8_dn.read()
+
     def test_write_non_serializable(self, json_file):
         json_dn = JSONDataNode("foo", Scope.SCENARIO, properties={"default_path": json_file})
         data = {"a": 1, "b": json_dn}


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/732

In this PR, the encoding option is only added to CSV and JSON DataNode.

For Parquet, we need to use the method provided by pandas since we need to read folder as well, but there is no "encoding" parameter supported.

For Excel, somehow the "encoding" parameter of pandas.read_excel() was dropped since pandas 1.0.1.
And if I try to open an excel file with encoding UTF-xx, I can't, because Excel are binary file and there will be always some sort of special unicode characters of Excel. 