### PR TITLE
Experiment additional information on core events

### DIFF
--- a/src/taipy/core/_entity/_entity.py
+++ b/src/taipy/core/_entity/_entity.py
@@ -12,7 +12,7 @@
 from typing import List
 
 from .._entity._reload import _get_manager
-from ..notification import _publish_event
+from ..notification import Notifier
 
 
 class _Entity:
@@ -34,6 +34,6 @@ class _Entity:
             self._properties.data.update(self._properties._pending_changes)
         _get_manager(self._MANAGER_NAME)._set(self)
 
-        while self._in_context_attributes_changed_collector:
-            _publish_event(*self._in_context_attributes_changed_collector.pop(0))
+        for event in self._in_context_attributes_changed_collector:
+            Notifier.publish(event)
         _get_manager(self._MANAGER_NAME)._set(self)

--- a/src/taipy/core/_entity/_properties.py
+++ b/src/taipy/core/_entity/_properties.py
@@ -11,11 +11,10 @@
 
 from collections import UserDict
 
-from ..notification import _ENTITY_TO_EVENT_ENTITY_TYPE, EventOperation, _publish_event
+from ..notification import _ENTITY_TO_EVENT_ENTITY_TYPE, EventOperation, Notifier, make_event
 
 
 class _Properties(UserDict):
-
     __PROPERTIES_ATTRIBUTE_NAME = "properties"
 
     def __init__(self, entity_owner, **kwargs):
@@ -29,20 +28,20 @@ class _Properties(UserDict):
         from ... import core as tp
 
         if hasattr(self, "_entity_owner"):
-            to_publish_event_parameters = [
-                _ENTITY_TO_EVENT_ENTITY_TYPE[self._entity_owner._MANAGER_NAME],
-                self._entity_owner.id,
+            event = make_event(
+                self._entity_owner,
                 EventOperation.UPDATE,
-                self.__PROPERTIES_ATTRIBUTE_NAME,
-            ]
+                attribute_name=self.__PROPERTIES_ATTRIBUTE_NAME,
+                attribute_value=value,
+            )
             if not self._entity_owner._is_in_context:
                 tp.set(self._entity_owner)
-                _publish_event(*to_publish_event_parameters)
+                Notifier.publish(event)
             else:
                 if key in self._pending_deletions:
                     self._pending_deletions.remove(key)
                 self._pending_changes[key] = value
-                self._entity_owner._in_context_attributes_changed_collector.append(to_publish_event_parameters)
+                self._entity_owner._in_context_attributes_changed_collector.append(event)
 
     def __getitem__(self, key):
         from taipy.config.common._template_handler import _TemplateHandler as _tpl
@@ -54,16 +53,16 @@ class _Properties(UserDict):
         from ... import core as tp
 
         if hasattr(self, "_entity_owner"):
-            to_publish_event_parameters = [
-                _ENTITY_TO_EVENT_ENTITY_TYPE[self._entity_owner._MANAGER_NAME],
-                self._entity_owner.id,
+            event = make_event(
+                self._entity_owner,
                 EventOperation.UPDATE,
-                self.__PROPERTIES_ATTRIBUTE_NAME,
-            ]
+                attribute_name=self.__PROPERTIES_ATTRIBUTE_NAME,
+                attribute_value=None,
+            )
             if not self._entity_owner._is_in_context:
                 tp.set(self._entity_owner)
-                _publish_event(*to_publish_event_parameters)
+                Notifier.publish(event)
             else:
                 self._pending_changes.pop(key, None)
                 self._pending_deletions.add(key)
-                self._entity_owner._in_context_attributes_changed_collector.append(to_publish_event_parameters)
+                self._entity_owner._in_context_attributes_changed_collector.append(event)

--- a/src/taipy/core/_entity/_reload.py
+++ b/src/taipy/core/_entity/_reload.py
@@ -11,7 +11,7 @@
 
 import functools
 
-from ..notification import EventOperation, _publish_event
+from ..notification import EventOperation, Notifier, make_event
 
 
 class _Reloader:
@@ -65,19 +65,23 @@ def _self_setter(manager):
         def _do_set_entity(self, *args, **kwargs):
             fct(self, *args, **kwargs)
             entity_manager = _get_manager(manager)
-            to_publish_event_parameters = [
-                entity_manager._EVENT_ENTITY_TYPE,
-                self.id,
+            if len(args) == 1:
+                value = args[0]
+            else:
+                value = args
+            event = make_event(
+                self,
                 EventOperation.UPDATE,
-                fct.__name__,
-            ]
+                attribute_name=fct.__name__,
+                attribute_value=value,
+            )
             if not self._is_in_context:
                 entity = _Reloader()._reload(manager, self)
                 fct(entity, *args, **kwargs)
                 entity_manager._set(entity)
-                _publish_event(*to_publish_event_parameters)
+                Notifier.publish(event)
             else:
-                self._in_context_attributes_changed_collector.append(to_publish_event_parameters)
+                self._in_context_attributes_changed_collector.append(event)
 
         return _do_set_entity
 

--- a/src/taipy/core/_manager/_manager.py
+++ b/src/taipy/core/_manager/_manager.py
@@ -34,7 +34,11 @@ class _Manager(Generic[EntityType]):
         """
         cls._repository._delete_all()
         if hasattr(cls, "_EVENT_ENTITY_TYPE"):
-            _publish_event(cls._EVENT_ENTITY_TYPE, "all", EventOperation.DELETION, None)
+            _publish_event(
+                cls._EVENT_ENTITY_TYPE,
+                EventOperation.DELETION,
+                delete_all=True,
+            )
 
     @classmethod
     def _delete_many(cls, ids: Iterable):
@@ -44,7 +48,12 @@ class _Manager(Generic[EntityType]):
         cls._repository._delete_many(ids)
         if hasattr(cls, "_EVENT_ENTITY_TYPE"):
             for entity_id in ids:
-                _publish_event(cls._EVENT_ENTITY_TYPE, entity_id, EventOperation.DELETION, None)  # type: ignore
+                _publish_event(
+                    cls._EVENT_ENTITY_TYPE,  # type: ignore
+                    EventOperation.DELETION,
+                    entity_id=entity_id,
+                    delete_all=True,
+                )
 
     @classmethod
     def _delete_by_version(cls, version_number: str):
@@ -53,7 +62,11 @@ class _Manager(Generic[EntityType]):
         """
         cls._repository._delete_by(attribute="version", value=version_number)
         if hasattr(cls, "_EVENT_ENTITY_TYPE"):
-            _publish_event(cls._EVENT_ENTITY_TYPE, None, EventOperation.DELETION, None)  # type: ignore
+            _publish_event(
+                cls._EVENT_ENTITY_TYPE,  # type: ignore
+                EventOperation.DELETION,
+                delete_by_version=version_number,
+            )
 
     @classmethod
     def _delete(cls, id):
@@ -62,7 +75,11 @@ class _Manager(Generic[EntityType]):
         """
         cls._repository._delete(id)
         if hasattr(cls, "_EVENT_ENTITY_TYPE"):
-            _publish_event(cls._EVENT_ENTITY_TYPE, id, EventOperation.DELETION, None)
+            _publish_event(
+                cls._EVENT_ENTITY_TYPE,
+                EventOperation.DELETION,
+                entity_id=id,
+            )
 
     @classmethod
     def _set(cls, entity: EntityType):

--- a/src/taipy/core/cycle/_cycle_manager.py
+++ b/src/taipy/core/cycle/_cycle_manager.py
@@ -40,7 +40,11 @@ class _CycleManager(_Manager[Cycle]):
             frequency, properties, creation_date=creation_date, start_date=start_date, end_date=end_date, name=name
         )
         cls._set(cycle)
-        _publish_event(cls._EVENT_ENTITY_TYPE, cycle.id, EventOperation.CREATION, None)
+        _publish_event(
+            cls._EVENT_ENTITY_TYPE,
+            EventOperation.CREATION,
+            entity_id=cycle.id,
+        )
         return cycle
 
     @classmethod

--- a/src/taipy/core/cycle/cycle.py
+++ b/src/taipy/core/cycle/cycle.py
@@ -21,6 +21,7 @@ from .._entity._labeled import _Labeled
 from .._entity._properties import _Properties
 from .._entity._reload import _Reloader, _self_reload, _self_setter
 from ..exceptions.exceptions import _SuspiciousFileOperation
+from ..notification.event import Event, EventEntityType, EventOperation, make_event
 from .cycle_id import CycleId
 
 
@@ -176,3 +177,22 @@ class Cycle(_Entity, _Labeled):
             The simple label of the cycle as a string.
         """
         return self._get_simple_label()
+
+
+@make_event.register(Cycle)
+def make_event_for_cycle(
+    cycle: Cycle,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    return Event(
+        entity_type=EventEntityType.CYCLE,
+        entity_id=cycle.id,
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata=kwargs,
+    )

--- a/src/taipy/core/data/_data_manager.py
+++ b/src/taipy/core/data/_data_manager.py
@@ -22,7 +22,7 @@ from .._version._version_mixin import _VersionMixin
 from ..config.data_node_config import DataNodeConfig
 from ..cycle.cycle_id import CycleId
 from ..exceptions.exceptions import InvalidDataNodeType
-from ..notification import EventEntityType, EventOperation, _publish_event
+from ..notification import Event, EventEntityType, EventOperation, Notifier, _publish_event
 from ..scenario.scenario_id import ScenarioId
 from ..sequence.sequence_id import SequenceId
 from ._abstract_file import _AbstractFileDataNode
@@ -33,7 +33,6 @@ from .pickle import PickleDataNode
 
 
 class _DataManager(_Manager[DataNode], _VersionMixin):
-
     __DATA_NODE_CLASS_MAP = DataNode._class_map()  # type: ignore
     _ENTITY_NAME = DataNode.__name__
     _EVENT_ENTITY_TYPE = EventEntityType.DATA_NODE
@@ -77,7 +76,9 @@ class _DataManager(_Manager[DataNode], _VersionMixin):
         cls._set(data_node)
         if isinstance(data_node, _AbstractFileDataNode):
             _append_to_backup_file(new_file_path=data_node._path)
-        _publish_event(cls._EVENT_ENTITY_TYPE, data_node.id, EventOperation.CREATION, None)
+        _publish_event(
+            EventEntityType.DATA_NODE, EventOperation.CREATION, entity_id=data_node.id, config_id=data_node.config_id
+        )
         return data_node
 
     @classmethod
@@ -166,7 +167,9 @@ class _DataManager(_Manager[DataNode], _VersionMixin):
         cls._clean_pickle_files(data_nodes)
         cls._remove_dn_file_paths_in_backup_file(data_nodes)
         cls._repository._delete_by(attribute="version", value=version_number)
-        _publish_event(cls._EVENT_ENTITY_TYPE, None, EventOperation.DELETION, None)
+        Notifier.publish(
+            Event(EventEntityType.DATA_NODE, EventOperation.DELETION, metadata={"delete_by_version": version_number})
+        )
 
     @classmethod
     def _get_by_config_id(cls, config_id: str, version_number: Optional[str] = None) -> List[DataNode]:

--- a/src/taipy/core/data/data_node.py
+++ b/src/taipy/core/data/data_node.py
@@ -29,6 +29,7 @@ from .._version._version_manager_factory import _VersionManagerFactory
 from ..common._warnings import _warn_deprecated
 from ..exceptions.exceptions import DataNodeIsBeingEdited, NoData
 from ..job.job_id import JobId
+from ..notification.event import Event, EventEntityType, EventOperation, make_event
 from ._filter import _FilterDataNode
 from .data_node_id import DataNodeId, Edit
 from .operator import JoinOperator
@@ -535,3 +536,23 @@ class DataNode(_Entity, _Labeled):
             The simple label of the data node as a string.
         """
         return self._get_simple_label()
+
+
+@make_event.register(DataNode)
+def make_event_for_datanode(
+    data_node: DataNode,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    return Event(
+        entity_type=EventEntityType.DATA_NODE,
+        entity_id=data_node.id,
+        config_id=data_node.config_id,
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata=kwargs,
+    )

--- a/src/taipy/core/job/_job_manager.py
+++ b/src/taipy/core/job/_job_manager.py
@@ -24,7 +24,6 @@ from .job_id import JobId
 
 
 class _JobManager(_Manager[Job], _VersionMixin):
-
     _ENTITY_NAME = Job.__name__
     _ID_PREFIX = "JOB_"
     _repository: _AbstractRepository
@@ -53,7 +52,7 @@ class _JobManager(_Manager[Job], _VersionMixin):
             version=version,
         )
         cls._set(job)
-        _publish_event(cls._EVENT_ENTITY_TYPE, job.id, EventOperation.CREATION, None)
+        _publish_event(EventEntityType.JOB, EventOperation.CREATION, entity_id=job.id, config_id=job._task.config_id)
         job._on_status_change(*callbacks)
         return job
 

--- a/src/taipy/core/job/job.py
+++ b/src/taipy/core/job/job.py
@@ -13,7 +13,7 @@ __all__ = ["Job"]
 
 import traceback
 from datetime import datetime
-from typing import Callable, List
+from typing import Any, Callable, List, Optional
 
 from taipy.logger._taipy_logger import _TaipyLogger
 
@@ -22,6 +22,7 @@ from .._entity._labeled import _Labeled
 from .._entity._reload import _self_reload, _self_setter
 from .._version._version_manager_factory import _VersionManagerFactory
 from ..common._utils import _fcts_to_dict
+from ..notification.event import Event, EventEntityType, EventOperation, make_event
 from ..task.task import Task
 from .job_id import JobId
 from .status import Status
@@ -69,6 +70,9 @@ class Job(_Entity, _Labeled):
         self._stacktrace: List[str] = []
         self.__logger = _TaipyLogger._get_logger()
         self._version = version or _VersionManagerFactory._build_manager()._get_latest_version()
+
+    def get_event_context(self):
+        return {"task_config_id": self._task.config_id}
 
     @property  # type: ignore
     @_self_reload(_MANAGER_NAME)
@@ -351,3 +355,24 @@ class Job(_Entity, _Labeled):
         from ... import core as tp
 
         return tp.is_deletable(self)
+
+
+@make_event.register(Job)
+def make_event_for_job(
+    job: Job,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    metadata = {"creation_date": job.creation_date}
+    return Event(
+        entity_type=EventEntityType.JOB,
+        entity_id=job.id,
+        config_id=job._task.config_id,  # OK
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata={**metadata, **kwargs},
+    )

--- a/src/taipy/core/notification/__init__.py
+++ b/src/taipy/core/notification/__init__.py
@@ -28,6 +28,6 @@ object) must be instantiated with an associated event queue.
 from ._registration import _Registration
 from ._topic import _Topic
 from .core_event_consumer import CoreEventConsumerBase
-from .event import _ENTITY_TO_EVENT_ENTITY_TYPE, Event, EventEntityType, EventOperation
+from .event import _ENTITY_TO_EVENT_ENTITY_TYPE, Event, EventEntityType, EventOperation, make_event
 from .notifier import Notifier, _publish_event
 from .registration_id import RegistrationId

--- a/src/taipy/core/notification/event.py
+++ b/src/taipy/core/notification/event.py
@@ -9,8 +9,10 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from functools import singledispatch
+from typing import Any, Optional
 
 from ..common._repr_enum import _ReprEnum
 from ..exceptions.exceptions import InvalidEventAttributeName, InvalidEventOperation
@@ -58,6 +60,7 @@ _ENTITY_TO_EVENT_ENTITY_TYPE = {
 }
 
 
+@dataclass(frozen=True)
 class Event:
     """Event object used to notify any change in the Core service.
 
@@ -71,30 +74,60 @@ class Event:
             and `SUBMISSION`) that was performed on the entity.
         attribute_name (Optional[str]): Name of the entity's attribute changed. Only relevant for `UPDATE`
             operations
+        attribute_value (Optional[str]): Name of the entity's attribute changed. Only relevant for `UPDATE`
+            operations
+        metadata (dict): A dict of additional medata about the source of this event
         creation_date (datetime): Date and time of the event creation.
     """
 
-    def __init__(
-        self,
-        entity_type: EventEntityType,
-        entity_id: Optional[str],
-        operation: EventOperation,
-        attribute_name: Optional[str] = None,
-    ):
-        self.creation_date = datetime.now()
-        self.entity_id = entity_id
-        self.entity_type = entity_type
-        self.operation = self.__preprocess_operation(operation, entity_type)
-        self.attribute_name = self.__preprocess_attribute_name(attribute_name, operation)
+    entity_type: EventEntityType
+    operation: EventOperation
+    entity_id: Optional[str] = None
+    config_id: Optional[str] = None
+    attribute_name: Optional[str] = None
+    attribute_value: Optional[Any] = None
 
-    @classmethod
-    def __preprocess_attribute_name(cls, attribute_name: Optional[str], operation: EventOperation) -> Optional[str]:
-        if operation in _NO_ATTRIBUTE_NAME_OPERATIONS and attribute_name is not None:
-            raise InvalidEventAttributeName
-        return attribute_name
+    metadata: dict = field(default_factory=dict)
+    creation_date: datetime = field(init=False)
 
-    @classmethod
-    def __preprocess_operation(cls, operation: EventOperation, entity_type: EventEntityType) -> EventOperation:
-        if entity_type in _UNSUBMITTABLE_ENTITY_TYPES and operation == EventOperation.SUBMISSION:
+    def __post_init__(self):
+        # Creation date
+        super().__setattr__("creation_date", datetime.now())
+
+        # Check operation:
+        if self.entity_type in _UNSUBMITTABLE_ENTITY_TYPES and self.operation == EventOperation.SUBMISSION:
             raise InvalidEventOperation
-        return operation
+
+        # Check attribute name:
+        if self.operation in _NO_ATTRIBUTE_NAME_OPERATIONS and self.attribute_name is not None:
+            raise InvalidEventAttributeName
+
+
+@singledispatch
+def make_event(
+    entity: Any,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    """Helper function to make an event for this entity with the given `EventOperation^` type.
+    In case of `EventOperation.UPDATE^` events, an attribute name and value must be given.
+
+    Parameters:
+        entity (Any): The entity object to generate an event for.
+        operation (EventOperation^): The operation of the event. The possible values are:
+            <ul>
+                <li>CREATION</li>
+                <li>UPDATE</li>
+                <li>DELETION</li>
+                <li>SUBMISSION</li>
+            </ul>
+        attribute_name (Optional[str]): The name of the updated attribute for a `EventOperation.UPDATE`.
+            This argument is always given in case of an UPDATE.
+        attribute_value (Optional[Any]): The value of the udated attribute for a `EventOperation.UPDATE`.
+            This argument is always given in case of an UPDATE.
+        **kwargs (dict[str, any]): Any extra information that would be passed to the metadata event.
+            Note: you should pass only simple types: str, float, double as values."""
+    raise Exception(f"Unexpected entity type: {type(entity)}")

--- a/src/taipy/core/notification/notifier.py
+++ b/src/taipy/core/notification/notifier.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from queue import SimpleQueue
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 from ._registration import _Registration
 from ._topic import _Topic
@@ -19,11 +19,38 @@ from .event import Event, EventEntityType, EventOperation
 
 def _publish_event(
     entity_type: EventEntityType,
-    entity_id: Optional[str],
     operation: EventOperation,
+    /,
+    entity_id: Optional[str] = None,
+    config_id: Optional[str] = None,
     attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
 ):
-    Notifier.publish(Event(entity_type, entity_id, operation, attribute_name))
+    """Internal helper function to send events.
+
+    It basically creates an event corresponding to the given arguments
+    and send it using `Notifier.publish(event)`
+
+    Parameters:
+        entity_type (EventEntityType^)
+        operation (EventOperation^)
+        entity_id (Optional[str])
+        config_id (Optional[str])
+        attribute_name (Optional[str])
+        attribute_value (Optional[Any])
+        **kwargs
+    """
+    event = Event(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        operation=operation,
+        config_id=config_id,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata=kwargs,
+    )
+    Notifier.publish(event)
 
 
 class Notifier:

--- a/src/taipy/core/scenario/_scenario_manager.py
+++ b/src/taipy/core/scenario/_scenario_manager.py
@@ -93,12 +93,25 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
     @classmethod
     def __add_subscriber(cls, callback, params, scenario: Scenario):
         scenario._add_subscriber(callback, params)
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "subscribers")
+        _publish_event(
+            EventEntityType.SCENARIO,
+            EventOperation.UPDATE,
+            entity_id=scenario.id,
+            config_id=scenario.config_id,
+            attribute_name="subscribers",
+            attribute_value=params,
+        )
 
     @classmethod
     def __remove_subscriber(cls, callback, params, scenario: Scenario):
         scenario._remove_subscriber(callback, params)
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "subscribers")
+        _publish_event(
+            EventEntityType.SCENARIO,
+            EventOperation.UPDATE,
+            entity_id=scenario.id,
+            config_id=scenario.config_id,
+            attribute_name="subscribers",
+        )
 
     @classmethod
     def _create(
@@ -180,9 +193,13 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
         for sequence_name in sequences.keys():
             if not actual_sequences[sequence_name]._is_consistent():
                 raise InvalidSequence(actual_sequences[sequence_name].id)
-            _publish_event(EventEntityType.SEQUENCE, actual_sequences[sequence_name].id, EventOperation.CREATION, None)
+            _publish_event(
+                EventEntityType.SEQUENCE, EventOperation.CREATION, entity_id=actual_sequences[sequence_name].id
+            )
 
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.CREATION, None)
+        _publish_event(
+            EventEntityType.SCENARIO, EventOperation.CREATION, entity_id=scenario.id, config_id=scenario.config_id
+        )
         return scenario
 
     @classmethod
@@ -215,7 +232,9 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
             ._orchestrator()
             .submit(scenario, callbacks=scenario_subscription_callback, force=force, wait=wait, timeout=timeout)
         )
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.SUBMISSION, None)
+        _publish_event(
+            EventEntityType.SCENARIO, EventOperation.SUBMISSION, entity_id=scenario.id, config_id=scenario.config_id
+        )
         return jobs
 
     @classmethod
@@ -297,13 +316,27 @@ class _ScenarioManager(_Manager[Scenario], _VersionMixin):
                 cls._set(old_tagged_scenario)
         scenario._add_tag(tag)
         cls._set(scenario)
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "tags")
+        _publish_event(
+            EventEntityType.SCENARIO,
+            EventOperation.UPDATE,
+            entity_id=scenario.id,
+            config_id=scenario.config_id,
+            attribute_name="tags",
+            attribute_value=scenario.tags,
+        )
 
     @classmethod
     def _untag(cls, scenario: Scenario, tag: str):
         scenario._remove_tag(tag)
         cls._set(scenario)
-        _publish_event(cls._EVENT_ENTITY_TYPE, scenario.id, EventOperation.UPDATE, "tags")
+        _publish_event(
+            EventEntityType.SCENARIO,
+            EventOperation.UPDATE,
+            entity_id=scenario.id,
+            config_id=scenario.config_id,
+            attribute_name="tags",
+            attribute_value=scenario.tags,
+        )
 
     @classmethod
     def _compare(cls, *scenarios: Scenario, data_node_config_id: Optional[str] = None):

--- a/src/taipy/core/scenario/scenario.py
+++ b/src/taipy/core/scenario/scenario.py
@@ -41,7 +41,7 @@ from ..exceptions.exceptions import (
     SequenceTaskDoesNotExistInScenario,
 )
 from ..job.job import Job
-from ..notification import EventEntityType, EventOperation, _publish_event
+from ..notification import Event, EventEntityType, EventOperation, Notifier, _publish_event, make_event
 from ..sequence.sequence import Sequence
 from ..task._task_manager_factory import _TaskManagerFactory
 from ..task.task import Task
@@ -209,7 +209,11 @@ class Scenario(_Entity, Submittable, _Labeled):
         self.sequences = _sequences  # type: ignore
         if not self.sequences[name]._is_consistent():
             raise InvalidSequence(name)
-        _publish_event(EventEntityType.SEQUENCE, self.sequences[name].id, EventOperation.CREATION, None)
+        _publish_event(
+            EventEntityType.SEQUENCE,
+            EventOperation.CREATION,
+            entity_id=self.sequences[name].id,
+        )
 
     def add_sequences(self, sequences: Dict[str, Union[List[Task], List[TaskId]]]):
         """Add multiple sequences to the scenario.
@@ -244,7 +248,7 @@ class Scenario(_Entity, Submittable, _Labeled):
         _sequences = _Reloader()._reload(self._MANAGER_NAME, self)._sequences
         _sequences.pop(name)
         self.sequences = _sequences  # type: ignore
-        _publish_event(EventEntityType.SEQUENCE, seq_id, EventOperation.DELETION, None)
+        _publish_event(EventEntityType.SEQUENCE, EventOperation.DELETION, entity_id=seq_id)
 
     def remove_sequences(self, sequence_names: List[str]):
         """
@@ -257,7 +261,13 @@ class Scenario(_Entity, Submittable, _Labeled):
         for sequence_name in sequence_names:
             seq_id = self.sequences[sequence_name].id
             _sequences.pop(sequence_name)
-            _publish_event(EventEntityType.SEQUENCE, seq_id, EventOperation.DELETION, None)
+            Notifier.publish(
+                Event(
+                    EventEntityType.SEQUENCE,
+                    EventOperation.DELETION,
+                    entity_id=seq_id,
+                )
+            )
         self.sequences = _sequences  # type: ignore
 
     @staticmethod
@@ -586,3 +596,23 @@ class Scenario(_Entity, Submittable, _Labeled):
                 continue
             return False
         return True
+
+
+@make_event.register(Scenario)
+def make_event_for_scenario(
+    scenario: Scenario,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    return Event(
+        entity_type=EventEntityType.SCENARIO,
+        entity_id=scenario.id,
+        config_id=scenario.config_id,
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata=kwargs,
+    )

--- a/src/taipy/core/sequence/sequence.py
+++ b/src/taipy/core/sequence/sequence.py
@@ -29,6 +29,7 @@ from ..common._utils import _Subscriber
 from ..data.data_node import DataNode
 from ..exceptions.exceptions import NonExistingTask
 from ..job.job import Job
+from ..notification.event import Event, EventEntityType, EventOperation, make_event
 from ..task.task import Task
 from ..task.task_id import TaskId
 from .sequence_id import SequenceId
@@ -255,3 +256,22 @@ class Sequence(_Entity, Submittable, _Labeled):
             The simple label of the sequence as a string.
         """
         return self._get_simple_label()
+
+
+@make_event.register(Sequence)
+def make_event_for_sequence(
+    sequence: Sequence,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    return Event(
+        entity_type=EventEntityType.SEQUENCE,
+        entity_id=sequence.id,
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata=kwargs,
+    )

--- a/src/taipy/core/task/_task_manager.py
+++ b/src/taipy/core/task/_task_manager.py
@@ -33,7 +33,6 @@ from .task_id import TaskId
 
 
 class _TaskManager(_Manager[Task], _VersionMixin):
-
     _ENTITY_NAME = Task.__name__
     _repository: _AbstractRepository
     _EVENT_ENTITY_TYPE = EventEntityType.TASK
@@ -115,7 +114,9 @@ class _TaskManager(_Manager[Task], _VersionMixin):
                 for dn in set(inputs + outputs):
                     dn._parent_ids.update([task.id])
                 cls._set(task)
-                _publish_event(cls._EVENT_ENTITY_TYPE, task.id, EventOperation.CREATION, None)
+                _publish_event(
+                    EventEntityType.TASK, EventOperation.CREATION, entity_id=task.id, config_id=task_config.id
+                )
                 tasks.append(task)
         return tasks
 
@@ -176,7 +177,7 @@ class _TaskManager(_Manager[Task], _VersionMixin):
         if check_inputs_are_ready:
             _warn_if_inputs_not_ready(task.input.values())
         job = cls._orchestrator().submit_task(task, callbacks=callbacks, force=force, wait=wait, timeout=timeout)
-        _publish_event(cls._EVENT_ENTITY_TYPE, task.id, EventOperation.SUBMISSION, None)
+        _publish_event(EventEntityType.TASK, EventOperation.SUBMISSION, entity_id=task_id, config_id=task.config_id)
         return job
 
     @classmethod

--- a/src/taipy/core/task/task.py
+++ b/src/taipy/core/task/task.py
@@ -24,6 +24,7 @@ from .._version._version_manager_factory import _VersionManagerFactory
 from ..data._data_manager_factory import _DataManagerFactory
 from ..data.data_node import DataNode
 from ..exceptions.exceptions import NonExistingDataNode
+from ..notification.event import Event, EventEntityType, EventOperation, make_event
 from .task_id import TaskId
 
 if TYPE_CHECKING:
@@ -207,3 +208,24 @@ class Task(_Entity, _Labeled):
             The simple label of the task as a string.
         """
         return self._get_simple_label()
+
+
+@make_event.register(Task)
+def make_event_for_task(
+    task: Task,
+    operation: EventOperation,
+    /,
+    attribute_name: Optional[str] = None,
+    attribute_value: Optional[Any] = None,
+    **kwargs,
+) -> Event:
+    metadata = {"version": task.version}
+    return Event(
+        entity_type=EventEntityType.TASK,
+        entity_id=task.id,
+        config_id=task.config_id,
+        operation=operation,
+        attribute_name=attribute_name,
+        attribute_value=attribute_value,
+        metadata={**metadata, **kwargs},
+    )

--- a/tests/core/notification/test_event.py
+++ b/tests/core/notification/test_event.py
@@ -13,24 +13,35 @@ import pytest
 
 from src.taipy.core.exceptions.exceptions import InvalidEventAttributeName, InvalidEventOperation
 from src.taipy.core.notification.event import Event, EventEntityType, EventOperation
+from taipy.config.common.frequency import Frequency
 
 
 def test_event_creation_cycle():
-    event_1 = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION)
+    event_1 = Event(
+        entity_type=EventEntityType.CYCLE,
+        operation=EventOperation.CREATION,
+        entity_id="cycle_id",
+    )
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.CYCLE
     assert event_1.entity_id == "cycle_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.UPDATE, "frequency")
+    event_2 = Event(
+        entity_type=EventEntityType.CYCLE,
+        operation=EventOperation.UPDATE,
+        entity_id="cycle_id",
+        attribute_name="frequency",
+        attribute_value=Frequency.DAILY,
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.CYCLE
     assert event_2.entity_id == "cycle_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "frequency"
 
-    event_3 = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.CYCLE
     assert event_3.entity_id == "cycle_id"
@@ -38,41 +49,62 @@ def test_event_creation_cycle():
     assert event_3.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION, "frequency")
+        _ = Event(
+            entity_type=EventEntityType.CYCLE,
+            operation=EventOperation.CREATION,
+            entity_id="cycle_id",
+            attribute_name="frequency",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.DELETION, "frequency")
+        _ = Event(EventEntityType.CYCLE, EventOperation.DELETION, entity_id="cycle_id", attribute_name="frequency")
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.SUBMISSION)
+        _ = Event(
+            entity_type=EventEntityType.CYCLE,
+            operation=EventOperation.SUBMISSION,
+            entity_id="cycle_id",
+        )
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.CYCLE, "cycle_id", EventOperation.SUBMISSION, "frequency")
+        _ = Event(
+            entity_type=EventEntityType.CYCLE,
+            operation=EventOperation.SUBMISSION,
+            entity_id="cycle_id",
+            attribute_name="frequency",
+        )
 
 
 def test_event_creation_scenario():
-    event_1 = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.CREATION)
+    event_1 = Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.CREATION)
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.SCENARIO
     assert event_1.entity_id == "scenario_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.UPDATE, "is_primary")
+    event_2 = Event(
+        entity_type=EventEntityType.SCENARIO,
+        entity_id="scenario_id",
+        operation=EventOperation.UPDATE,
+        attribute_name="is_primary",
+        attribute_value=True,
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.SCENARIO
     assert event_2.entity_id == "scenario_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "is_primary"
+    assert event_2.attribute_value is True
 
-    event_3 = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.SCENARIO
     assert event_3.entity_id == "scenario_id"
     assert event_3.operation == EventOperation.DELETION
     assert event_3.attribute_name is None
 
-    event_4 = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION)
+    event_4 = Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION)
     assert event_4.creation_date is not None
     assert event_4.entity_type == EventEntityType.SCENARIO
     assert event_4.entity_id == "scenario_id"
@@ -80,38 +112,59 @@ def test_event_creation_scenario():
     assert event_4.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.CREATION, "is_primary")
+        _ = Event(
+            entity_type=EventEntityType.SCENARIO,
+            entity_id="scenario_id",
+            operation=EventOperation.CREATION,
+            attribute_name="is_primary",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.DELETION, "is_primary")
+        _ = Event(
+            entity_type=EventEntityType.SCENARIO,
+            entity_id="scenario_id",
+            operation=EventOperation.DELETION,
+            attribute_name="is_primary",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION, "is_primary")
+        _ = Event(
+            entity_type=EventEntityType.SCENARIO,
+            entity_id="scenario_id",
+            operation=EventOperation.SUBMISSION,
+            attribute_name="is_primary",
+        )
 
 
 def test_event_creation_sequence():
-    event_1 = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.CREATION)
+    event_1 = Event(entity_type=EventEntityType.SEQUENCE, entity_id="sequence_id", operation=EventOperation.CREATION)
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.SEQUENCE
     assert event_1.entity_id == "sequence_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "subscribers")
+    event_2 = Event(
+        entity_type=EventEntityType.SEQUENCE,
+        entity_id="sequence_id",
+        operation=EventOperation.UPDATE,
+        attribute_name="subscribers",
+        attribute_value=object(),
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.SEQUENCE
     assert event_2.entity_id == "sequence_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "subscribers"
 
-    event_3 = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.SEQUENCE, entity_id="sequence_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.SEQUENCE
     assert event_3.entity_id == "sequence_id"
     assert event_3.operation == EventOperation.DELETION
     assert event_3.attribute_name is None
 
-    event_4 = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.SUBMISSION)
+    event_4 = Event(entity_type=EventEntityType.SEQUENCE, entity_id="sequence_id", operation=EventOperation.SUBMISSION)
     assert event_4.creation_date is not None
     assert event_4.entity_type == EventEntityType.SEQUENCE
     assert event_4.entity_id == "sequence_id"
@@ -119,38 +172,58 @@ def test_event_creation_sequence():
     assert event_4.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.CREATION, "subscribers")
+        _ = Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.CREATION,
+            attribute_name="subscribers",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.DELETION, "subscribers")
+        _ = Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.DELETION,
+            attribute_name="subscribers",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.SUBMISSION, "subscribers")
+        _ = Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.SUBMISSION,
+            attribute_name="subscribers",
+        )
 
 
 def test_event_creation_task():
-    event_1 = Event(EventEntityType.TASK, "task_id", EventOperation.CREATION)
+    event_1 = Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.CREATION)
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.TASK
     assert event_1.entity_id == "task_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.TASK, "task_id", EventOperation.UPDATE, "function")
+    event_2 = Event(
+        entity_type=EventEntityType.TASK,
+        entity_id="task_id",
+        operation=EventOperation.UPDATE,
+        attribute_name="function",
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.TASK
     assert event_2.entity_id == "task_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "function"
 
-    event_3 = Event(EventEntityType.TASK, "task_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.TASK
     assert event_3.entity_id == "task_id"
     assert event_3.operation == EventOperation.DELETION
     assert event_3.attribute_name is None
 
-    event_4 = Event(EventEntityType.TASK, "task_id", EventOperation.SUBMISSION)
+    event_4 = Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.SUBMISSION)
     assert event_4.creation_date is not None
     assert event_4.entity_type == EventEntityType.TASK
     assert event_4.entity_id == "task_id"
@@ -158,31 +231,51 @@ def test_event_creation_task():
     assert event_4.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.TASK, "task_id", EventOperation.CREATION, "function")
+        _ = Event(
+            entity_type=EventEntityType.TASK,
+            entity_id="task_id",
+            operation=EventOperation.CREATION,
+            attribute_name="function",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.TASK, "task_id", EventOperation.DELETION, "function")
+        _ = Event(
+            entity_type=EventEntityType.TASK,
+            entity_id="task_id",
+            operation=EventOperation.DELETION,
+            attribute_name="function",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.TASK, "task_id", EventOperation.SUBMISSION, "function")
+        _ = Event(
+            entity_type=EventEntityType.TASK,
+            entity_id="task_id",
+            operation=EventOperation.SUBMISSION,
+            attribute_name="function",
+        )
 
 
 def test_event_creation_datanode():
-    event_1 = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.CREATION)
+    event_1 = Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.CREATION)
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.DATA_NODE
     assert event_1.entity_id == "dn_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.UPDATE, "properties")
+    event_2 = Event(
+        entity_type=EventEntityType.DATA_NODE,
+        entity_id="dn_id",
+        operation=EventOperation.UPDATE,
+        attribute_name="properties",
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.DATA_NODE
     assert event_2.entity_id == "dn_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "properties"
 
-    event_3 = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.DATA_NODE
     assert event_3.entity_id == "dn_id"
@@ -190,34 +283,51 @@ def test_event_creation_datanode():
     assert event_3.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.CREATION, "properties")
+        _ = Event(
+            entity_type=EventEntityType.DATA_NODE,
+            entity_id="dn_id",
+            operation=EventOperation.CREATION,
+            attribute_name="properties",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.DELETION, "properties")
+        _ = Event(
+            entity_type=EventEntityType.DATA_NODE,
+            entity_id="dn_id",
+            operation=EventOperation.DELETION,
+            attribute_name="properties",
+        )
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.SUBMISSION)
+        _ = Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.SUBMISSION)
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.SUBMISSION, "properties")
+        _ = Event(
+            entity_type=EventEntityType.DATA_NODE,
+            entity_id="dn_id",
+            operation=EventOperation.SUBMISSION,
+            attribute_name="properties",
+        )
 
 
 def test_event_creation_job():
-    event_1 = Event(EventEntityType.JOB, "job_id", EventOperation.CREATION)
+    event_1 = Event(entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.CREATION)
     assert event_1.creation_date is not None
     assert event_1.entity_type == EventEntityType.JOB
     assert event_1.entity_id == "job_id"
     assert event_1.operation == EventOperation.CREATION
     assert event_1.attribute_name is None
 
-    event_2 = Event(EventEntityType.JOB, "job_id", EventOperation.UPDATE, "force")
+    event_2 = Event(
+        entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.UPDATE, attribute_name="force"
+    )
     assert event_2.creation_date is not None
     assert event_2.entity_type == EventEntityType.JOB
     assert event_2.entity_id == "job_id"
     assert event_2.operation == EventOperation.UPDATE
     assert event_2.attribute_name == "force"
 
-    event_3 = Event(EventEntityType.JOB, "job_id", EventOperation.DELETION)
+    event_3 = Event(entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.DELETION)
     assert event_3.creation_date is not None
     assert event_3.entity_type == EventEntityType.JOB
     assert event_3.entity_id == "job_id"
@@ -225,13 +335,28 @@ def test_event_creation_job():
     assert event_3.attribute_name is None
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.JOB, "job_id", EventOperation.CREATION, "force")
+        _ = Event(
+            entity_type=EventEntityType.JOB,
+            entity_id="job_id",
+            operation=EventOperation.CREATION,
+            attribute_name="force",
+        )
 
     with pytest.raises(InvalidEventAttributeName):
-        _ = Event(EventEntityType.JOB, "job_id", EventOperation.DELETION, "force")
+        _ = Event(
+            entity_type=EventEntityType.JOB,
+            entity_id="job_id",
+            operation=EventOperation.DELETION,
+            attribute_name="force",
+        )
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.JOB, "job_id", EventOperation.SUBMISSION)
+        _ = Event(entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.SUBMISSION)
 
     with pytest.raises(InvalidEventOperation):
-        _ = Event(EventEntityType.JOB, "job_id", EventOperation.SUBMISSION, "force")
+        _ = Event(
+            entity_type=EventEntityType.JOB,
+            entity_id="job_id",
+            operation=EventOperation.SUBMISSION,
+            attribute_name="force",
+        )

--- a/tests/core/notification/test_events_published.py
+++ b/tests/core/notification/test_events_published.py
@@ -9,9 +9,14 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from dataclasses import dataclass, field
+from math import exp
 from queue import SimpleQueue
 
+from colorama import init
+
 from src.taipy.core import taipy as tp
+from src.taipy.core.config import scenario_config
 from src.taipy.core.notification.core_event_consumer import CoreEventConsumerBase
 from src.taipy.core.notification.event import Event, EventEntityType, EventOperation
 from src.taipy.core.notification.notifier import Notifier
@@ -19,20 +24,56 @@ from taipy.config import Config, Frequency
 from tests.core.utils import assert_true_after_time
 
 
-class AllCoreEventConsumer(CoreEventConsumerBase):
-    def __init__(self, registration_id: str, queue: SimpleQueue):
-        self.event_collected = 0
-        self.entity_type_collected: dict = {}
-        self.operation_collected: dict = {}
-        self.attr_name_collected: dict = {}
-        super().__init__(registration_id, queue)
+class Snapshot:
+    """
+    A captured snapshot of the recording core events consumer.
+    """
 
-    def process_event(self, event: Event):
-        self.event_collected += 1
+    def __init__(self):
+        self.events_collected = []
+        self.entity_type_collected = {}
+        self.operation_collected = {}
+        self.attr_name_collected = {}
+
+    def capture_event(self, event):
+        self.events_collected.append(event)
         self.entity_type_collected[event.entity_type] = self.entity_type_collected.get(event.entity_type, 0) + 1
         self.operation_collected[event.operation] = self.operation_collected.get(event.operation, 0) + 1
         if event.attribute_name:
             self.attr_name_collected[event.attribute_name] = self.attr_name_collected.get(event.attribute_name, 0) + 1
+
+
+class RecordingConsumer(CoreEventConsumerBase):
+    """
+    A straightforward and no-thread core events consumer that allows to
+    capture snapshots of received events.
+    """
+
+    def __init__(self, registration_id: str, queue: SimpleQueue):
+        super().__init__(registration_id, queue)
+
+    def capture(self) -> Snapshot:
+        """
+        Capture a snapshot of events received between the previous snapshot
+        (or from the start of this consumer).
+        """
+        snapshot = Snapshot()
+        while not self.queue.empty():
+            event = self.queue.get()
+            snapshot.capture_event(event)
+        return snapshot
+
+    def process_event(self, event: Event):
+        # Nothing todo
+        pass
+
+    def start(self):
+        # Nothing to do here
+        pass
+
+    def stop(self):
+        # Nothing to do here either
+        pass
 
 
 def identity(x):
@@ -41,7 +82,7 @@ def identity(x):
 
 def test_event_published():
     register_id_0, register_queue_0 = Notifier.register()
-    all_evts = AllCoreEventConsumer(register_id_0, register_queue_0)
+    all_evts = RecordingConsumer(register_id_0, register_queue_0)
     all_evts.start()
 
     input_config = Config.configure_data_node("the_input")
@@ -53,61 +94,120 @@ def test_event_published():
 
     # Create a scenario only trigger 6 creation events (for cycle, data node(x2), task, sequence and scenario)
     scenario = tp.create_scenario(sc_config)
-    assert_true_after_time(lambda: all_evts.event_collected == 6, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.CYCLE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.DATA_NODE] == 2, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.TASK] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SEQUENCE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SCENARIO] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.CREATION] == 6, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 6
+    assert snapshot.entity_type_collected.get(EventEntityType.CYCLE, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 2
+    assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 1
+    assert snapshot.operation_collected.get(EventOperation.CREATION, 0) == 6
 
     # Get all scenarios does not trigger any event
     tp.get_scenarios()
-    assert_true_after_time(lambda: all_evts.event_collected == 6, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 0
 
     # Get one scenario does not trigger any event
     sc = tp.get(scenario.id)
-    assert_true_after_time(lambda: all_evts.event_collected == 6, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 0
 
     # Write input manually trigger 4 data node update events (for last_edit_date, editor_id, editor_expiration_date
     # and edit_in_progress)
     sc.the_input.write("test")
-    assert_true_after_time(lambda: all_evts.event_collected == 10, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.CYCLE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.DATA_NODE] == 6, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.TASK] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SEQUENCE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SCENARIO] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.CREATION] == 6, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.UPDATE] == 4, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 4
+    assert snapshot.entity_type_collected.get(EventEntityType.CYCLE, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 4
+    assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 0
+    assert snapshot.operation_collected.get(EventOperation.CREATION, 0) == 0
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 4
 
     # Submit a scenario trigger 1 scenario submission event
     # 7 data node update events (for last_edit_date, editor_id(x2), editor_expiration_date(x2) and edit_in_progress(x2))
     # 1 job creation event and 3 job update events (for status: PENDING, RUNNING and COMPLETED)
     sc.submit()
-    assert_true_after_time(lambda: all_evts.event_collected == 22, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.CYCLE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.DATA_NODE] == 13, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.TASK] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SEQUENCE] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SCENARIO] == 2, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.JOB] == 4, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.CREATION] == 7, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.UPDATE] == 14, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.SUBMISSION] == 1, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 12
+    assert snapshot.entity_type_collected.get(EventEntityType.CYCLE, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 7
+    assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 0
+    assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.JOB, 0) == 4
+    assert snapshot.operation_collected.get(EventOperation.CREATION, 0) == 1
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 10
+    assert snapshot.operation_collected.get(EventOperation.SUBMISSION, 0) == 1
 
     # Delete a scenario trigger 7 update events
     tp.delete(scenario.id)
-    assert_true_after_time(lambda: all_evts.event_collected == 29, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.CYCLE] == 2, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.DATA_NODE] == 15, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.TASK] == 2, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SEQUENCE] == 2, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.SCENARIO] == 3, time=10)
-    assert_true_after_time(lambda: all_evts.entity_type_collected[EventEntityType.JOB] == 5, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.CREATION] == 7, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.UPDATE] == 14, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.SUBMISSION] == 1, time=10)
-    assert_true_after_time(lambda: all_evts.operation_collected[EventOperation.DELETION] == 7, time=10)
+    snapshot = all_evts.capture()
+    assert len(snapshot.events_collected) == 7
+    assert snapshot.entity_type_collected.get(EventEntityType.CYCLE, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.DATA_NODE, 0) == 2
+    assert snapshot.entity_type_collected.get(EventEntityType.TASK, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.SEQUENCE, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.SCENARIO, 0) == 1
+    assert snapshot.entity_type_collected.get(EventEntityType.JOB, 0) == 1
+    assert snapshot.operation_collected.get(EventOperation.UPDATE, 0) == 0
+    assert snapshot.operation_collected.get(EventOperation.SUBMISSION, 0) == 0
+    assert snapshot.operation_collected.get(EventOperation.DELETION, 0) == 7
 
     all_evts.stop()
+
+
+def test_job_events():
+    input_config = Config.configure_data_node("the_input")
+    output_config = Config.configure_data_node("the_output")
+    task_config = Config.configure_task("the_task", identity, input=input_config, output=output_config)
+    sc_config = Config.configure_scenario(
+        "the_scenario", task_configs=[task_config], frequency=Frequency.DAILY, sequences={"the_seq": [task_config]}
+    )
+    register_id, register_queue = Notifier.register(entity_type=EventEntityType.JOB)
+    consumer = RecordingConsumer(register_id, register_queue)
+    consumer.start()
+
+    # Create scenario
+    scenario = tp.create_scenario(sc_config)
+    snapshot = consumer.capture()
+    assert len(snapshot.events_collected) == 0
+
+    # Submit scenario
+    scenario.submit()
+    snapshot = consumer.capture()
+    # 2 events expected: one for creation, another for status update
+    assert len(snapshot.events_collected) == 2
+    for event in snapshot.events_collected:
+        # make sure they all have context
+        assert event.config_id == task_config.id
+
+    consumer.stop()
+
+
+def test_scenario_events():
+    input_config = Config.configure_data_node("the_input")
+    output_config = Config.configure_data_node("the_output")
+    task_config = Config.configure_task("the_task", identity, input=input_config, output=output_config)
+    sc_config = Config.configure_scenario(
+        "the_scenario", task_configs=[task_config], frequency=Frequency.DAILY, sequences={"the_seq": [task_config]}
+    )
+    register_id, register_queue = Notifier.register(entity_type=EventEntityType.SCENARIO)
+    consumer = RecordingConsumer(register_id, register_queue)
+    consumer.start()
+    scenario = tp.create_scenario(sc_config)
+
+    snapshot = consumer.capture()
+    assert len(snapshot.events_collected) == 1
+    for event in snapshot.events_collected:
+        assert event.config_id == sc_config.id
+
+    scenario.submit()
+    snapshot = consumer.capture()
+    assert len(snapshot.events_collected) == 1
+    for event in snapshot.events_collected:
+        assert event.config_id == sc_config.id
+
+    consumer.stop()

--- a/tests/core/notification/test_notifier.py
+++ b/tests/core/notification/test_notifier.py
@@ -119,75 +119,132 @@ def test_register():
 
 
 def test_matching():
-    assert Notifier._is_matching(Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION), _Topic())
     assert Notifier._is_matching(
-        Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION), _Topic(EventEntityType.CYCLE)
+        Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.CREATION), _Topic()
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION), _Topic(EventEntityType.CYCLE, "cycle_id")
+        Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.CREATION),
+        _Topic(EventEntityType.CYCLE),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION), _Topic(operation=EventOperation.CREATION)
+        Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.CREATION),
+        _Topic(EventEntityType.CYCLE, "cycle_id"),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION),
+        Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.CREATION),
+        _Topic(operation=EventOperation.CREATION),
+    )
+    assert Notifier._is_matching(
+        Event(entity_type=EventEntityType.CYCLE, entity_id="cycle_id", operation=EventOperation.CREATION),
         _Topic(EventEntityType.CYCLE, "cycle_id", EventOperation.CREATION),
     )
 
-    assert Notifier._is_matching(Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION), _Topic())
     assert Notifier._is_matching(
-        Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION), _Topic(EventEntityType.SCENARIO)
+        Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION),
+        _Topic(),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION),
+        Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION),
+        _Topic(EventEntityType.SCENARIO),
+    )
+    assert Notifier._is_matching(
+        Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION),
         _Topic(
             EventEntityType.SCENARIO,
             "scenario_id",
         ),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION),
+        Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION),
         _Topic(operation=EventOperation.SUBMISSION),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION),
+        Event(entity_type=EventEntityType.SCENARIO, entity_id="scenario_id", operation=EventOperation.SUBMISSION),
         _Topic(EventEntityType.SCENARIO, "scenario_id", EventOperation.SUBMISSION),
     )
 
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"), _Topic()
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name=r"tasks",
+        ),
+        _Topic(),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"), _Topic(EventEntityType.SEQUENCE)
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
+        _Topic(EventEntityType.SEQUENCE),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(
             EventEntityType.SEQUENCE,
             "sequence_id",
         ),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(operation=EventOperation.UPDATE),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"), _Topic(attribute_name="tasks")
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
+        _Topic(attribute_name="tasks"),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(EventEntityType.SEQUENCE, attribute_name="tasks"),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(operation=EventOperation.UPDATE, attribute_name="tasks"),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
+        Event(
+            entity_type=EventEntityType.SEQUENCE,
+            entity_id="sequence_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="tasks",
+        ),
         _Topic(EventEntityType.SEQUENCE, "sequence_id", EventOperation.UPDATE, "tasks"),
     )
     assert Notifier._is_matching(Event(EventEntityType.TASK, "task_id", EventOperation.DELETION), _Topic())
@@ -195,45 +252,57 @@ def test_matching():
         Event(EventEntityType.TASK, "task_id", EventOperation.DELETION), _Topic(EventEntityType.TASK)
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.TASK, "task_id", EventOperation.DELETION),
+        Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.DELETION),
         _Topic(
             EventEntityType.TASK,
             "task_id",
         ),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.TASK, "task_id", EventOperation.DELETION), _Topic(operation=EventOperation.DELETION)
+        Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.DELETION),
+        _Topic(operation=EventOperation.DELETION),
     )
     assert Notifier._is_matching(
-        Event(EventEntityType.TASK, "task_id", EventOperation.DELETION),
+        Event(entity_type=EventEntityType.TASK, entity_id="task_id", operation=EventOperation.DELETION),
         _Topic(EventEntityType.TASK, "task_id", EventOperation.DELETION),
     )
 
     assert not Notifier._is_matching(
-        Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.CREATION), _Topic(EventEntityType.CYCLE)
+        Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.CREATION),
+        _Topic(EventEntityType.CYCLE),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.CREATION),
+        Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.CREATION),
         _Topic(EventEntityType.SCENARIO, "scenario_id"),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.DATA_NODE, "dn_id", EventOperation.CREATION),
+        Event(entity_type=EventEntityType.DATA_NODE, entity_id="dn_id", operation=EventOperation.CREATION),
         _Topic(EventEntityType.TASK, "task_id", EventOperation.CREATION),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.JOB, "job_id", EventOperation.DELETION),
+        Event(entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.DELETION),
         _Topic(EventEntityType.JOB, "job_id", EventOperation.CREATION),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.JOB, "job_id", EventOperation.DELETION),
+        Event(entity_type=EventEntityType.JOB, entity_id="job_id", operation=EventOperation.DELETION),
         _Topic(EventEntityType.JOB, "job_id_1", EventOperation.DELETION),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.JOB, "job_id", EventOperation.UPDATE, "status"),
+        Event(
+            entity_type=EventEntityType.JOB,
+            entity_id="job_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="status",
+        ),
         _Topic(EventEntityType.JOB, "job_id", EventOperation.UPDATE, "submit_id"),
     )
     assert not Notifier._is_matching(
-        Event(EventEntityType.JOB, "job_id", EventOperation.UPDATE, "status"),
+        Event(
+            entity_type=EventEntityType.JOB,
+            entity_id="job_id",
+            operation=EventOperation.UPDATE,
+            attribute_name="status",
+        ),
         _Topic(operation=EventOperation.UPDATE, attribute_name="submit_id"),
     )
 
@@ -466,7 +535,6 @@ def test_publish_event():
     # If multiple entities is in context, the last to enter will be the first to exit
     # So the published event will have the order starting with scenario first and ending with dn
     with dn as d, task as t, sequence as s, cycle as c, scenario as sc:
-
         sc.is_primary = True
         assert registration_queue.qsize() == 0
 


### PR DESCRIPTION
# Goals
* Add additional data to core events

# Changes
* Simplification: Class `Event` is now a frozen dataclass
* Added `Event.attribute_value` to contain the value of a changed attribute
* Added `Event.config_id`, an optional field indicating the config ID of the entity
* Added `Event.metadata`, a dict to contain any extra information we would like to transmit via the event
* `Entity` now has a `get_event_context` method that can return any data we want to transmit to an event.
* Introduce a disptachjable function `make_event` to create an event for a particular entity type.

 