### PR TITLE
editor_id and editor_expiration_date must be stored in the datamodel.

### DIFF
--- a/src/taipy/core/data/_abstract_sql.py
+++ b/src/taipy/core/data/_abstract_sql.py
@@ -94,6 +94,8 @@ class _AbstractSQLDataNode(DataNode, _AbstractTabularDataNode):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -116,6 +118,8 @@ class _AbstractSQLDataNode(DataNode, _AbstractTabularDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         self._engine = None

--- a/src/taipy/core/data/_data_converter.py
+++ b/src/taipy/core/data/_data_converter.py
@@ -169,6 +169,8 @@ class _DataNodeConverter(_AbstractConverter):
             data_node._validity_period.days if data_node._validity_period else None,
             data_node._validity_period.seconds if data_node._validity_period else None,
             data_node._edit_in_progress,
+            data_node._editor_id,
+            data_node._editor_expiration_date.isoformat() if data_node._editor_expiration_date else None,
             properties,
         )
 
@@ -300,6 +302,7 @@ class _DataNodeConverter(_AbstractConverter):
         if model.validity_seconds is not None and model.validity_days is not None:
             validity_period = timedelta(days=model.validity_days, seconds=model.validity_seconds)
 
+        exp_date = datetime.fromisoformat(model.editor_expiration_date) if model.editor_expiration_date else None
         datanode = DataNode._class_map()[model.storage_type](
             config_id=model.config_id,
             scope=model.scope,
@@ -312,6 +315,8 @@ class _DataNodeConverter(_AbstractConverter):
             version=model.version,
             validity_period=validity_period,
             edit_in_progress=model.edit_in_progress,
+            editor_id=model.editor_id,
+            editor_expiration_date=exp_date,
             properties=data_node_properties,
         )
         return _migrate_entity(datanode)

--- a/src/taipy/core/data/_data_model.py
+++ b/src/taipy/core/data/_data_model.py
@@ -54,6 +54,8 @@ class _DataNodeModel(_BaseModel):
         Column("validity_days", Float),
         Column("validity_seconds", Float),
         Column("edit_in_progress", Boolean),
+        Column("editor_id", String),
+        Column("editor_expiration_date", String),
         Column("data_node_properties", JSON),
     )
     __table_args__ = (UniqueConstraint("config_id", "owner_id", name="_config_owner_uc"),)
@@ -71,6 +73,8 @@ class _DataNodeModel(_BaseModel):
     validity_days: Optional[float]
     validity_seconds: Optional[float]
     edit_in_progress: bool
+    editor_id: Optional[str]
+    editor_expiration_date: Optional[str]
     data_node_properties: Dict[str, Any]
 
     @staticmethod
@@ -96,5 +100,7 @@ class _DataNodeModel(_BaseModel):
             validity_seconds=data["validity_seconds"],
             # Migrate edition_in_progress attribute for compatibility between <2.0 to >=2.0 versions.
             edit_in_progress=bool(data.get("edit_in_progress", data.get("edition_in_progress", False))),
+            editor_id=data.get("editor_id", None),
+            editor_expiration_date=data.get("editor_expiration_date"),
             data_node_properties=dn_properties,
         )

--- a/src/taipy/core/data/csv.py
+++ b/src/taipy/core/data/csv.py
@@ -52,6 +52,8 @@ class CSVDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         path (str): The path to the CSV file.
         properties (dict[str, Any]): A dictionary of additional properties. The _properties_
             must have a _"default_path"_ or _"path"_ entry with the path of the CSV file:
@@ -89,6 +91,8 @@ class CSVDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -118,6 +122,8 @@ class CSVDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         self._path = properties.get(self.__PATH_KEY, properties.get(self.__DEFAULT_PATH_KEY))

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -75,6 +75,8 @@ class DataNode(_Entity, _Labeled):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if the data node is locked for modification. False
             otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         kwargs: A dictionary of additional properties.
     """
 
@@ -101,6 +103,8 @@ class DataNode(_Entity, _Labeled):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         **kwargs,
     ):
         self.config_id = _validate_id(config_id)
@@ -113,8 +117,8 @@ class DataNode(_Entity, _Labeled):
         self._edit_in_progress = edit_in_progress
         self._version = version or _VersionManagerFactory._build_manager()._get_latest_version()
         self._validity_period = validity_period
-        self._editor_id: Optional[str] = None
-        self._editor_expiration_date: Optional[datetime] = None
+        self._editor_id: Optional[str] = editor_id
+        self._editor_expiration_date: Optional[datetime] = editor_expiration_date
 
         # Track edits
         self._edits = edits or list()
@@ -228,6 +232,26 @@ class DataNode(_Entity, _Labeled):
     @_self_setter(_MANAGER_NAME)
     def edit_in_progress(self, val):
         self._edit_in_progress = val
+
+    @property  # type: ignore
+    @_self_reload(_MANAGER_NAME)
+    def editor_id(self):
+        return self._editor_id
+
+    @editor_id.setter  # type: ignore
+    @_self_setter(_MANAGER_NAME)
+    def editor_id(self, val):
+        self._editor_id = val
+
+    @property  # type: ignore
+    @_self_reload(_MANAGER_NAME)
+    def editor_expiration_date(self):
+        return self._editor_expiration_date
+
+    @editor_expiration_date.setter  # type: ignore
+    @_self_setter(_MANAGER_NAME)
+    def editor_expiration_date(self, val):
+        self._editor_expiration_date = val
 
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
@@ -356,20 +380,21 @@ class DataNode(_Entity, _Labeled):
         Parameters:
             editor_id (Optional[str]): The editor's identifier.
         """
-        if editor_id:
-            if (
-                self.edit_in_progress
-                and self._editor_id != editor_id
-                and self._editor_expiration_date
-                and self._editor_expiration_date > datetime.now()
-            ):
-                raise DataNodeIsBeingEdited(self.id, self._editor_id)
-            self._editor_id = editor_id
-            self._editor_expiration_date = datetime.now() + timedelta(minutes=self.__EDIT_TIMEOUT)
-        else:
-            self._editor_id = None
-            self._editor_expiration_date = None
-        self.edit_in_progress = True  # type: ignore
+        with self:
+            if editor_id:
+                if (
+                    self.edit_in_progress
+                    and self.editor_id != editor_id
+                    and self.editor_expiration_date
+                    and self.editor_expiration_date > datetime.now()
+                ):
+                    raise DataNodeIsBeingEdited(self.id, self._editor_id)
+                self.editor_id = editor_id  # type: ignore
+                self.editor_expiration_date = datetime.now() + timedelta(minutes=self.__EDIT_TIMEOUT)  # type: ignore
+            else:
+                self.editor_id = None  # type: ignore
+                self.editor_expiration_date = None  # type: ignore
+            self.edit_in_progress = True  # type: ignore
 
     def unlock_edit(self, editor_id: Optional[str] = None):
         """Unlocks the data node modification.
@@ -380,17 +405,18 @@ class DataNode(_Entity, _Labeled):
         Parameters:
             editor_id (Optional[str]): The editor's identifier.
         """
-        if (
-            editor_id
-            and self._editor_id != editor_id
-            and self._editor_expiration_date
-            and self._editor_expiration_date > datetime.now()
-        ):
-            raise DataNodeIsBeingEdited(self.id, self._editor_id)
-        else:
-            self._editor_id = None
-            self._editor_expiration_date = None
-            self.edit_in_progress = False  # type: ignore
+        with self:
+            if (
+                editor_id
+                and self.editor_id != editor_id
+                and self.editor_expiration_date
+                and self.editor_expiration_date > datetime.now()
+            ):
+                raise DataNodeIsBeingEdited(self.id, self._editor_id)
+            else:
+                self.editor_id = None  # type: ignore
+                self.editor_expiration_date = None  # type: ignore
+                self.edit_in_progress = False  # type: ignore
 
     def filter(self, operators: Union[List, Tuple], join_operator=JoinOperator.AND):
         """Read and filter the data referenced by this data node.

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -380,21 +380,20 @@ class DataNode(_Entity, _Labeled):
         Parameters:
             editor_id (Optional[str]): The editor's identifier.
         """
-        with self:
-            if editor_id:
-                if (
-                    self.edit_in_progress
-                    and self.editor_id != editor_id
-                    and self.editor_expiration_date
-                    and self.editor_expiration_date > datetime.now()
-                ):
-                    raise DataNodeIsBeingEdited(self.id, self._editor_id)
-                self.editor_id = editor_id  # type: ignore
-                self.editor_expiration_date = datetime.now() + timedelta(minutes=self.__EDIT_TIMEOUT)  # type: ignore
-            else:
-                self.editor_id = None  # type: ignore
-                self.editor_expiration_date = None  # type: ignore
-            self.edit_in_progress = True  # type: ignore
+        if editor_id:
+            if (
+                self.edit_in_progress
+                and self.editor_id != editor_id
+                and self.editor_expiration_date
+                and self.editor_expiration_date > datetime.now()
+            ):
+                raise DataNodeIsBeingEdited(self.id, self._editor_id)
+            self.editor_id = editor_id  # type: ignore
+            self.editor_expiration_date = datetime.now() + timedelta(minutes=self.__EDIT_TIMEOUT)  # type: ignore
+        else:
+            self.editor_id = None  # type: ignore
+            self.editor_expiration_date = None  # type: ignore
+        self.edit_in_progress = True  # type: ignore
 
     def unlock_edit(self, editor_id: Optional[str] = None):
         """Unlocks the data node modification.
@@ -405,18 +404,17 @@ class DataNode(_Entity, _Labeled):
         Parameters:
             editor_id (Optional[str]): The editor's identifier.
         """
-        with self:
-            if (
-                editor_id
-                and self.editor_id != editor_id
-                and self.editor_expiration_date
-                and self.editor_expiration_date > datetime.now()
-            ):
-                raise DataNodeIsBeingEdited(self.id, self._editor_id)
-            else:
-                self.editor_id = None  # type: ignore
-                self.editor_expiration_date = None  # type: ignore
-                self.edit_in_progress = False  # type: ignore
+        if (
+            editor_id
+            and self.editor_id != editor_id
+            and self.editor_expiration_date
+            and self.editor_expiration_date > datetime.now()
+        ):
+            raise DataNodeIsBeingEdited(self.id, self._editor_id)
+        else:
+            self.editor_id = None  # type: ignore
+            self.editor_expiration_date = None  # type: ignore
+            self.edit_in_progress = False  # type: ignore
 
     def filter(self, operators: Union[List, Tuple], join_operator=JoinOperator.AND):
         """Read and filter the data referenced by this data node.

--- a/src/taipy/core/data/excel.py
+++ b/src/taipy/core/data/excel.py
@@ -58,6 +58,8 @@ class ExcelDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         path (str): The path to the Excel file.
         properties (dict[str, Any]): A dictionary of additional properties. The _properties_
             must have a _"default_path"_ or _"path"_ entry with the path of the Excel file:
@@ -95,6 +97,8 @@ class ExcelDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Dict = None,
     ):
         if properties is None:
@@ -124,6 +128,8 @@ class ExcelDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         if not self._path:

--- a/src/taipy/core/data/generic.py
+++ b/src/taipy/core/data/generic.py
@@ -45,6 +45,8 @@ class GenericDataNode(DataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
             _properties_ parameter must at least contain an entry for either _"read_fct"_ or
             _"write_fct"_ representing the read and write functions.
@@ -73,6 +75,8 @@ class GenericDataNode(DataNode):
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Dict = None,
     ):
         if properties is None:
@@ -103,6 +107,8 @@ class GenericDataNode(DataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         if not self._last_edit_date:

--- a/src/taipy/core/data/in_memory.py
+++ b/src/taipy/core/data/in_memory.py
@@ -49,6 +49,8 @@ class InMemoryDataNode(DataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. When creating an
             _In Memory_ data node, if the _properties_ dictionary contains a _"default_data"_
             entry, the data node is automatically written with the corresponding _"default_data"_
@@ -72,6 +74,8 @@ class InMemoryDataNode(DataNode):
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties=None,
     ):
         if properties is None:
@@ -89,6 +93,8 @@ class InMemoryDataNode(DataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties
         )
         if default_value is not None and self.id not in in_memory_storage:

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -50,6 +50,8 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         path (str): The path to the JSON file.
         encoder (json.JSONEncoder): The JSON encoder that is used to write into the JSON file.
         decoder (json.JSONDecoder): The JSON decoder that is used to read from the JSON file.
@@ -83,6 +85,8 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -105,6 +109,8 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         self._path = properties.get(self.__PATH_KEY, properties.get(self.__DEFAULT_PATH_KEY))

--- a/src/taipy/core/data/mongo.py
+++ b/src/taipy/core/data/mongo.py
@@ -46,6 +46,8 @@ class MongoCollectionDataNode(DataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
             _properties_ parameter must at least contain an entry for _"db_name"_ and _"collection_name"_:
 
@@ -94,6 +96,8 @@ class MongoCollectionDataNode(DataNode):
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Dict = None,
     ):
         if properties is None:
@@ -118,6 +122,8 @@ class MongoCollectionDataNode(DataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
 

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -52,6 +52,8 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode)
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         path (str): The path to the Parquet file.
         properties (dict[str, Any]): A dictionary of additional properties. *properties*
             must have a *"default_path"* or *"path"* entry with the path of the Parquet file:
@@ -104,6 +106,8 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode)
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -154,6 +158,8 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode)
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         self._path = properties.get(self.__PATH_KEY, properties.get(self.__DEFAULT_PATH_KEY))

--- a/src/taipy/core/data/pickle.py
+++ b/src/taipy/core/data/pickle.py
@@ -49,6 +49,8 @@ class PickleDataNode(DataNode, _AbstractFileDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties.
             When creating a pickle data node, if the _properties_ dictionary contains a
             _"default_data"_ entry, the data node is automatically written with the corresponding
@@ -77,6 +79,8 @@ class PickleDataNode(DataNode, _AbstractFileDataNode):
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties=None,
     ):
         if properties is None:
@@ -99,6 +103,8 @@ class PickleDataNode(DataNode, _AbstractFileDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             **properties,
         )
         if self._path is None:

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -43,6 +43,8 @@ class SQLDataNode(_AbstractSQLDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
             _properties_ parameter must at least contain an entry for _"db_name"_, _"db_engine"_, _"read_query"_,
             and _"write_query_builder"_:
@@ -83,6 +85,8 @@ class SQLDataNode(_AbstractSQLDataNode):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -104,6 +108,8 @@ class SQLDataNode(_AbstractSQLDataNode):
             version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period,
             edit_in_progress,
+            editor_id,
+            editor_expiration_date,
             properties=properties,
         )
 

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -48,6 +48,8 @@ class SQLTableDataNode(_AbstractSQLDataNode):
             If _validity_period_ is set to `None`, the data node is always up-to-date.
         edit_in_progress (bool): True if a task computing the data node has been submitted
             and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
             _properties_ parameter must at least contain an entry for _"db_name"_, _"db_engine"_, _"table_name"_:
 
@@ -84,6 +86,8 @@ class SQLTableDataNode(_AbstractSQLDataNode):
         version: Optional[str] = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
         properties: Optional[Dict] = None,
     ):
         if properties is None:
@@ -102,6 +106,8 @@ class SQLTableDataNode(_AbstractSQLDataNode):
             version=version or _VersionManagerFactory._build_manager()._get_latest_version(),
             validity_period=validity_period,
             edit_in_progress=edit_in_progress,
+            editor_id=editor_id,
+            editor_expiration_date=editor_expiration_date,
             properties=properties,
         )
         self._TAIPY_PROPERTIES.update({self.__TABLE_KEY})


### PR DESCRIPTION
The editor_id and the expiration date must be stored in the repo.

Before writing a data node, a user can lock it providing an editor id. The UI can read the editor_id before to let a user write the data to guarantee he s the one that locked the data node.
To be able to retrieve the editor_id, it must be stored in the repo.