### PR TITLE
Fix/#818 - Config.core.version_number should be the correct version number even if not specified in the CLI

### DIFF
--- a/tests/core/config/test_core_section.py
+++ b/tests/core/config/test_core_section.py
@@ -12,6 +12,7 @@
 from unittest.mock import patch
 
 from src.taipy.core import Core
+from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
 from taipy.config import Config
 from tests.core.utils.named_temporary_file import NamedTemporaryFile
 
@@ -21,7 +22,7 @@ def test_core_section():
         core = Core()
         core.run()
     assert Config.core.mode == "development"
-    assert Config.core.version_number == ""
+    assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
     assert not Config.core.force
     core.stop()
 
@@ -74,5 +75,6 @@ def test_clean_config():
 
     assert core_config.mode == "development"
     assert core_config.version_number == ""
+
     assert core_config.force is False
     assert core_config.properties == {}

--- a/tests/core/test_core_cli.py
+++ b/tests/core/test_core_cli.py
@@ -15,6 +15,7 @@ import pytest
 
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager import _VersionManager
+from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
 from src.taipy.core.common._utils import _load_fct
 from src.taipy.core.cycle._cycle_manager import _CycleManager
 from src.taipy.core.data._data_manager import _DataManager
@@ -35,7 +36,7 @@ def test_core_cli_no_arguments():
         core = Core()
         core.run()
         assert Config.core.mode == "development"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         assert not Config.core.force
         core.stop()
 
@@ -45,6 +46,7 @@ def test_core_cli_development_mode():
         core = Core()
         core.run()
         assert Config.core.mode == "development"
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         core.stop()
 
 
@@ -53,6 +55,7 @@ def test_core_cli_dev_mode():
         core = Core()
         core.run()
         assert Config.core.mode == "development"
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         core.stop()
 
 
@@ -61,7 +64,7 @@ def test_core_cli_experiment_mode():
         core = Core()
         core.run()
         assert Config.core.mode == "experiment"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_latest_version()
         assert not Config.core.force
         core.stop()
 
@@ -92,7 +95,7 @@ def test_core_cli_production_mode():
         core = Core()
         core.run()
         assert Config.core.mode == "production"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_latest_version()
         assert not Config.core.force
         core.stop()
 

--- a/tests/core/test_core_cli_with_sql_repo.py
+++ b/tests/core/test_core_cli_with_sql_repo.py
@@ -15,6 +15,7 @@ import pytest
 
 from src.taipy.core import Core
 from src.taipy.core._version._version_manager import _VersionManager
+from src.taipy.core._version._version_manager_factory import _VersionManagerFactory
 from src.taipy.core.common._utils import _load_fct
 from src.taipy.core.cycle._cycle_manager import _CycleManager
 from src.taipy.core.data._data_manager import _DataManager
@@ -35,7 +36,7 @@ def test_core_cli_no_arguments(init_sql_repo):
         core = Core()
         core.run()
         assert Config.core.mode == "development"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         assert not Config.core.force
         core.stop()
 
@@ -45,6 +46,7 @@ def test_core_cli_development_mode(init_sql_repo):
         core = Core()
         core.run()
         assert Config.core.mode == "development"
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         core.stop()
 
 
@@ -53,6 +55,7 @@ def test_core_cli_dev_mode(init_sql_repo):
         core = Core()
         core.run()
         assert Config.core.mode == "development"
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_development_version()
         core.stop()
 
 
@@ -61,7 +64,7 @@ def test_core_cli_experiment_mode(init_sql_repo):
         core = Core()
         core.run()
         assert Config.core.mode == "experiment"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_latest_version()
         assert not Config.core.force
         core.stop()
 
@@ -91,7 +94,7 @@ def test_core_cli_production_mode(init_sql_repo):
         core = Core()
         core.run()
         assert Config.core.mode == "production"
-        assert Config.core.version_number == ""
+        assert Config.core.version_number == _VersionManagerFactory._build_manager()._get_latest_version()
         assert not Config.core.force
         core.stop()
 


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/818