### PR TITLE
Address issues encountered on MacOS

### DIFF
--- a/tests/core/data/test_csv_data_node.py
+++ b/tests/core/data/test_csv_data_node.py
@@ -369,9 +369,9 @@ class TestCSVDataNode:
         )
 
         # Test datanode indexing and slicing
-        assert dn["foo"].equals(modin_pd.Series([1, 1, 1, 2, None]))
-        assert dn["bar"].equals(modin_pd.Series([1, 2, None, 2, 2]))
-        assert dn[:2].equals(modin_pd.DataFrame([{"foo": 1.0, "bar": 1.0}, {"foo": 1.0, "bar": 2.0}]))
+        df_equals(dn["foo"], modin_pd.Series([1, 1, 1, 2, None]))
+        df_equals(dn["bar"], modin_pd.Series([1, 2, None, 2, 2]))
+        df_equals(dn[:2], modin_pd.DataFrame([{"foo": 1.0, "bar": 1.0}, {"foo": 1.0, "bar": 2.0}]))
 
         # Test filter data
         filtered_by_filter_method = dn.filter(("foo", 1, Operator.EQUAL))

--- a/tests/core/data/test_parquet_data_node.py
+++ b/tests/core/data/test_parquet_data_node.py
@@ -378,9 +378,9 @@ class TestParquetDataNode:
         )
 
         # Test datanode indexing and slicing
-        assert dn["foo"].equals(modin_pd.Series([1, 1, 1, 2, None]))
-        assert dn["bar"].equals(modin_pd.Series([1, 2, None, 2, 2]))
-        assert dn[:2].equals(modin_pd.DataFrame([{"foo": 1.0, "bar": 1.0}, {"foo": 1.0, "bar": 2.0}]))
+        df_equals(dn["foo"], modin_pd.Series([1, 1, 1, 2, None]))
+        df_equals(dn["bar"], modin_pd.Series([1, 2, None, 2, 2]))
+        df_equals(dn[:2], modin_pd.DataFrame([{"foo": 1.0, "bar": 1.0}, {"foo": 1.0, "bar": 2.0}]))
 
         # Test filter data
         filtered_by_filter_method = dn.filter(("foo", 1, Operator.EQUAL))

--- a/tests/core/data/test_pickle_data_node.py
+++ b/tests/core/data/test_pickle_data_node.py
@@ -17,6 +17,7 @@ from time import sleep
 import modin.pandas as modin_pd
 import pandas as pd
 import pytest
+from modin.pandas.test.utils import df_equals
 
 from src.taipy.core.data._data_manager import _DataManager
 from src.taipy.core.data.pickle import PickleDataNode
@@ -137,7 +138,7 @@ class TestPickleDataNodeEntity:
         assert new_pandas_df.equals(pickle_pandas.read())
         assert isinstance(pickle_pandas.read(), pd.DataFrame)
         pickle_pandas.write(new_modin_df)
-        assert new_modin_df.equals(pickle_pandas.read())
+        df_equals(new_modin_df, pickle_pandas.read())
         assert isinstance(pickle_pandas.read(), modin_pd.DataFrame)
         pickle_pandas.write(1998)
         assert pickle_pandas.read() == 1998

--- a/tests/core/data/test_sql_data_node.py
+++ b/tests/core/data/test_sql_data_node.py
@@ -388,9 +388,9 @@ class TestSQLDataNode:
         )
 
         # Test datanode indexing and slicing
-        assert dn["foo"].equals(pd.Series([1, 1, 1, 2, 2, 2]))
-        assert dn["bar"].equals(pd.Series([1, 2, 3, 1, 2, 3]))
-        assert dn[:2].equals(modin_pd.DataFrame([{"foo": 1, "bar": 1}, {"foo": 1, "bar": 2}]))
+        df_equals(dn["foo"], pd.Series([1, 1, 1, 2, 2, 2]))
+        df_equals(dn["bar"], pd.Series([1, 2, 3, 1, 2, 3]))
+        df_equals(dn[:2], modin_pd.DataFrame([{"foo": 1, "bar": 1}, {"foo": 1, "bar": 2}]))
 
         # Test filter data
         filtered_by_filter_method = dn.filter(("foo", 1, Operator.EQUAL))

--- a/tests/core/data/test_sql_table_data_node.py
+++ b/tests/core/data/test_sql_table_data_node.py
@@ -353,7 +353,7 @@ class TestSQLTableDataNode:
 
             with patch("src.taipy.core.data.sql_table.SQLTableDataNode._insert_dataframe") as mck:
                 dn.write(df)
-                assert mck.call_args[0][0].equals(df)
+                df_equals(mck.call_args[0][0], df)
 
         # test write modin dataframe
         custom_properties = modin_properties.copy()
@@ -369,7 +369,7 @@ class TestSQLTableDataNode:
 
             with patch("src.taipy.core.data.sql_table.SQLTableDataNode._insert_dataframe") as mck:
                 dn.write(df)
-                assert mck.call_args[0][0].equals(df)
+                df_equals(mck.call_args[0][0], df)
 
     @pytest.mark.parametrize(
         "data",
@@ -526,9 +526,9 @@ class TestSQLTableDataNode:
         )
 
         # Test datanode indexing and slicing
-        assert dn["foo"].equals(pd.Series([1, 1, 1, 2, 2, 2]))
-        assert dn["bar"].equals(pd.Series([1, 2, 3, 1, 2, 3]))
-        assert dn[:2].equals(modin_pd.DataFrame([{"foo": 1, "bar": 1}, {"foo": 1, "bar": 2}]))
+        df_equals(dn["foo"], pd.Series([1, 1, 1, 2, 2, 2]))
+        df_equals(dn["bar"], pd.Series([1, 2, 3, 1, 2, 3]))
+        df_equals(dn[:2], modin_pd.DataFrame([{"foo": 1, "bar": 1}, {"foo": 1, "bar": 2}]))
 
         # Test filter data
         filtered_by_filter_method = dn.filter(("foo", 1, Operator.EQUAL))


### PR DESCRIPTION
# Goals
Make all the unit tests pass on MacOS

# Changes
* Use Modin builtin `df_equals` instead of `equals` to compare a Modin DF with a Pandas DF
 