### PR TITLE
Feature/#755 - Open append() method on datanodes

### DIFF
--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -164,6 +164,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
             ],
             DataNodeConfig._STORAGE_TYPE_VALUE_SQL: [
                 DataNodeConfig._REQUIRED_WRITE_QUERY_BUILDER_SQL_PROPERTY,
+                DataNodeConfig._OPTIONAL_APPEND_QUERY_BUILDER_SQL_PROPERTY,
             ],
         }
 

--- a/src/taipy/core/config/config.schema.json
+++ b/src/taipy/core/config/config.schema.json
@@ -178,6 +178,11 @@
             "type": "string",
             "taipy_function": true
           },
+          "append_query_builder": {
+            "description": "storage_type: sql specific. A callable function that takes in the data as an input parameter and returns a list of SQL queries to be executed when the append data node method is called.",
+            "type": "string",
+            "taipy_function": true
+          },
           "collection_name ": {
             "description": "storage_type: mongo_collection specific.",
             "type": "string"

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -120,6 +120,7 @@ class DataNodeConfig(Section):
     # SQL
     _REQUIRED_READ_QUERY_SQL_PROPERTY = "read_query"
     _REQUIRED_WRITE_QUERY_BUILDER_SQL_PROPERTY = "write_query_builder"
+    _OPTIONAL_APPEND_QUERY_BUILDER_SQL_PROPERTY = "append_query_builder"
     # MONGO
     _REQUIRED_DB_NAME_MONGO_PROPERTY = "db_name"
     _REQUIRED_COLLECTION_NAME_MONGO_PROPERTY = "collection_name"
@@ -207,6 +208,7 @@ class DataNodeConfig(Section):
             _OPTIONAL_HOST_SQL_PROPERTY: "localhost",
             _OPTIONAL_PORT_SQL_PROPERTY: 1433,
             _OPTIONAL_DRIVER_SQL_PROPERTY: "",
+            _OPTIONAL_APPEND_QUERY_BUILDER_SQL_PROPERTY: None,
             _OPTIONAL_FOLDER_PATH_SQLITE_PROPERTY: None,
             _OPTIONAL_FILE_EXTENSION_SQLITE_PROPERTY: ".db",
             _OPTIONAL_DB_EXTRA_ARGS_SQL_PROPERTY: None,
@@ -867,6 +869,7 @@ class DataNodeConfig(Section):
         db_engine: str,
         read_query: str,
         write_query_builder: Callable,
+        append_query_builder: Optional[Callable] = None,
         db_username: Optional[str] = None,
         db_password: Optional[str] = None,
         db_host: Optional[str] = None,
@@ -889,7 +892,9 @@ class DataNodeConfig(Section):
                 or *"postgresql"*.
             read_query (str): The SQL query string used to read the data from the database.
             write_query_builder (Callable): A callback function that takes the data as an input parameter
-                and returns a list of SQL queries.
+                and returns a list of SQL queries to be executed when writing data to the data node.
+            append_query_builder (Optional[Callable]): A callback function that takes the data as an input parameter
+                and returns a list of SQL queries to be executed when appending data to the data node.
             db_username (Optional[str]): The database username. Required by the *"mssql"*, *"mysql"*, and
                 *"postgresql"* engines.
             db_password (Optional[str]): The database password. Required by the *"mssql"*, *"mysql"*, and
@@ -927,6 +932,8 @@ class DataNodeConfig(Section):
             }
         )
 
+        if append_query_builder is not None:
+            properties[cls._OPTIONAL_APPEND_QUERY_BUILDER_SQL_PROPERTY] = append_query_builder
         if db_username is not None:
             properties[cls._OPTIONAL_DB_USERNAME_SQL_PROPERTY] = db_username
         if db_password is not None:

--- a/src/taipy/core/data/_abstract_sql.py
+++ b/src/taipy/core/data/_abstract_sql.py
@@ -289,6 +289,22 @@ class _AbstractSQLDataNode(DataNode, _AbstractTabularDataNode):
     def _get_base_read_query(self) -> str:
         raise NotImplementedError
 
+    def _append(self, data) -> None:
+        engine = self._get_engine()
+        with engine.connect() as connection:
+            with connection.begin() as transaction:
+                try:
+                    self._do_append(data, engine, connection)
+                except Exception as e:
+                    transaction.rollback()
+                    raise e
+                else:
+                    transaction.commit()
+
+    @abstractmethod
+    def _do_append(self, data, engine, connection) -> None:
+        raise NotImplementedError
+
     def _write(self, data) -> None:
         """Check data against a collection of types to handle insertion on the database."""
         engine = self._get_engine()

--- a/src/taipy/core/data/_data_converter.py
+++ b/src/taipy/core/data/_data_converter.py
@@ -33,6 +33,8 @@ class _DataNodeConverter(_AbstractConverter):
     _EXPOSED_TYPE_KEY = "exposed_type"
     __WRITE_QUERY_BUILDER_NAME_KEY = "write_query_builder_name"
     __WRITE_QUERY_BUILDER_MODULE_KEY = "write_query_builder_module"
+    __APPEND_QUERY_BUILDER_NAME_KEY = "append_query_builder_name"
+    __APPEND_QUERY_BUILDER_MODULE_KEY = "append_query_builder_module"
     # TODO: This limits the valid string to only the ones provided by the Converter.
     # While in practice, each data nodes might have different exposed type possibilities.
     # The previous implementation used tabular datanode but it's no longer suitable so
@@ -71,10 +73,15 @@ class _DataNodeConverter(_AbstractConverter):
 
     @classmethod
     def __serialize_sql_dn_properties(cls, datanode_properties: dict) -> dict:
-        query_builder = datanode_properties.get(SQLDataNode._WRITE_QUERY_BUILDER_KEY)
-        datanode_properties[cls.__WRITE_QUERY_BUILDER_NAME_KEY] = query_builder.__name__ if query_builder else None
-        datanode_properties[cls.__WRITE_QUERY_BUILDER_MODULE_KEY] = query_builder.__module__ if query_builder else None
+        write_qb = datanode_properties.get(SQLDataNode._WRITE_QUERY_BUILDER_KEY)
+        datanode_properties[cls.__WRITE_QUERY_BUILDER_NAME_KEY] = write_qb.__name__ if write_qb else None
+        datanode_properties[cls.__WRITE_QUERY_BUILDER_MODULE_KEY] = write_qb.__module__ if write_qb else None
         datanode_properties.pop(SQLDataNode._WRITE_QUERY_BUILDER_KEY, None)
+
+        append_qb = datanode_properties.get(SQLDataNode._APPEND_QUERY_BUILDER_KEY)
+        datanode_properties[cls.__APPEND_QUERY_BUILDER_NAME_KEY] = append_qb.__name__ if append_qb else None
+        datanode_properties[cls.__APPEND_QUERY_BUILDER_MODULE_KEY] = append_qb.__module__ if append_qb else None
+        datanode_properties.pop(SQLDataNode._APPEND_QUERY_BUILDER_KEY, None)
 
         return datanode_properties
 
@@ -209,7 +216,6 @@ class _DataNodeConverter(_AbstractConverter):
 
     @classmethod
     def __deserialize_sql_dn_model_properties(cls, datanode_model_properties: dict) -> dict:
-
         if datanode_model_properties[cls.__WRITE_QUERY_BUILDER_MODULE_KEY]:
             datanode_model_properties[SQLDataNode._WRITE_QUERY_BUILDER_KEY] = _load_fct(
                 datanode_model_properties[cls.__WRITE_QUERY_BUILDER_MODULE_KEY],
@@ -220,6 +226,17 @@ class _DataNodeConverter(_AbstractConverter):
 
         del datanode_model_properties[cls.__WRITE_QUERY_BUILDER_NAME_KEY]
         del datanode_model_properties[cls.__WRITE_QUERY_BUILDER_MODULE_KEY]
+
+        if datanode_model_properties[cls.__APPEND_QUERY_BUILDER_MODULE_KEY]:
+            datanode_model_properties[SQLDataNode._APPEND_QUERY_BUILDER_KEY] = _load_fct(
+                datanode_model_properties[cls.__APPEND_QUERY_BUILDER_MODULE_KEY],
+                datanode_model_properties[cls.__APPEND_QUERY_BUILDER_NAME_KEY],
+            )
+        else:
+            datanode_model_properties[SQLDataNode._APPEND_QUERY_BUILDER_KEY] = None
+
+        del datanode_model_properties[cls.__APPEND_QUERY_BUILDER_NAME_KEY]
+        del datanode_model_properties[cls.__APPEND_QUERY_BUILDER_MODULE_KEY]
 
         return datanode_model_properties
 

--- a/src/taipy/core/data/csv.py
+++ b/src/taipy/core/data/csv.py
@@ -233,6 +233,14 @@ class CSVDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode):
         except pd.errors.EmptyDataError:
             return modin_pd.DataFrame()
 
+    def _append(self, data: Any):
+        if isinstance(data, (pd.DataFrame, modin_pd.DataFrame)):
+            data.to_csv(self._path, mode="a", index=False, encoding=self.properties[self.__ENCODING_KEY], header=False)
+        else:
+            pd.DataFrame(data).to_csv(
+                self._path, mode="a", index=False, encoding=self.properties[self.__ENCODING_KEY], header=False
+            )
+
     def _write(self, data: Any):
         if isinstance(data, (pd.DataFrame, modin_pd.DataFrame)):
             data.to_csv(self._path, index=False, encoding=self.properties[self.__ENCODING_KEY])

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -332,6 +332,22 @@ class DataNode(_Entity, _Labeled):
             )
             return None
 
+    def append(self, data, job_id: Optional[JobId] = None, **kwargs: Dict[str, Any]):
+        """Append some data to this data node.
+
+        Parameters:
+            data (Any): The data to write to this data node.
+            job_id (JobId^): An optional identifier of the writer.
+            **kwargs (dict[str, any]): Extra information to attach to the edit document
+                corresponding to this write.
+        """
+        from ._data_manager_factory import _DataManagerFactory
+
+        self._append(data)
+        self.track_edit(job_id=job_id, **kwargs)
+        self.unlock_edit()
+        _DataManagerFactory._build_manager()._set(self)
+
     def write(self, data, job_id: Optional[JobId] = None, **kwargs: Dict[str, Any]):
         """Write some data to this data node.
 
@@ -436,6 +452,10 @@ class DataNode(_Entity, _Labeled):
 
     @abstractmethod
     def _read(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def _append(self, data):
         raise NotImplementedError
 
     @abstractmethod

--- a/src/taipy/core/data/json.py
+++ b/src/taipy/core/data/json.py
@@ -183,6 +183,20 @@ class JSONDataNode(DataNode, _AbstractFileDataNode):
         with open(self._path, "r", encoding=self.properties[self.__ENCODING_KEY]) as f:
             return json.load(f, cls=self._decoder)
 
+    def _append(self, data: Any):
+        with open(self._path, "r+", encoding=self.properties[self.__ENCODING_KEY]) as f:
+            file_data = json.load(f, cls=self._decoder)
+            if isinstance(file_data, List):
+                if isinstance(data, List):
+                    file_data.extend(data)
+                else:
+                    file_data.append(data)
+            elif isinstance(data, Dict):
+                file_data.update(data)
+
+            f.seek(0)
+            json.dump(file_data, f, indent=4, cls=self._encoder)
+
     def _write(self, data: Any):
         with open(self._path, "w", encoding=self.properties[self.__ENCODING_KEY]) as f:  # type: ignore
             json.dump(data, f, indent=4, cls=self._encoder)

--- a/src/taipy/core/data/parquet.py
+++ b/src/taipy/core/data/parquet.py
@@ -227,6 +227,9 @@ class ParquetDataNode(DataNode, _AbstractFileDataNode, _AbstractTabularDataNode)
     def _read_as_modin_dataframe(self, read_kwargs: Dict) -> modin_pd.DataFrame:
         return modin_pd.read_parquet(self._path, **read_kwargs)
 
+    def _append(self, data: Any):
+        self.write_with_kwargs(data, engine="fastparquet", append=True)
+
     def _write(self, data: Any):
         self.write_with_kwargs(data)
 

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -17,7 +17,7 @@ from sqlalchemy import text
 from taipy.config.common.scope import Scope
 
 from .._version._version_manager_factory import _VersionManagerFactory
-from ..exceptions.exceptions import MissingRequiredProperty
+from ..exceptions.exceptions import MissingAppendQueryBuilder, MissingRequiredProperty
 from ._abstract_sql import _AbstractSQLDataNode
 from .data_node_id import DataNodeId, Edit
 
@@ -131,6 +131,9 @@ class SQLDataNode(_AbstractSQLDataNode):
         return self.properties.get(self.__READ_QUERY_KEY)
 
     def _do_append(self, data, engine, connection) -> None:
+        if not self.properties.get(self._APPEND_QUERY_BUILDER_KEY):
+            raise MissingAppendQueryBuilder
+
         queries = self.properties.get(self._APPEND_QUERY_BUILDER_KEY)(data)
         self.__execute_queries(queries, connection)
 

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -138,8 +138,8 @@ class SQLDataNode(_AbstractSQLDataNode):
         queries = self.properties.get(self._WRITE_QUERY_BUILDER_KEY)(data)
         self.__execute_queries(queries, connection)
 
-    def __execute_queries(self, queries: List[str], connection) -> None:
-        if not isinstance(queries, list):
+    def __execute_queries(self, queries, connection) -> None:
+        if not isinstance(queries, List):
             queries = [queries]
         for query in queries:
             if isinstance(query, str):

--- a/src/taipy/core/data/sql.py
+++ b/src/taipy/core/data/sql.py
@@ -55,7 +55,9 @@ class SQLDataNode(_AbstractSQLDataNode):
                 _"postgresql"_.
             - _"read_query"_ `(str)`: The SQL query string used to read the data from the database.
             - _"write_query_builder"_ `(Callable)`: A callback function that takes the data as an input parameter and
-                returns a list of SQL queries.
+                returns a list of SQL queries to be executed when writing data to the data node.
+            - _"append_query_builder"_ `(Callable)`: A callback function that takes the data as an input parameter and
+                returns a list of SQL queries to be executed when appending data to the data node.
             - _"db_username"_ `(str)`: The database username.
             - _"db_password"_ `(str)`: The database password.
             - _"db_host"_ `(str)`: The database host. The default value is _"localhost"_.
@@ -72,6 +74,7 @@ class SQLDataNode(_AbstractSQLDataNode):
     __STORAGE_TYPE = "sql"
     __READ_QUERY_KEY = "read_query"
     _WRITE_QUERY_BUILDER_KEY = "write_query_builder"
+    _APPEND_QUERY_BUILDER_KEY = "append_query_builder"
 
     def __init__(
         self,
@@ -116,6 +119,7 @@ class SQLDataNode(_AbstractSQLDataNode):
             {
                 self.__READ_QUERY_KEY,
                 self._WRITE_QUERY_BUILDER_KEY,
+                self._APPEND_QUERY_BUILDER_KEY,
             }
         )
 
@@ -126,8 +130,15 @@ class SQLDataNode(_AbstractSQLDataNode):
     def _get_base_read_query(self) -> str:
         return self.properties.get(self.__READ_QUERY_KEY)
 
+    def _do_append(self, data, engine, connection) -> None:
+        queries = self.properties.get(self._APPEND_QUERY_BUILDER_KEY)(data)
+        self.__execute_queries(queries, connection)
+
     def _do_write(self, data, engine, connection) -> None:
         queries = self.properties.get(self._WRITE_QUERY_BUILDER_KEY)(data)
+        self.__execute_queries(queries, connection)
+
+    def __execute_queries(self, queries: List[str], connection) -> None:
         if not isinstance(queries, list):
             queries = [queries]
         for query in queries:

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -116,17 +116,8 @@ class SQLTableDataNode(_AbstractSQLDataNode):
     def _get_base_read_query(self) -> str:
         return f"SELECT * FROM {self.properties[self.__TABLE_KEY]}"
 
-    def _append(self, data) -> None:
-        engine = self._get_engine()
-        with engine.connect() as connection:
-            with connection.begin() as transaction:
-                try:
-                    self.__insert_data(data, engine, connection)
-                except Exception as e:
-                    transaction.rollback()
-                    raise e
-                else:
-                    transaction.commit()
+    def _do_append(self, data, engine, connection) -> None:
+        self.__insert_data(data, engine, connection)
 
     def _do_write(self, data, engine, connection) -> None:
         self.__insert_data(data, engine, connection, delete_table=True)

--- a/src/taipy/core/data/sql_table.py
+++ b/src/taipy/core/data/sql_table.py
@@ -116,25 +116,52 @@ class SQLTableDataNode(_AbstractSQLDataNode):
     def _get_base_read_query(self) -> str:
         return f"SELECT * FROM {self.properties[self.__TABLE_KEY]}"
 
+    def _append(self, data) -> None:
+        engine = self._get_engine()
+        with engine.connect() as connection:
+            with connection.begin() as transaction:
+                try:
+                    self.__insert_data(data, engine, connection)
+                except Exception as e:
+                    transaction.rollback()
+                    raise e
+                else:
+                    transaction.commit()
+
     def _do_write(self, data, engine, connection) -> None:
+        self.__insert_data(data, engine, connection, delete_table=True)
+
+    def __insert_data(self, data, engine, connection, delete_table: bool = False) -> None:
+        """
+        Insert data into a SQL table.
+
+        Parameters:
+            data (List[Dict]): a list of dictionaries, where each dictionary represents a row of the table.
+            table: a SQLAlchemy object that represents a table.
+            connection: a SQLAlchemy connection to write the data.
+            delete_table (bool): indicates if the table should be deleted before inserting the data.
+        """
         table = self._create_table(engine)
         if isinstance(data, (modin_pd.DataFrame, pd.DataFrame)):
-            self._insert_dataframe(data, table, connection)
+            self.__insert_dataframe(data, table, connection, delete_table)
+            return
+
+        if isinstance(data, np.ndarray):
+            data = data.tolist()
+        if not isinstance(data, list):
+            data = [data]
+
+        if len(data) == 0:
+            self.__delete_all_rows(table, connection, delete_table)
+            return
+
+        if isinstance(data[0], (tuple, list)):
+            self.__insert_tuples(data, table, connection, delete_table)
+        elif isinstance(data[0], dict):
+            self.__insert_dicts(data, table, connection, delete_table)
+        # If data is a primitive type, it will be inserted as a tuple of one element.
         else:
-            if isinstance(data, np.ndarray):
-                data = data.tolist()
-            if not isinstance(data, list):
-                data = [data]
-            if len(data) == 0:
-                self._delete_all_rows(table, connection)
-            else:
-                if isinstance(data[0], (tuple, list)):
-                    self._insert_tuples(data, table, connection)
-                elif isinstance(data[0], dict):
-                    self._insert_dicts(data, table, connection)
-                # If data is a primitive type, it will be inserted as a tuple of one element.
-                else:
-                    self._insert_tuples([(x,) for x in data], table, connection)
+            self.__insert_tuples([(x,) for x in data], table, connection, delete_table)
 
     def _create_table(self, engine) -> Table:
         return Table(
@@ -143,37 +170,35 @@ class SQLTableDataNode(_AbstractSQLDataNode):
             autoload_with=engine,
         )
 
-    @staticmethod
-    def _insert_dicts(data: List[Dict], table: Any, connection: Any) -> None:
+    @classmethod
+    def __insert_dicts(cls, data: List[Dict], table: Any, connection: Any, delete_table: bool) -> None:
         """
         This method will insert the data contained in a list of dictionaries into a table. The query itself is handled
         by SQLAlchemy, so it's only needed to pass the correct data type.
         """
-        connection.execute(table.delete())
+        cls.__delete_all_rows(table, connection, delete_table)
         connection.execute(table.insert(), data)
 
-    @staticmethod
-    def _insert_dataframe(df: Union[modin_pd.DataFrame, pd.DataFrame], table: Any, connection: Any) -> None:
-        """
-        :param data: a pandas dataframe
-        :param table: a SQLAlchemy object that represents a table
-        :param connection: a SQLAlchemy connection to write the data
-        """
-        SQLTableDataNode._insert_dicts(df.to_dict(orient="records"), table, connection)
+    @classmethod
+    def __insert_dataframe(
+        cls, df: Union[modin_pd.DataFrame, pd.DataFrame], table: Any, connection: Any, delete_table: bool
+    ) -> None:
+        cls.__insert_dicts(df.to_dict(orient="records"), table, connection, delete_table)
 
-    @staticmethod
-    def _delete_all_rows(table, connection):
-        connection.execute(table.delete())
-
-    @staticmethod
-    def _insert_tuples(data: List[Union[Tuple, List]], table: Any, connection: Any) -> None:
+    @classmethod
+    def __insert_tuples(cls, data: List[Union[Tuple, List]], table: Any, connection: Any, delete_table: bool) -> None:
         """
         This method will look up the length of the first object of the list and build the insert through
         creation of a string of '?' equivalent to the length of the element. The '?' character is used as
         placeholder for a tuple of same size.
         """
-        connection.execute(table.delete())
+        cls.__delete_all_rows(table, connection, delete_table)
         markers = ",".join("?" * len(data[0]))
         ins = "INSERT INTO {tablename} VALUES ({markers})"
         ins = ins.format(tablename=table.name, markers=markers)
         connection.execute(ins, data)
+
+    @classmethod
+    def __delete_all_rows(cls, table: Any, connection: Any, delete_table: bool) -> None:
+        if delete_table:
+            connection.execute(table.delete())

--- a/src/taipy/core/exceptions/exceptions.py
+++ b/src/taipy/core/exceptions/exceptions.py
@@ -62,6 +62,10 @@ class UnknownDatabaseEngine(Exception):
     """Raised if the database engine is not known when creating a connection with a SQLDataNode."""
 
 
+class MissingAppendQueryBuilder(Exception):
+    """Raised if no append query build is provided when appending data to a SQLDataNode."""
+
+
 class UnknownParquetEngine(Exception):
     """Raised if the parquet engine is not known or not supported when create a ParquetDataNode."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def excel_file_with_sheet_name(tmpdir_factory) -> str:
 def json_file(tmpdir_factory) -> str:
     json_data = pd.DataFrame([{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}])
     fn = tmpdir_factory.mktemp("data").join("df.json")
-    json_data.to_json(str(fn))
+    json_data.to_json(str(fn), orient="records")
     return fn.strpath
 
 

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -440,16 +440,22 @@ class TestDataNodeConfigChecker:
             "db_engine": "foo",
             "read_query": "foo",
             "write_query_builder": 1,
+            "append_query_builder": 2,
         }
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
             Config.check()
-        assert len(Config._collector.errors) == 1
-        expected_error_message = (
+        assert len(Config._collector.errors) == 2
+        expected_error_message_1 = (
             "`write_query_builder` of DataNodeConfig `new` must be populated with a Callable function."
             " Current value of property `write_query_builder` is 1."
         )
-        assert expected_error_message in caplog.text
+        assert expected_error_message_1 in caplog.text
+        expected_error_message_2 = (
+            "`append_query_builder` of DataNodeConfig `new` must be populated with a Callable function."
+            " Current value of property `append_query_builder` is 2."
+        )
+        assert expected_error_message_2 in caplog.text
 
         config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
         config._sections[DataNodeConfig.name]["new"].properties = {"write_fct": 12}

--- a/tests/core/config/test_config.py
+++ b/tests/core/config/test_config.py
@@ -67,7 +67,7 @@ class TestConfig:
         assert len(Config.data_nodes) == 2
 
     def test_configure_sql_data_node(self):
-        a, b, c, d, e, f, g, h, i, j, extra_args, exposed_type, scope, vp, k = (
+        a, b, c, d, e, f, g, h, i, j, k, extra_args, exposed_type, scope, vp, k = (
             "foo",
             "user",
             "pwd",
@@ -75,6 +75,7 @@ class TestConfig:
             "engine",
             "read_query",
             "write_query_builder",
+            "append_query_builder",
             "port",
             "host",
             "driver",
@@ -84,7 +85,7 @@ class TestConfig:
             timedelta(1),
             "qux",
         )
-        Config.configure_sql_data_node(a, b, c, d, e, f, g, h, i, j, extra_args, exposed_type, scope, vp, property=k)
+        Config.configure_sql_data_node(a, b, c, d, e, f, g, h, i, j, k, extra_args, exposed_type, scope, vp, property=k)
         assert len(Config.data_nodes) == 2
 
     def test_configure_mongo_data_node(self):

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -431,6 +431,7 @@ def test_set_default_sql_data_node_configuration():
         db_engine="mssql",
         read_query="SELECT * FROM default_table",
         write_query_builder=query_builder,
+        append_query_builder=query_builder,
         db_port=1010,
         db_host="default_host",
         db_driver="default server",
@@ -449,6 +450,7 @@ def test_set_default_sql_data_node_configuration():
     assert dn1.db_engine == "mssql"
     assert dn1.read_query == "SELECT * FROM default_table"
     assert dn1.write_query_builder == query_builder
+    assert dn1.append_query_builder == query_builder
     assert dn1.db_port == 1010
     assert dn1.db_host == "default_host"
     assert dn1.db_driver == "default server"
@@ -468,6 +470,7 @@ def test_set_default_sql_data_node_configuration():
     assert dn2.db_engine == "mssql"
     assert dn2.read_query == "SELECT * FROM table_2"
     assert dn2.write_query_builder == query_builder
+    assert dn2.append_query_builder == query_builder
     assert dn2.db_port == 2020
     assert dn2.db_host == "host_2"
     assert dn2.db_driver == "default server"
@@ -495,6 +498,7 @@ def test_set_default_sql_data_node_configuration():
     assert dn3.db_engine == "postgresql"
     assert dn3.read_query == "SELECT * FROM table_3"
     assert dn3.write_query_builder == query_builder
+    assert dn3.append_query_builder == query_builder
     assert dn3.db_port == 1010
     assert dn3.db_host == "default_host"
     assert dn3.db_driver == "default server"

--- a/tests/core/data/test_json_data_node.py
+++ b/tests/core/data/test_json_data_node.py
@@ -172,6 +172,35 @@ class TestJSONDataNode:
         with pytest.raises(ValueError):
             dn.read()
 
+    def test_append_to_list(self, json_file):
+        json_dn = JSONDataNode("foo", Scope.SCENARIO, properties={"default_path": json_file})
+        original_data = json_dn.read()
+
+        # Append a dictionary
+        append_data_1 = {"a": 1, "b": 2, "c": 3}
+        json_dn.append(append_data_1)
+        assert json_dn.read() == original_data + [append_data_1]
+
+        # Append a list of dictionaries
+        append_data_data_2 = [{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]
+        json_dn.append(append_data_data_2)
+        assert json_dn.read() == original_data + [append_data_1] + append_data_data_2
+
+    def test_append_to_a_dictionary(self, json_file):
+        json_dn = JSONDataNode("foo", Scope.SCENARIO, properties={"default_path": json_file})
+        original_data = {"a": 1, "b": 2, "c": 3}
+        json_dn.write(original_data)
+
+        # Append another dictionary
+        append_data_1 = {"d": 1, "e": 2, "f": 3}
+        json_dn.append(append_data_1)
+        assert json_dn.read() == {**original_data, **append_data_1}
+
+        # Append an overlap dictionary
+        append_data_data_2 = {"a": 10, "b": 20, "g": 30}
+        json_dn.append(append_data_data_2)
+        assert json_dn.read() == {**original_data, **append_data_1, **append_data_data_2}
+
     def test_write(self, json_file):
         json_dn = JSONDataNode("foo", Scope.SCENARIO, properties={"default_path": json_file})
         data = {"a": 1, "b": 2, "c": 3}

--- a/tests/core/data/test_mongo_data_node.py
+++ b/tests/core/data/test_mongo_data_node.py
@@ -210,6 +210,25 @@ class TestMongoCollectionDataNode:
     @mongomock.patch(servers=(("localhost", 27017),))
     @pytest.mark.parametrize("properties", __properties)
     @pytest.mark.parametrize(
+        "data",
+        [
+            ([{"foo": 11, "bar": 22}, {"foo": 33, "bar": 44}]),
+            ({"foz": 1, "baz": 2}),
+        ],
+    )
+    def test_append(self, properties, data):
+        mongo_dn = MongoCollectionDataNode("foo", Scope.SCENARIO, properties=properties)
+        mongo_dn.append(data)
+
+        original_data = [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]
+        mongo_dn.write(original_data)
+
+        mongo_dn.append(data)
+        assert len(mongo_dn.read()) == len(data if isinstance(data, list) else [data]) + len(original_data)
+
+    @mongomock.patch(servers=(("localhost", 27017),))
+    @pytest.mark.parametrize("properties", __properties)
+    @pytest.mark.parametrize(
         "data,written_data",
         [
             ([{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}], [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]),

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -300,6 +300,7 @@ class TestParquetDataNode:
 
         os.unlink(temp_file_path)
 
+    @pytest.mark.skipif(not util.find_spec("fastparquet"), reason="Append parquet requires fastparquet to be installed")
     @pytest.mark.parametrize(
         "content",
         [
@@ -308,10 +309,6 @@ class TestParquetDataNode:
         ],
     )
     def test_append_pandas(self, parquet_file_path, default_data_frame, content):
-        # !!! append data only works with `fastparquet`
-        if not util.find_spec("fastparquet"):
-            pass
-
         dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": parquet_file_path})
         assert_frame_equal(dn.read(), default_data_frame)
 
@@ -321,6 +318,7 @@ class TestParquetDataNode:
             pd.concat([default_data_frame, pd.DataFrame(content, columns=["a", "b", "c"])]).reset_index(drop=True),
         )
 
+    @pytest.mark.skipif(not util.find_spec("fastparquet"), reason="Append parquet requires fastparquet to be installed")
     @pytest.mark.parametrize(
         "content",
         [
@@ -329,10 +327,6 @@ class TestParquetDataNode:
         ],
     )
     def test_append_modin(self, parquet_file_path, default_data_frame, content):
-        # !!! append data only works with `fastparquet`
-        if not util.find_spec("fastparquet"):
-            pass
-
         dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": parquet_file_path, "exposed_type": "modin"})
         df_equals(dn.read(), modin_pd.DataFrame(default_data_frame))
 

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -301,6 +301,50 @@ class TestParquetDataNode:
         os.unlink(temp_file_path)
 
     @pytest.mark.parametrize(
+        "content",
+        [
+            ([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}]),
+            (pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}])),
+        ],
+    )
+    def test_append_pandas(self, parquet_file_path, default_data_frame, content):
+        # !!! append data only works with `fastparquet`
+        if not util.find_spec("fastparquet"):
+            pass
+
+        dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": parquet_file_path})
+        assert_frame_equal(dn.read(), default_data_frame)
+
+        dn.append(content)
+        assert_frame_equal(
+            dn.read(),
+            pd.concat([default_data_frame, pd.DataFrame(content, columns=["a", "b", "c"])]).reset_index(drop=True),
+        )
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            ([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}]),
+            (pd.DataFrame([{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}])),
+        ],
+    )
+    def test_append_modin(self, parquet_file_path, default_data_frame, content):
+        # !!! append data only works with `fastparquet`
+        if not util.find_spec("fastparquet"):
+            pass
+
+        dn = ParquetDataNode("foo", Scope.SCENARIO, properties={"path": parquet_file_path, "exposed_type": "modin"})
+        df_equals(dn.read(), modin_pd.DataFrame(default_data_frame))
+
+        dn.append(content)
+        df_equals(
+            dn.read(),
+            modin_pd.concat([default_data_frame, pd.DataFrame(content, columns=["a", "b", "c"])]).reset_index(
+                drop=True
+            ),
+        )
+
+    @pytest.mark.parametrize(
         "data",
         [
             [{"a": 11, "b": 22, "c": 33}, {"a": 44, "b": 55, "c": 66}],

--- a/tests/core/data/test_sql_table_data_node.py
+++ b/tests/core/data/test_sql_table_data_node.py
@@ -465,6 +465,26 @@ class TestSQLTableDataNode:
         dn.append(append_data_1)
         assert_frame_equal(dn.read(), pd.concat([original_data, append_data_1]).reset_index(drop=True))
 
+    def test_sqlite_append_modin(self, tmp_sqlite_sqlite3_file_path):
+        folder_path, db_name, file_extension = tmp_sqlite_sqlite3_file_path
+        properties = {
+            "db_engine": "sqlite",
+            "table_name": "example",
+            "db_name": db_name,
+            "sqlite_folder_path": folder_path,
+            "sqlite_file_extension": file_extension,
+            "exposed_type": "modin",
+        }
+
+        dn = SQLTableDataNode("sqlite_dn", Scope.SCENARIO, properties=properties)
+        original_data = modin_pd.DataFrame([{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}])
+        data = dn.read()
+        df_equals(data, original_data)
+
+        append_data_1 = modin_pd.DataFrame([{"foo": 5, "bar": 6}, {"foo": 7, "bar": 8}])
+        dn.append(append_data_1)
+        df_equals(dn.read(), modin_pd.concat([original_data, append_data_1]).reset_index(drop=True))
+
     def test_filter_pandas_exposed_type(self, tmp_sqlite_sqlite3_file_path):
         folder_path, db_name, file_extension = tmp_sqlite_sqlite3_file_path
         properties = {


### PR DESCRIPTION
https://github.com/Avaiga/taipy/issues/408

This PR opens new `.append()` API for CSV, Excel, Json, MongoCollection, SQLTable data node types.

Notes on other data node types:
- GenericDataNode, we can open a new attribute to let the user define their own append method. Let me know if we want to do this.
- InMemoryDataNode, we don't know what kind of data stored in memory.
- PickleDataNode, we don't know what kind of data stored in the pickle file.
- SQLDataNode, the user can just modify the read query to append data.
- ParquetDataNode, the current method is to read the data, append the data, then rewrite, which is slow and not working properly with modin. Using `fastparquet`, there is a simpler way to do this, but I'm working on finding a better way using `pyarrow`, which is our default engine.