### PR TITLE
fix: the Core._orchestrator is now only built at run(), after managing the version

### DIFF
--- a/src/taipy/core/_core.py
+++ b/src/taipy/core/_core.py
@@ -37,7 +37,7 @@ class Core:
         """
         Initialize a Core service.
         """
-        self._orchestrator = _OrchestratorFactory._build_orchestrator()
+        pass
 
     def run(self, force_restart=False):
         """
@@ -48,6 +48,8 @@ class Core:
         """
         self.__update_and_check_config()
         self.__manage_version()
+        if self._orchestrator is None:
+            self._orchestrator = _OrchestratorFactory._build_orchestrator()
         self.__start_dispatcher(force_restart)
 
     def stop(self):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -36,16 +36,16 @@ class TestCore:
         _OrchestratorFactory._dispatcher = None
 
         core = Core()
-        assert core._orchestrator is not None
-        assert core._orchestrator == _Orchestrator
-        assert _OrchestratorFactory._orchestrator is not None
-        assert _OrchestratorFactory._orchestrator == _Orchestrator
-
+        assert core._orchestrator is None
         assert core._dispatcher is None
         assert _OrchestratorFactory._dispatcher is None
 
         Config.configure_job_executions(mode=JobConfig._DEVELOPMENT_MODE)
         core.run()
+        assert core._orchestrator is not None
+        assert core._orchestrator == _Orchestrator
+        assert _OrchestratorFactory._orchestrator is not None
+        assert _OrchestratorFactory._orchestrator == _Orchestrator
         assert core._dispatcher is not None
         assert isinstance(core._dispatcher, _DevelopmentJobDispatcher)
         assert isinstance(_OrchestratorFactory._dispatcher, _DevelopmentJobDispatcher)
@@ -54,16 +54,17 @@ class TestCore:
         _OrchestratorFactory._dispatcher = None
 
         core = Core()
-        assert core._orchestrator is not None
-        assert core._orchestrator == _Orchestrator
-        assert _OrchestratorFactory._orchestrator is not None
-        assert _OrchestratorFactory._orchestrator == _Orchestrator
+        assert core._orchestrator is None
 
         assert core._dispatcher is None
         assert _OrchestratorFactory._dispatcher is None
 
         Config.configure_job_executions(mode=JobConfig._STANDALONE_MODE, max_nb_of_workers=2)
         core.run()
+        assert core._orchestrator is not None
+        assert core._orchestrator == _Orchestrator
+        assert _OrchestratorFactory._orchestrator is not None
+        assert _OrchestratorFactory._orchestrator == _Orchestrator
         assert core._dispatcher is not None
         assert isinstance(core._dispatcher, _StandaloneJobDispatcher)
         assert isinstance(_OrchestratorFactory._dispatcher, _StandaloneJobDispatcher)


### PR DESCRIPTION
In this PR, the `Core._orchestrator` is now only built at `run()`, after managing the version.

This is to make sure that the old entities are managed properly before the orchestrator trigger anything.