### PR TITLE
feature/enterprise/#242 align pymongo version for core and enterprise

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ modin = {extras = ["dask"], version = "==0.23.0"}
 networkx = "==2.6"
 openpyxl = "==3.1.2"
 pyarrow = "==10.0.1"
-pymongo = "==4.2.0"
+pymongo = {extras = ["srv"], version = "==4.2.0"}
 sqlalchemy = "==2.0.16"
 toml = "==0.10"
 taipy-config = {ref = "develop", git = "https://github.com/avaiga/taipy-config.git"}

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "networkx>=2.6,<3.0",
     "openpyxl>=3.1.2,<3.2",
     "modin[dask]>=0.23.0,<1.0",
-    "pymongo>=4.2.0,<5.0",
+    "pymongo[srv]>=4.2.0,<5.0",
     "sqlalchemy>=2.0.16,<2.1",
     "toml>=0.10,<0.11",
     "taipy-config@git+https://git@github.com/Avaiga/taipy-config.git@develop",

--- a/src/taipy/core/common/_mongo_connector.py
+++ b/src/taipy/core/common/_mongo_connector.py
@@ -19,8 +19,8 @@ def _connect_mongodb(
     db_host: str, db_port: int, db_username: str, db_password: str, db_extra_args: frozenset, db_driver: str
 ) -> pymongo.MongoClient:
     """Create a connection to a Mongo database.
-    The `"mongodb_extra_args"` passed by the user is originally a dictionary, but since `@lru_cache` wrapper only accepts
-    hashable parameters, the `"mongodb_extra_args"` should be converted into a frozenset beforehand.
+    The `"mongodb_extra_args"` passed by the user is originally a dictionary, but since `@lru_cache` wrapper only
+    accepts hashable parameters, the `"mongodb_extra_args"` should be converted into a frozenset beforehand.
 
     Parameters:
         db_host (str): the database host.

--- a/src/taipy/core/common/_mongo_connector.py
+++ b/src/taipy/core/common/_mongo_connector.py
@@ -9,29 +9,26 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from typing import Dict, Optional
+from functools import lru_cache
 
 import pymongo
 
 
+@lru_cache
 def _connect_mongodb(
-    db_host: str,
-    db_port: int,
-    db_username: str,
-    db_password: str,
-    db_extra_args: Dict[str, str],
-    db_driver: Optional[str] = None,
+    db_host: str, db_port: int, db_username: str, db_password: str, db_extra_args: frozenset, db_driver: str
 ) -> pymongo.MongoClient:
     """Create a connection to a Mongo database.
+    The `"mongodb_extra_args"` passed by the user is originally a dictionary, but since `@lru_cache` wrapper only accepts
+    hashable parameters, the `"mongodb_extra_args"` should be converted into a frozenset beforehand.
 
-    Args:
+    Parameters:
         db_host (str): the database host.
         db_port (int): the database port.
         db_username (str): the database username.
         db_password (str): the database password.
-        db_extra_args (Dict[str, Any]): A dictionary of additional arguments to be passed into database connection
-            string.
-
+        db_extra_args (frozenset): A frozenset converted from a dictionary of additional arguments to be passed into
+            database connection string.
     Returns:
         pymongo.MongoClient
     """
@@ -39,7 +36,7 @@ def _connect_mongodb(
     if db_username and db_password:
         auth_str = f"{db_username}:{db_password}@"
 
-    extra_args_str = "&".join(f"{k}={str(v)}" for k, v in db_extra_args.items())
+    extra_args_str = "&".join(f"{k}={str(v)}" for k, v in db_extra_args)
     if extra_args_str:
         extra_args_str = "/?" + extra_args_str
 

--- a/src/taipy/core/common/_mongo_connector.py
+++ b/src/taipy/core/common/_mongo_connector.py
@@ -1,0 +1,54 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from typing import Dict, Optional
+
+import pymongo
+
+
+def _connect_mongodb(
+    db_host: str,
+    db_port: int,
+    db_username: str,
+    db_password: str,
+    db_extra_args: Dict[str, str],
+    db_driver: Optional[str] = None,
+) -> pymongo.MongoClient:
+    """Create a connection to a Mongo database.
+
+    Args:
+        db_host (str): the database host.
+        db_port (int): the database port.
+        db_username (str): the database username.
+        db_password (str): the database password.
+        db_extra_args (Dict[str, Any]): A dictionary of additional arguments to be passed into database connection
+            string.
+
+    Returns:
+        pymongo.MongoClient
+    """
+    auth_str = ""
+    if db_username and db_password:
+        auth_str = f"{db_username}:{db_password}@"
+
+    extra_args_str = "&".join(f"{k}={str(v)}" for k, v in db_extra_args.items())
+    if extra_args_str:
+        extra_args_str = "/?" + extra_args_str
+
+    driver = "mongodb"
+    if db_driver:
+        driver = f"{driver}+{db_driver}"
+
+    connection_string = f"{driver}://{auth_str}{db_host}"
+    connection_string = connection_string if db_driver else f"{connection_string}:{db_port}"
+    connection_string += extra_args_str
+
+    return pymongo.MongoClient(connection_string)

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -128,6 +128,7 @@ class DataNodeConfig(Section):
     _OPTIONAL_PASSWORD_MONGO_PROPERTY = "db_password"
     _OPTIONAL_HOST_MONGO_PROPERTY = "db_host"
     _OPTIONAL_PORT_MONGO_PROPERTY = "db_port"
+    _OPTIONAL_DRIVER_MONGO_PROPERTY = "db_driver"
     _OPTIONAL_DB_EXTRA_ARGS_MONGO_PROPERTY = "db_extra_args"
     # Pickle
     _OPTIONAL_DEFAULT_PATH_PICKLE_PROPERTY = "default_path"
@@ -217,6 +218,7 @@ class DataNodeConfig(Section):
             _OPTIONAL_PASSWORD_MONGO_PROPERTY: "",
             _OPTIONAL_HOST_MONGO_PROPERTY: "localhost",
             _OPTIONAL_PORT_MONGO_PROPERTY: 27017,
+            _OPTIONAL_DRIVER_MONGO_PROPERTY: "",
             _OPTIONAL_DB_EXTRA_ARGS_MONGO_PROPERTY: None,
         },
         _STORAGE_TYPE_VALUE_PICKLE: {
@@ -957,6 +959,7 @@ class DataNodeConfig(Section):
         db_password: Optional[str] = None,
         db_host: Optional[str] = None,
         db_port: Optional[int] = None,
+        db_driver: Optional[str] = None,
         db_extra_args: Optional[Dict[str, Any]] = None,
         scope: Optional[Scope] = None,
         validity_period: Optional[timedelta] = None,
@@ -979,6 +982,7 @@ class DataNodeConfig(Section):
                 The default value is "localhost".
             db_port (Optional[int]): The database port.<br/>
                 The default value is 27017.
+            db_driver (Optional[str]): The database driver.
             db_extra_args (Optional[dict[str, any]]): A dictionary of additional arguments to be passed
                 into database connection string.
             scope (Optional[Scope^]): The scope of the Mongo collection data node configuration.<br/>
@@ -1010,6 +1014,8 @@ class DataNodeConfig(Section):
             properties[cls._OPTIONAL_HOST_MONGO_PROPERTY] = db_host
         if db_port is not None:
             properties[cls._OPTIONAL_PORT_MONGO_PROPERTY] = db_port
+        if db_driver is not None:
+            properties[cls._OPTIONAL_DRIVER_MONGO_PROPERTY] = db_driver
         if db_extra_args is not None:
             properties[cls._OPTIONAL_DB_EXTRA_ARGS_MONGO_PROPERTY] = db_extra_args
 

--- a/src/taipy/core/data/mongo.py
+++ b/src/taipy/core/data/mongo.py
@@ -10,11 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 from datetime import datetime, timedelta
-from functools import lru_cache
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Set
-
-import pymongo
 
 from taipy.config.common.scope import Scope
 
@@ -61,6 +58,7 @@ class MongoCollectionDataNode(DataNode):
             - _"db_password"_ `(str)`: The database password.\n
             - _"db_host"_ `(str)`: The database host. The default value is _"localhost"_.\n
             - _"db_port"_ `(int)`: The database port. The default value is 27017.\n
+            - _"db_driver"_ `(str)`: The database driver.\n
             - _"db_extra_args"_ `(Dict[str, Any])`: A dictionary of additional arguments to be passed into database
                 connection string.\n
     """
@@ -74,12 +72,12 @@ class MongoCollectionDataNode(DataNode):
     __DB_HOST_KEY = "db_host"
     __DB_PORT_KEY = "db_port"
     __DB_EXTRA_ARGS_KEY = "db_extra_args"
+    __DB_DRIVER_KEY = "db_driver"
 
     __DB_HOST_DEFAULT = "localhost"
     __DB_PORT_DEFAULT = 27017
 
     _CUSTOM_DOCUMENT_PROPERTY = "custom_document"
-    __DB_EXTRA_ARGS_KEY = "db_extra_args"
     _REQUIRED_PROPERTIES: List[str] = [
         __DB_NAME_KEY,
         __COLLECTION_KEY,
@@ -134,7 +132,8 @@ class MongoCollectionDataNode(DataNode):
             db_port=properties.get(self.__DB_PORT_KEY, self.__DB_PORT_DEFAULT),
             db_username=properties.get(self.__DB_USERNAME_KEY, ""),
             db_password=properties.get(self.__DB_PASSWORD_KEY, ""),
-            db_extra_args=properties.get(self.__DB_EXTRA_ARGS_KEY, {}),
+            db_driver=properties.get(self.__DB_DRIVER_KEY, ""),
+            db_extra_args=frozenset(properties.get(self.__DB_EXTRA_ARGS_KEY, {}).items()),
         )
         self.collection = mongo_client[properties.get(self.__DB_NAME_KEY, "")][
             properties.get(self.__COLLECTION_KEY, "")
@@ -164,6 +163,7 @@ class MongoCollectionDataNode(DataNode):
                 self.__DB_PASSWORD_KEY,
                 self.__DB_HOST_KEY,
                 self.__DB_PORT_KEY,
+                self.__DB_DRIVER_KEY,
                 self.__DB_EXTRA_ARGS_KEY,
             }
         )

--- a/src/taipy/core/data/mongo.py
+++ b/src/taipy/core/data/mongo.py
@@ -10,6 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from datetime import datetime, timedelta
+from functools import lru_cache
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Set
 
@@ -18,6 +19,7 @@ import pymongo
 from taipy.config.common.scope import Scope
 
 from .._version._version_manager_factory import _VersionManagerFactory
+from ..common._mongo_connector import _connect_mongodb
 from ..exceptions.exceptions import InvalidCustomDocument, MissingRequiredProperty
 from .data_node import DataNode
 from .data_node_id import DataNodeId, Edit
@@ -231,32 +233,3 @@ class MongoCollectionDataNode(DataNode):
             The document dictionary.
         """
         return document_object.__dict__
-
-
-def _connect_mongodb(
-    db_host: str, db_port: int, db_username: str, db_password: str, db_extra_args: Dict[str, str]
-) -> pymongo.MongoClient:
-    """Create a connection to a Mongo database.
-
-    Args:
-        db_host (str): the database host.
-        db_port (int): the database port.
-        db_username (str): the database username.
-        db_password (str): the database password.
-        db_extra_args (Dict[str, Any]): A dictionary of additional arguments to be passed into database connection
-            string.
-
-    Returns:
-        pymongo.MongoClient
-    """
-    auth_str = ""
-    if db_username and db_password:
-        auth_str = f"{db_username}:{db_password}@"
-
-    extra_args_str = "&".join(f"{k}={str(v)}" for k, v in db_extra_args.items())
-    if extra_args_str:
-        extra_args_str = "/?" + extra_args_str
-
-    connection_string = f"mongodb://{auth_str}{db_host}:{db_port}{extra_args_str}"
-
-    return pymongo.MongoClient(connection_string)

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -527,6 +527,7 @@ def test_set_default_mongo_collection_data_node_configuration():
     assert dn1.custom_document == MongoDefaultDocument
     assert dn1.db_host == "default_host"
     assert dn1.db_port == 1010
+    assert dn1.db_driver == "default server"
     assert dn1.db_extra_args == {"default": "default"}
     assert dn1.scope == Scope.GLOBAL
     assert dn1.validity_period == timedelta(2)
@@ -547,6 +548,7 @@ def test_set_default_mongo_collection_data_node_configuration():
     assert dn2.custom_document == MongoDefaultDocument
     assert dn2.db_host == "host_2"
     assert dn2.db_port == 2020
+    assert dn2.db_driver == "default server"
     assert dn2.db_extra_args == {"default": "default"}
     assert dn2.scope == Scope.GLOBAL
     assert dn2.validity_period == timedelta(2)

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -91,6 +91,7 @@ def test_data_node_config_default_parameter():
     assert mongo_dn_cfg.custom_document == MongoDefaultDocument
     assert mongo_dn_cfg.db_username == ""
     assert mongo_dn_cfg.db_password == ""
+    assert mongo_dn_cfg.db_driver == ""
     assert mongo_dn_cfg.validity_period is None
 
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/taipy-613ef328affde6000ff77fb3/issues/gh/avaiga/taipy-enterprise/242

Since additional "srv" option for pymongo can be installed really quickly, I decided to keep it and not make it optional and complicating the solution