### PR TITLE
Accept to set a data node name using the property dict

### DIFF
--- a/src/taipy/core/data/_data_converter.py
+++ b/src/taipy/core/data/_data_converter.py
@@ -144,7 +144,7 @@ class _DataNodeConverter(_AbstractConverter):
             data_node.config_id,
             data_node._scope,
             data_node.storage_type(),
-            data_node._name,
+            properties.pop("name", None) or data_node._name,
             data_node.owner_id,
             list(data_node._parent_ids),
             data_node._last_edit_date.isoformat() if data_node._last_edit_date else None,

--- a/tests/core/data/test_data_node.py
+++ b/tests/core/data/test_data_node.py
@@ -913,3 +913,14 @@ class TestDataNode:
         )
         assert dn.get_label() == "a label"
         assert dn.get_simple_label() == "a label"
+
+    def test_change_data_node_name(self):
+        cgf = Config.configure_data_node("foo", scope=Scope.GLOBAL)
+        dn = tp.create_global_data_node(cgf)
+
+        dn.name = "bar"
+        assert dn.name == "bar"
+
+        # This new syntax will be the only one allowed: https://github.com/Avaiga/taipy-core/issues/806
+        dn.properties["name"] = "baz"
+        assert dn.name == "baz"


### PR DESCRIPTION
Accept to set a data node name using the property dict instead of the actual attribute.