### PR TITLE
bug/ fixed multiple values for "name" argument

### DIFF
--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -38,6 +38,7 @@ class _DataManager(_Manager[DataNode], _VersionMixin):
     _ENTITY_NAME = DataNode.__name__
     _EVENT_ENTITY_TYPE = EventEntityType.DATA_NODE
     _repository: _DataFSRepository
+    __NAME_KEY = "name"
 
     @classmethod
     def _bulk_get_or_create(
@@ -95,6 +96,7 @@ class _DataManager(_Manager[DataNode], _VersionMixin):
             return cls.__DATA_NODE_CLASS_MAP[storage_type](
                 config_id=data_node_config.id,
                 scope=data_node_config.scope or DataNodeConfig._DEFAULT_SCOPE,
+                name=props.pop(cls.__NAME_KEY, None),
                 validity_period=data_node_config.validity_period,
                 owner_id=owner_id,
                 parent_ids=parent_ids,

--- a/tests/core/data/test_data_manager.py
+++ b/tests/core/data/test_data_manager.py
@@ -44,6 +44,11 @@ class TestDataManager:
         assert dn.properties.get("foo") == "bar"
         assert dn.properties.get("baz") == "qux"
 
+    def test_create_data_node_with_name_provided(self):
+        dn_config = Config.configure_data_node(id="dn", foo="bar", name="acb")
+        dn = _DataManager._create_and_set(dn_config, None, None)
+        assert dn.name == "acb"
+
     def test_create_and_get_csv_data_node(self):
         # Test we can instantiate a CsvDataNode from DataNodeConfig with :
         # - a csv type


### PR DESCRIPTION
Fixed issue raised by Fabien

"""
Bad issue trying to change the label of a Data Node.
Scenario :
- my page has a data node selector and a data node viewer
- a scenario configured containing a data node called 'a' (literal, pickle)
- I select the 'a' data node from the selector and change its name to 'b' in the data node viewer.
  (click in the 'Label' value cell, change to 'b' and Apply.
  First issue: the label is not changed in the data node viewer (and anywhere for that matter).
  Taipy does receive a 'DATA_NODE' event.
   Note: in `.data`, the data node's definition now contains two "name" properties (a no-no in JSON).
   The first one is set to null, the second is set to the new value.
- I select another data node from the selector.
  First issue: the app is locked and the console contains:

```
TaipyGuiWarning: Access to <class 'taipy.core.scenario.scenario.Scenario'> (SCENARIO_scenario_<id>) failed:
Traceback (most recent call last):
File "...\taipy\src\taipy\gui_core\_context.py", line 535, in data_node_adapter
    self.__do_datanodes_tree()
File "...\taipy\src\taipy\gui_core\_context.py", line 520, in __do_datanodes_tree
    for dn in get_data_nodes():
File "...\taipy\core\taipy.py", line 677, in get_data_nodes   
    return _DataManagerFactory._build_manager()._get_all()
File "...\taipy\core\data\_data_manager.py", line 113, in _get_all
    return cls._repository._load_all(filters)
File "...\taipy\core\_repository\_filesystem_repository.py", line 87, in _load_all
    entities.append(self.__file_content_to_entity(data))
File "...\taipy\core\_repository\_filesystem_repository.py", line 231, in __file_content_to_entity
    entity = self.converter._model_to_entity(model)
File "...\taipy\core\data\_data_converter.py", line 286, in _model_to_entity
    datanode = DataNode._class_map()[model.storage_type](
File "...\taipy\core\data\pickle.py", line 94, in __init__    
    super().__init__(
TypeError: __init__() got multiple values for argument 'name'
```

- Last issue: if I stop the app and rerun it, it gets stuck in "Development mode: Clean all entities of version..."
  I need to stop the app again and manually remove the .data folder to make it runnable again.

That to me is a very bad issue that we shouldn't live with.
"""