### PR TITLE
remove type:ignore from DataNode.storageType() method #417

### DIFF
--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -311,7 +311,7 @@ class DataNode(_Entity, _Labeled):
     @classmethod
     @abstractmethod
     def storage_type(cls) -> str:
-        return NotImplementedError  # type: ignore
+        raise NotImplementedError
 
     def read_or_raise(self) -> Any:
         """Read the data referenced by this data node.


### PR DESCRIPTION
Instead of 
```
return NotImplementedError
```
I did
```
raise NotImplementedError
```
This is for issue #417 