### PR TITLE
Added aws s3 data node

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ pyarrow = "==10.0.1"
 pymongo = {extras = ["srv"], version = "==4.2.0"}
 sqlalchemy = "==2.0.16"
 toml = "==0.10"
+boto3 = "==1.29.1"
 taipy-config = {ref = "develop", git = "https://github.com/avaiga/taipy-config.git"}
 
 [dev-packages]
@@ -27,6 +28,7 @@ tox = ">=3.24"
 types-toml = ">=0.10.0"
 autopep8 = "*"
 mongomock = ">=4.1.2"
+moto = ">=4.2.9"
 
 [requires]
 python_version = "3"

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ requirements = [
     "pymongo[srv]>=4.2.0,<5.0",
     "sqlalchemy>=2.0.16,<2.1",
     "toml>=0.10,<0.11",
+    "boto3>=1.29.1",
     "taipy-config@git+https://git@github.com/Avaiga/taipy-config.git@develop",
 ]
 

--- a/src/taipy/core/config/__init__.py
+++ b/src/taipy/core/config/__init__.py
@@ -54,6 +54,9 @@ _inject_section(
         ("configure_pickle_data_node", DataNodeConfig._configure_pickle),
         ("configure_excel_data_node", DataNodeConfig._configure_excel),
         ("configure_generic_data_node", DataNodeConfig._configure_generic),
+        ("configure_s3_object_data_node", DataNodeConfig._configure_s3_object),
+
+
     ],
 )
 _inject_section(

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -44,7 +44,8 @@ class _DataNodeConfigChecker(_ConfigChecker):
                 data_node_config._STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
                 f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be"
-                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory.",
+                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object,"
+                f" or in_memory.",
             )
 
     def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -44,7 +44,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
                 data_node_config._STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
                 f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be"
-                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory.",
+                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, in_memory, or s3_object.",
             )
 
     def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):

--- a/src/taipy/core/config/checkers/_data_node_config_checker.py
+++ b/src/taipy/core/config/checkers/_data_node_config_checker.py
@@ -44,7 +44,7 @@ class _DataNodeConfigChecker(_ConfigChecker):
                 data_node_config._STORAGE_TYPE_KEY,
                 data_node_config.storage_type,
                 f"`{data_node_config._STORAGE_TYPE_KEY}` field of DataNodeConfig `{data_node_config_id}` must be"
-                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, in_memory, or s3_object.",
+                f" either csv, sql_table, sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory.",
             )
 
     def _check_scope(self, data_node_config_id: str, data_node_config: DataNodeConfig):

--- a/src/taipy/core/config/config.schema.json
+++ b/src/taipy/core/config/config.schema.json
@@ -99,7 +99,8 @@
               "in_memory",
               "generic",
               "parquet",
-              ""
+              "s3_object",
+              "",
             ],
             "default": "pickle"
           },
@@ -236,6 +237,30 @@
             "description": "storage_type: parquet specific.Additional parameters when writing parquet files, default is an empty dictionary",
             "type": "object"
           },
+          "aws_access_key":{
+            "description": "storage_type: s3_object specific.Amazon Storage public key",
+            "type": "string"
+          },
+          "aws_secret_access_key":{
+            "description": "storage_type: s3_object specific.Amazon Storage secret key",
+            "type": "string"
+          },
+          "aws_s3_bucket_name":{
+            "description": "storage_type: s3_object specific.Name of Bucket",
+            "type": "string"
+          },
+          "aws_s3_object_key":{
+            "description": "storage_type: s3_object specific.File name",
+            "type": "string"
+          },
+          "aws_region":{
+            "description": "storage_type: s3_object specific.Bucket Location",
+            "type": "string"
+          },
+          "aws_s3_object_parameters":{
+            "description": "storage_type: s3_object specific.Additional parameters when accesing s3 object, default is an empty dictionary",
+            "type": "array"
+          },
           "if": {
             "properties": {
               "storage_type": {
@@ -281,6 +306,23 @@
               "then": {
                 "required": [
                   "db_name"
+                ],
+            "else": {
+              "if": {
+                "properties": {
+                  "storage_type": {
+                    "enum": [
+                      "s3_object",
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "aws_access_key",
+                  "aws_secret_access_key",
+                  "aws_s3_bucket_name",
+                  "aws_s3_object_key"
                 ],
                 "if": {
                   "properties": {

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -35,7 +35,7 @@ class DataNodeConfig(Section):
     Attributes:
         id (str): Unique identifier of the data node config. It must be a valid Python variable name.
         storage_type (str): Storage type of the data nodes created from the data node config. The possible values
-            are : "csv", "excel", "pickle", "sql_table", "sql", "mongo_collection", "generic", "json", "parquet", 
+            are : "csv", "excel", "pickle", "sql_table", "sql", "mongo_collection", "generic", "json", "parquet",
             "in_memory and "s3_object".
             The default value is "pickle".
             Note that the "in_memory" value can only be used when `JobConfig^`.mode is "standalone".
@@ -172,7 +172,7 @@ class DataNodeConfig(Section):
         _STORAGE_TYPE_VALUE_MONGO_COLLECTION: [
             _REQUIRED_DB_NAME_MONGO_PROPERTY,
             _REQUIRED_COLLECTION_NAME_MONGO_PROPERTY,
-        ],        
+        ]
         _STORAGE_TYPE_VALUE_CSV: [],
         _STORAGE_TYPE_VALUE_EXCEL: [],
         _STORAGE_TYPE_VALUE_IN_MEMORY: [],
@@ -1073,7 +1073,8 @@ class DataNodeConfig(Section):
             aws_access_key (str): Amazon Web Services ID for to identify account.
             aws_secret_access_key (str): Amazon Web Services access key to authenticate programmatic requests.
             aws_s3_bucket_name (str): The bucket in S3 to read from and to write the data to.
-            aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.
+            aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS) 
+                infrastructure is located.
             aws_s3_object_parameters (Optional[dict[str, any]]): A dictionary of additional arguments to be passed
                 into AWS S3 bucket access string.
             scope (Optional[Scope^]): The scope of the S3 Object data node configuration.<br/>

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -172,7 +172,7 @@ class DataNodeConfig(Section):
         _STORAGE_TYPE_VALUE_MONGO_COLLECTION: [
             _REQUIRED_DB_NAME_MONGO_PROPERTY,
             _REQUIRED_COLLECTION_NAME_MONGO_PROPERTY,
-        ]
+        ],
         _STORAGE_TYPE_VALUE_CSV: [],
         _STORAGE_TYPE_VALUE_EXCEL: [],
         _STORAGE_TYPE_VALUE_IN_MEMORY: [],

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -35,8 +35,8 @@ class DataNodeConfig(Section):
     Attributes:
         id (str): Unique identifier of the data node config. It must be a valid Python variable name.
         storage_type (str): Storage type of the data nodes created from the data node config. The possible values
-            are : "csv", "excel", "pickle", "sql_table", "sql", "mongo_collection", "generic", "json", "parquet" and
-            "in_memory".
+            are : "csv", "excel", "pickle", "sql_table", "sql", "mongo_collection", "generic", "json", "parquet", 
+            "in_memory and "s3_object".
             The default value is "pickle".
             Note that the "in_memory" value can only be used when `JobConfig^`.mode is "standalone".
         scope (Optional[Scope^]): The optional `Scope^` of the data nodes instantiated from the data node config.
@@ -57,7 +57,7 @@ class DataNodeConfig(Section):
     _STORAGE_TYPE_VALUE_GENERIC = "generic"
     _STORAGE_TYPE_VALUE_JSON = "json"
     _STORAGE_TYPE_VALUE_PARQUET = "parquet"
-    _STORAGE_TYPE_VALUE_S3_OBJECT = "aws_s3_object"
+    _STORAGE_TYPE_VALUE_S3_OBJECT = "s3_object"
 
     _DEFAULT_STORAGE_TYPE = _STORAGE_TYPE_VALUE_PICKLE
     _ALL_STORAGE_TYPES = [
@@ -150,9 +150,9 @@ class DataNodeConfig(Section):
     _OPTIONAL_WRITE_KWARGS_PARQUET_PROPERTY = "write_kwargs"
     # S3object
     _REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY = "aws_access_key"
-    _REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY = "aws_secret_acces_key"
+    _REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY = "aws_secret_access_key"
     _REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY = "aws_s3_bucket_name"
-    _REQUIRED_AWS_S3_OBJECT_KEY = "aws_s3_object_key"
+    _REQUIRED_AWS_S3_OBJECT_KEY_PROPERTY = "aws_s3_object_key"
     _OPTIONAL_AWS_REGION_PROPERTY = "aws_region"
     _OPTIONAL_AWS_S3_OBJECT_PARAMETERS_PROPERTY = "aws_s3_object_parameters"
 
@@ -184,7 +184,7 @@ class DataNodeConfig(Section):
             _REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY,
             _REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY,
             _REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY,
-            _REQUIRED_AWS_S3_OBJECT_KEY,
+            _REQUIRED_AWS_S3_OBJECT_KEY_PROPERTY,
         ],
     }
 
@@ -1057,8 +1057,9 @@ class DataNodeConfig(Section):
         cls,
         id: str,
         aws_access_key: str,
-        aws_secret_acces_key: str,
+        aws_secret_access_key: str,
         aws_s3_bucket_name: str,
+        aws_s3_object_key: str,
         aws_region: Optional[str] = None,
         aws_s3_object_parameters: Optional[Dict[str, Any]] = None,
         scope: Optional[Scope] = None,
@@ -1070,7 +1071,7 @@ class DataNodeConfig(Section):
         Parameters:
             id (str): The unique identifier of the new S3 Object data node configuration.
             aws_access_key (str): Amazon Web Services ID for to identify account.
-            aws_secret_acces_key (str): Amazon Web Services access key to authenticate programmatic requests.
+            aws_secret_access_key (str): Amazon Web Services access key to authenticate programmatic requests.
             aws_s3_bucket_name (str): The bucket in S3 to read from and to write the data to.
             aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.
             aws_s3_object_parameters (Optional[dict[str, any]]): A dictionary of additional arguments to be passed
@@ -1090,9 +1091,9 @@ class DataNodeConfig(Section):
         properties.update(
             {
                 cls._REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY: aws_access_key,
-                cls._REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY: aws_secret_acces_key,
+                cls._REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY: aws_secret_access_key,
                 cls._REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY: aws_s3_bucket_name,
-                cls._REQUIRED_AWS_S3_OBJECT_KEY: aws_s3_object_key,
+                cls._REQUIRED_AWS_S3_OBJECT_KEY_PROPERTY: aws_s3_object_key,
             }
         )
 

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -1073,7 +1073,7 @@ class DataNodeConfig(Section):
             aws_access_key (str): Amazon Web Services ID for to identify account.
             aws_secret_access_key (str): Amazon Web Services access key to authenticate programmatic requests.
             aws_s3_bucket_name (str): The bucket in S3 to read from and to write the data to.
-            aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS) 
+            aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS)
                 infrastructure is located.
             aws_s3_object_parameters (Optional[dict[str, any]]): A dictionary of additional arguments to be passed
                 into AWS S3 bucket access string.

--- a/src/taipy/core/config/data_node_config.py
+++ b/src/taipy/core/config/data_node_config.py
@@ -57,6 +57,8 @@ class DataNodeConfig(Section):
     _STORAGE_TYPE_VALUE_GENERIC = "generic"
     _STORAGE_TYPE_VALUE_JSON = "json"
     _STORAGE_TYPE_VALUE_PARQUET = "parquet"
+    _STORAGE_TYPE_VALUE_S3_OBJECT = "aws_s3_object"
+
     _DEFAULT_STORAGE_TYPE = _STORAGE_TYPE_VALUE_PICKLE
     _ALL_STORAGE_TYPES = [
         _STORAGE_TYPE_VALUE_PICKLE,
@@ -69,6 +71,7 @@ class DataNodeConfig(Section):
         _STORAGE_TYPE_VALUE_GENERIC,
         _STORAGE_TYPE_VALUE_JSON,
         _STORAGE_TYPE_VALUE_PARQUET,
+        _STORAGE_TYPE_VALUE_S3_OBJECT,
     ]
 
     _EXPOSED_TYPE_KEY = "exposed_type"
@@ -145,6 +148,13 @@ class DataNodeConfig(Section):
     _OPTIONAL_COMPRESSION_PARQUET_PROPERTY = "compression"
     _OPTIONAL_READ_KWARGS_PARQUET_PROPERTY = "read_kwargs"
     _OPTIONAL_WRITE_KWARGS_PARQUET_PROPERTY = "write_kwargs"
+    # S3object
+    _REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY = "aws_access_key"
+    _REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY = "aws_secret_acces_key"
+    _REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY = "aws_s3_bucket_name"
+    _REQUIRED_AWS_S3_OBJECT_KEY = "aws_s3_object_key"
+    _OPTIONAL_AWS_REGION_PROPERTY = "aws_region"
+    _OPTIONAL_AWS_S3_OBJECT_PARAMETERS_PROPERTY = "aws_s3_object_parameters"
 
     _REQUIRED_PROPERTIES: Dict[str, List] = {
         _STORAGE_TYPE_VALUE_PICKLE: [],
@@ -162,13 +172,20 @@ class DataNodeConfig(Section):
         _STORAGE_TYPE_VALUE_MONGO_COLLECTION: [
             _REQUIRED_DB_NAME_MONGO_PROPERTY,
             _REQUIRED_COLLECTION_NAME_MONGO_PROPERTY,
-        ],
+        ],        
         _STORAGE_TYPE_VALUE_CSV: [],
         _STORAGE_TYPE_VALUE_EXCEL: [],
         _STORAGE_TYPE_VALUE_IN_MEMORY: [],
         _STORAGE_TYPE_VALUE_GENERIC: [],
         _STORAGE_TYPE_VALUE_JSON: [],
         _STORAGE_TYPE_VALUE_PARQUET: [],
+
+        _STORAGE_TYPE_VALUE_S3_OBJECT: [
+            _REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY,
+            _REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY,
+            _REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY,
+            _REQUIRED_AWS_S3_OBJECT_KEY,
+        ],
     }
 
     _OPTIONAL_PROPERTIES = {
@@ -240,6 +257,10 @@ class DataNodeConfig(Section):
             _OPTIONAL_READ_KWARGS_PARQUET_PROPERTY: None,
             _OPTIONAL_WRITE_KWARGS_PARQUET_PROPERTY: None,
             _OPTIONAL_EXPOSED_TYPE_PARQUET_PROPERTY: _DEFAULT_EXPOSED_TYPE,
+        },
+        _STORAGE_TYPE_VALUE_S3_OBJECT: {
+            _OPTIONAL_AWS_REGION_PROPERTY: None,
+            _OPTIONAL_AWS_S3_OBJECT_PARAMETERS_PROPERTY: None,
         },
     }
 
@@ -380,8 +401,8 @@ class DataNodeConfig(Section):
         Parameters:
             storage_type (str): The default storage type for all data node configurations.
                 The possible values are *"pickle"* (the default value), *"csv"*, *"excel"*,
-                *"sql"*, *"mongo_collection"*, *"in_memory"*, *"json"*, *"parquet"* or
-                *"generic"*.
+                *"sql"*, *"mongo_collection"*, *"in_memory"*, *"json"*, *"parquet"*, *"generic"*,
+                or *"s3_object"*.
             scope (Optional[Scope^]): The default scope for all data node configurations.<br/>
                 The default value is `Scope.SCENARIO`.
             validity_period (Optional[timedelta]): The duration since the last edit date for which the data node can be
@@ -465,6 +486,7 @@ class DataNodeConfig(Section):
             cls._STORAGE_TYPE_VALUE_GENERIC: cls._configure_generic,
             cls._STORAGE_TYPE_VALUE_JSON: cls._configure_json,
             cls._STORAGE_TYPE_VALUE_PARQUET: cls._configure_parquet,
+            cls._STORAGE_TYPE_VALUE_S3_OBJECT: cls._configure_s3_object,
         }
 
         if storage_type in cls._ALL_STORAGE_TYPES:
@@ -1028,6 +1050,59 @@ class DataNodeConfig(Section):
 
         return cls.__configure(
             id, DataNodeConfig._STORAGE_TYPE_VALUE_MONGO_COLLECTION, scope, validity_period, **properties
+        )
+
+    @classmethod
+    def _configure_s3_object(
+        cls,
+        id: str,
+        aws_access_key: str,
+        aws_secret_acces_key: str,
+        aws_s3_bucket_name: str,
+        aws_region: Optional[str] = None,
+        aws_s3_object_parameters: Optional[Dict[str, Any]] = None,
+        scope: Optional[Scope] = None,
+        validity_period: Optional[timedelta] = None,
+        **properties,
+    ) -> "DataNodeConfig":
+        """Configure a new S3 object data node configuration.
+
+        Parameters:
+            id (str): The unique identifier of the new S3 Object data node configuration.
+            aws_access_key (str): Amazon Web Services ID for to identify account.
+            aws_secret_acces_key (str): Amazon Web Services access key to authenticate programmatic requests.
+            aws_s3_bucket_name (str): The bucket in S3 to read from and to write the data to.
+            aws_region (Optional[str]): Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.
+            aws_s3_object_parameters (Optional[dict[str, any]]): A dictionary of additional arguments to be passed
+                into AWS S3 bucket access string.
+            scope (Optional[Scope^]): The scope of the S3 Object data node configuration.<br/>
+                The default value is `Scope.SCENARIO`.
+            validity_period (Optional[timedelta]): The duration since the last edit date for which the data node can be
+                considered up-to-date. Once the validity period has passed, the data node is considered stale and
+                relevant tasks will run even if they are skippable (see the
+                [Task configs page](../core/config/task-config.md) for more details).
+                If *validity_period* is set to None, the data node is always up-to-date.
+            **properties (dict[str, any]): A keyworded variable length list of additional arguments.
+
+        Returns:
+            The new S3 object data node configuration.
+        """
+        properties.update(
+            {
+                cls._REQUIRED_AWS_ACCESS_KEY_ID_PROPERTY: aws_access_key,
+                cls._REQUIRED_AWS_SECRET_ACCESS_KEY_PROPERTY: aws_secret_acces_key,
+                cls._REQUIRED_AWS_STORAGE_BUCKET_NAME_PROPERTY: aws_s3_bucket_name,
+                cls._REQUIRED_AWS_S3_OBJECT_KEY: aws_s3_object_key,
+            }
+        )
+
+        if aws_region is not None:
+            properties[cls._OPTIONAL_AWS_REGION_PROPERTY] = aws_region
+        if aws_s3_object_parameters is not None:
+            properties[cls._OPTIONAL_AWS_S3_OBJECT_PARAMETERS_PROPERTY] = aws_s3_object_parameters
+
+        return cls.__configure(
+            id, DataNodeConfig._STORAGE_TYPE_VALUE_S3_OBJECT, scope, validity_period, **properties
         )
 
     @staticmethod

--- a/src/taipy/core/data/__init__.py
+++ b/src/taipy/core/data/__init__.py
@@ -21,3 +21,4 @@ from .parquet import ParquetDataNode
 from .pickle import PickleDataNode
 from .sql import SQLDataNode
 from .sql_table import SQLTableDataNode
+from .aws_s3 import S3ObjectDataNode

--- a/src/taipy/core/data/aws_s3.py
+++ b/src/taipy/core/data/aws_s3.py
@@ -48,10 +48,10 @@ class S3ObjectDataNode(DataNode):
         editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
         editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
-            _properties_ parameter must at least contain an entry for _"aws_access_key"_ , _"aws_secret_acces_key"_ , _aws_s3_bucket_name_ and _aws_s3_object_key_ :
+            _properties_ parameter must at least contain an entry for _"aws_access_key"_ , _"aws_secret_access_key"_ , _aws_s3_bucket_name_ and _aws_s3_object_key_ :
 
             - _"aws_access_key"_ `(str)`: Amazon Web Services ID for to identify account\n
-            - _"aws_secret_acces_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
+            - _"aws_secret_access_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
             - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.\n
             - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple Storage Service (S3).\n
             - _"aws_s3_object_key"_ `(str)`:  unique idntifier for the name of the object(file) that has to be read or written. \n
@@ -59,12 +59,13 @@ class S3ObjectDataNode(DataNode):
 
     """
 
-    __STORAGE_TYPE = "aws_s3"
+    __STORAGE_TYPE = "s3_object"
+
     __AWS_ACCESS_KEY_ID = "aws_access_key"
-    __AWS_SECRET_ACCESS_KEY = "aws_secret_acces_key"
-    __AWS_REGION = "aws_region"
+    __AWS_SECRET_ACCESS_KEY = "aws_secret_access_key"
     __AWS_STORAGE_BUCKET_NAME = "aws_s3_bucket_name"
     __AWS_S3_OBJECT_KEY = "aws_s3_object_key"
+    __AWS_REGION = "aws_region"    
     __AWS_S3_OBJECT_PARAMETERS  = "aws_s3_object_parameters"
 
 
@@ -84,13 +85,13 @@ class S3ObjectDataNode(DataNode):
         owner_id: Optional[str] = None,
         parent_ids: Optional[Set[str]] = None,
         last_edit_date: Optional[datetime] = None,
-        edits: List[Edit] = None,
+        edits: Optional[List[Edit]] = None,
         version: str = None,
         validity_period: Optional[timedelta] = None,
         edit_in_progress: bool = False,
         editor_id: Optional[str] = None,
         editor_expiration_date: Optional[datetime] = None,
-        properties: Dict = None,
+        properties: Optional[Dict] = None,
     ):
         if properties is None:
             properties = {}
@@ -129,8 +130,9 @@ class S3ObjectDataNode(DataNode):
             {
                 self.__AWS_ACCESS_KEY_ID,
                 self.__AWS_SECRET_ACCESS_KEY,
-                self.__AWS_REGION,
                 self.__AWS_STORAGE_BUCKET_NAME,
+                self.__AWS_S3_OBJECT_KEY,
+                self.__AWS_REGION,
                 self.__AWS_S3_OBJECT_PARAMETERS,
             }
         )

--- a/src/taipy/core/data/aws_s3.py
+++ b/src/taipy/core/data/aws_s3.py
@@ -1,0 +1,156 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+import boto3
+from datetime import datetime, timedelta
+from inspect import isclass
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+from taipy.config.common.scope import Scope
+
+from .._version._version_manager_factory import _VersionManagerFactory
+from ..exceptions.exceptions import InvalidCustomDocument, MissingRequiredProperty
+from .data_node import DataNode
+from .data_node_id import DataNodeId, Edit
+
+
+
+class AWSs3DataNode(DataNode):
+    """Data Node stored in a Amazon Web Service S3 Bucket .
+
+    Attributes:
+        config_id (str): Identifier of the data node configuration. It must be a valid Python
+            identifier.
+        scope (Scope^): The scope of this data node.
+        id (str): The unique identifier of this data node.
+        owner_id (str): The identifier of the owner (sequence_id, scenario_id, cycle_id) or
+            None.
+        parent_ids (Optional[Set[str]]): The identifiers of the parent tasks or `None`.
+        last_edit_date (datetime): The date and time of the last modification.
+        edits (List[Edit^]): The ordered list of edits for that job.
+        version (str): The string indicates the application version of the data node to instantiate. If not provided,
+            the current version is used.
+        validity_period (Optional[timedelta]): The duration implemented as a timedelta since the last edit date for
+            which the data node can be considered up-to-date. Once the validity period has passed, the data node is
+            considered stale and relevant tasks will run even if they are skippable (see the
+            [Task management page](../core/entities/task-mgt.md) for more details).
+            If _validity_period_ is set to `None`, the data node is always up-to-date.
+        edit_in_progress (bool): True if a task computing the data node has been submitted
+            and not completed yet. False otherwise.
+        editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
+        editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
+        properties (dict[str, Any]): A dictionary of additional properties. Note that the
+            _properties_ parameter must at least contain an entry for _"db_name"_ and _"collection_name"_:
+
+            - _"aws_access_key"_ `(str)`: Amazon Web Services ID for to identify account\n
+            - _"aws_secret_acces_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
+            - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.\n
+            - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple Storage Service (S3).\n
+            - _"aws _S3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with the AWS service\n
+
+    """
+
+    __STORAGE_TYPE = "aws_s3_bucket"
+    __AWS_ACCESS_KEY_ID = "aws_access_key"
+    __AWS_SECRET_ACCESS_KEY = "aws_secret_acces_key"
+    __AWS_REGION = "aws_region"
+    __AWS_STORAGE_BUCKET_NAME = "aws_s3_bucket_name"
+    __AWS_S3_OBJECT_PARAMETERS  = "aws _S3_object_parameters"
+
+
+    _REQUIRED_PROPERTIES: List[str] = [
+        __AWS_ACCESS_KEY_ID,
+        __AWS_SECRET_ACCESS_KEY,
+    ]
+
+    def __init__(
+        self,
+        config_id: str,
+        scope: Scope,
+        id: Optional[DataNodeId] = None,
+        owner_id: Optional[str] = None,
+        parent_ids: Optional[Set[str]] = None,
+        last_edit_date: Optional[datetime] = None,
+        edits: List[Edit] = None,
+        version: str = None,
+        validity_period: Optional[timedelta] = None,
+        edit_in_progress: bool = False,
+        editor_id: Optional[str] = None,
+        editor_expiration_date: Optional[datetime] = None,
+        properties: Dict = None,
+    ):
+        if properties is None:
+            properties = {}
+        required = self._REQUIRED_PROPERTIES
+        if missing := set(required) - set(properties.keys()):
+            raise MissingRequiredProperty(
+                f"The following properties " f"{', '.join(x for x in missing)} were not informed and are required"
+            )
+
+
+        super().__init__(
+            config_id,
+            scope,
+            id,
+            owner_id,
+            parent_ids,
+            last_edit_date,
+            edits,
+            version or _VersionManagerFactory._build_manager()._get_latest_version(),
+            validity_period,
+            edit_in_progress,
+            editor_id,
+            editor_expiration_date,
+            **properties,
+        )
+
+        self.s3_client = boto3.client('s3',
+            aws_access_key_id=properties.get(self.__AWS_ACCESS_KEY_ID),
+            aws_secret_access_key=properties.get(self.__AWS_SECRET_ACCESS_KEY),
+        )
+
+        if not self._last_edit_date:
+            self._last_edit_date = datetime.now()
+
+        self._TAIPY_PROPERTIES.update(
+            {
+                self.__AWS_ACCESS_KEY_ID,
+                self.__AWS_SECRET_ACCESS_KEY,
+                self.__AWS_REGION,
+                self.__AWS_STORAGE_BUCKET_NAME,
+                self.__AWS_S3_OBJECT_PARAMETERS,
+            }
+        )
+
+    @classmethod
+    def storage_type(cls) -> str:
+        return cls.__STORAGE_TYPE
+
+
+    def read_object_stream(self ,bucket_name , object_key ):
+        aws_s3_object = self.s3_client.get_object(
+            Bucket = bucket_name,
+            Key = object_key
+        )
+        return  aws_s3_object['Body'].read().decode('utf-8')
+
+    def write_object_stream(self , bucket_name , object_key ,  data  ):
+        self.s3_client.put_object(
+            Bucket = bucket_name,
+            Key = object_key,
+            Body = data
+            )
+
+
+
+
+

--- a/src/taipy/core/data/aws_s3.py
+++ b/src/taipy/core/data/aws_s3.py
@@ -48,14 +48,19 @@ class S3ObjectDataNode(DataNode):
         editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
         editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
-            _properties_ parameter must at least contain an entry for _"aws_access_key"_ , _"aws_secret_access_key"_ , _aws_s3_bucket_name_ and _aws_s3_object_key_ :
+            _properties_ parameter must at least contain an entry for _"aws_access_key"_ , _"aws_secret_access_key"_ ,
+            _aws_s3_bucket_name_ and _aws_s3_object_key_ :
 
             - _"aws_access_key"_ `(str)`: Amazon Web Services ID for to identify account\n
             - _"aws_secret_access_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
-            - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.\n
-            - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple Storage Service (S3).\n
-            - _"aws_s3_object_key"_ `(str)`:  unique idntifier for the name of the object(file) that has to be read or written. \n
-            - _"aws _s3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with the AWS service\n
+            - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is
+                    located.\n
+            - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple
+                    Storage Service (S3).\n
+            - _"aws_s3_object_key"_ `(str)`:  unique idntifier for the name of the object(file) that has to be read
+                    or written. \n
+            - _"aws _s3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with
+                    the AWS service\n
 
     """
 
@@ -65,9 +70,8 @@ class S3ObjectDataNode(DataNode):
     __AWS_SECRET_ACCESS_KEY = "aws_secret_access_key"
     __AWS_STORAGE_BUCKET_NAME = "aws_s3_bucket_name"
     __AWS_S3_OBJECT_KEY = "aws_s3_object_key"
-    __AWS_REGION = "aws_region"    
-    __AWS_S3_OBJECT_PARAMETERS  = "aws_s3_object_parameters"
-
+    __AWS_REGION = "aws_region"
+    __AWS_S3_OBJECT_PARAMETERS = "aws_s3_object_parameters"
 
     _REQUIRED_PROPERTIES: List[str] = [
         __AWS_ACCESS_KEY_ID,
@@ -100,8 +104,6 @@ class S3ObjectDataNode(DataNode):
             raise MissingRequiredProperty(
                 f"The following properties " f"{', '.join(x for x in missing)} were not informed and are required."
             )
-
-
         super().__init__(
             config_id,
             scope,
@@ -118,7 +120,8 @@ class S3ObjectDataNode(DataNode):
             **properties,
         )
 
-        self._s3_client = boto3.client('s3',
+        self._s3_client = boto3.client(
+            's3',
             aws_access_key_id=properties.get(self.__AWS_ACCESS_KEY_ID),
             aws_secret_access_key=properties.get(self.__AWS_SECRET_ACCESS_KEY),
         )
@@ -141,17 +144,16 @@ class S3ObjectDataNode(DataNode):
     def storage_type(cls) -> str:
         return cls.__STORAGE_TYPE
 
-
     def _read(self):
         aws_s3_object = self._s3_client.get_object(
-            Bucket = self.properties[self.__AWS_STORAGE_BUCKET_NAME],
-            Key = self.properties[self.__AWS_S3_OBJECT_KEY],
+            Bucket=self.properties[self.__AWS_STORAGE_BUCKET_NAME],
+            Key=self.properties[self.__AWS_S3_OBJECT_KEY],
         )
-        return  aws_s3_object['Body'].read().decode('utf-8')
+        return aws_s3_object['Body'].read().decode('utf-8')
 
     def _write(self, data: Any):
         self._s3_client.put_object(
-            Bucket = self.properties[self.__AWS_STORAGE_BUCKET_NAME],
-            Key = self.properties[self.__AWS_S3_OBJECT_KEY],
-            Body = data,
+            Bucket=self.properties[self.__AWS_STORAGE_BUCKET_NAME],
+            Key=self.properties[self.__AWS_S3_OBJECT_KEY],
+            Body=data,
         )

--- a/src/taipy/core/data/aws_s3.py
+++ b/src/taipy/core/data/aws_s3.py
@@ -54,7 +54,7 @@ class S3ObjectDataNode(DataNode):
             - _"aws_secret_acces_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
             - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.\n
             - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple Storage Service (S3).\n
-            - _"aws_s3_object_key"_`(str)`:  unique idntifier for the name of the object(file) that has to be read or written. \n
+            - _"aws_s3_object_key"_ `(str)`:  unique idntifier for the name of the object(file) that has to be read or written. \n
             - _"aws _s3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with the AWS service\n
 
     """

--- a/src/taipy/core/data/aws_s3.py
+++ b/src/taipy/core/data/aws_s3.py
@@ -24,7 +24,7 @@ from .data_node_id import DataNodeId, Edit
 
 
 
-class AWSs3DataNode(DataNode):
+class S3DataNode(DataNode):
     """Data Node stored in a Amazon Web Service S3 Bucket .
 
     Attributes:
@@ -49,22 +49,22 @@ class AWSs3DataNode(DataNode):
         editor_id (Optional[str]): The identifier of the user who is currently editing the data node.
         editor_expiration_date (Optional[datetime]): The expiration date of the editor lock.
         properties (dict[str, Any]): A dictionary of additional properties. Note that the
-            _properties_ parameter must at least contain an entry for _"db_name"_ and _"collection_name"_:
+            _properties_ parameter must at least contain an entry for _"aws_access_key"_ and _"aws_secret_acces_key"_:
 
             - _"aws_access_key"_ `(str)`: Amazon Web Services ID for to identify account\n
             - _"aws_secret_acces_key"_ `(str)`: Amazon Web Services access key to authenticate programmatic requests.\n
             - _"aws_region"_ `(Any)`: Self-contained geographic area where Amazon Web Services (AWS) infrastructure is located.\n
             - _"aws_s3_bucket_name"_ `(str)`: unique identifier for a container that stores objects in Amazon Simple Storage Service (S3).\n
-            - _"aws _S3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with the AWS service\n
+            - _"aws _s3_object_parameters"_ `(str)`: A dictionary of additional arguments to be passed to interact with the AWS service\n
 
     """
 
-    __STORAGE_TYPE = "aws_s3_bucket"
+    __STORAGE_TYPE = "aws_s3"
     __AWS_ACCESS_KEY_ID = "aws_access_key"
     __AWS_SECRET_ACCESS_KEY = "aws_secret_acces_key"
     __AWS_REGION = "aws_region"
     __AWS_STORAGE_BUCKET_NAME = "aws_s3_bucket_name"
-    __AWS_S3_OBJECT_PARAMETERS  = "aws _S3_object_parameters"
+    __AWS_S3_OBJECT_PARAMETERS  = "aws _s3_object_parameters"
 
 
     _REQUIRED_PROPERTIES: List[str] = [
@@ -136,16 +136,16 @@ class AWSs3DataNode(DataNode):
         return cls.__STORAGE_TYPE
 
 
-    def read_object_stream(self ,bucket_name , object_key ):
+    def _read(self , object_key ):
         aws_s3_object = self.s3_client.get_object(
-            Bucket = bucket_name,
+            Bucket = self.properties[self.__AWS_STORAGE_BUCKET_NAME],
             Key = object_key
         )
         return  aws_s3_object['Body'].read().decode('utf-8')
 
-    def write_object_stream(self , bucket_name , object_key ,  data  ):
+    def _write(self ,object_key ,  data  ):
         self.s3_client.put_object(
-            Bucket = bucket_name,
+            Bucket = self.properties[self.__AWS_STORAGE_BUCKET_NAME],
             Key = object_key,
             Body = data
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,7 +372,6 @@ def init_config():
             ("configure_excel_data_node", DataNodeConfig._configure_excel),
             ("configure_generic_data_node", DataNodeConfig._configure_generic),
             ("configure_s3_object_data_node", DataNodeConfig._configure_s3_object),
-
         ],
     )
     _inject_section(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,8 @@ def init_config():
             ("configure_pickle_data_node", DataNodeConfig._configure_pickle),
             ("configure_excel_data_node", DataNodeConfig._configure_excel),
             ("configure_generic_data_node", DataNodeConfig._configure_generic),
+            ("configure_s3_object_data_node", DataNodeConfig._configure_s3_object),
+
         ],
     )
     _inject_section(

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -91,7 +91,7 @@ class TestDataNodeConfigChecker:
             " sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory."
             ' Current value of property `storage_type` is "bar".'
         )
-        assert expected_error_message  in caplog.text
+        assert expected_error_message in caplog.text
 
         config._sections[DataNodeConfig.name]["new"].storage_type = "csv"
         Config._collector = IssueCollector()
@@ -370,7 +370,7 @@ class TestDataNodeConfigChecker:
         config._sections[DataNodeConfig.name]["new"].properties = {
             "aws_access_key": "access_key",
             "aws_secret_access_key": "secret_acces_key",
-            "aws_s3_bucket_name": "s3_bucket_name", 
+            "aws_s3_bucket_name": "s3_bucket_name",
             "aws_s3_object_key": "s3_object_key",
         }
         Config._collector = IssueCollector()

--- a/tests/core/config/checkers/test_data_node_config_checker.py
+++ b/tests/core/config/checkers/test_data_node_config_checker.py
@@ -123,6 +123,11 @@ class TestDataNodeConfigChecker:
         Config.check()
         assert len(Config._collector.errors) == 0
 
+        config._sections[DataNodeConfig.name]["new"].storage_type = "s3_object"
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
         config._sections[DataNodeConfig.name]["new"].storage_type = "generic"
         with pytest.raises(SystemExit):
             Config._collector = IssueCollector()
@@ -349,6 +354,17 @@ class TestDataNodeConfigChecker:
 
         config._sections[DataNodeConfig.name]["new"].storage_type = "mongo_collection"
         config._sections[DataNodeConfig.name]["new"].properties = {"db_name": "foo", "collection_name": "bar"}
+        Config._collector = IssueCollector()
+        Config.check()
+        assert len(Config._collector.errors) == 0
+
+        config._sections[DataNodeConfig.name]["new"].storage_type = "s3_object"
+        config._sections[DataNodeConfig.name]["new"].properties = {
+            "aws_access_key": "access_key",
+            "aws_secret_access_key": "secret_acces_key",
+            "aws_s3_bucket_name": "s3_bucket_name", 
+            "aws_s3_object_key": "s3_object_key",
+        }
         Config._collector = IssueCollector()
         Config.check()
         assert len(Config._collector.errors) == 0

--- a/tests/core/config/test_config.py
+++ b/tests/core/config/test_config.py
@@ -105,3 +105,19 @@ class TestConfig:
         )
         Config.configure_mongo_collection_data_node(a, b, c, d, e, f, g, h, extra_args, scope, vp, property=k)
         assert len(Config.data_nodes) == 2
+
+    def test_configure_s3_object_data_node(self):
+        a, b, c, d, e, f, extra_args, scope, vp, k = (
+            "foo",
+            "access_key",
+            "secret_acces_key",
+            "s3_bucket_name",
+            "s3_object_key",
+            None,
+            {"foo": "bar"},
+            Scope.SCENARIO,
+            timedelta(1),
+            "qux",
+        )
+        Config.configure_s3_object_data_node(a, b, c, d, e, f, extra_args, scope, vp, property=k)
+        assert len(Config.data_nodes) == 2

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -41,6 +41,11 @@ def test_set_default_data_node_configuration():
     assert data_node4.scope == Scope.SCENARIO
     assert data_node4.validity_period == timedelta(1)
 
+    Config.set_default_data_node_configuration("s3_object", validity_period=timedelta(1))
+    data_node5 = Config.configure_data_node(id="input_data5")
+    assert data_node5.storage_type == "s3_object"
+    assert data_node5.scope == Scope.SCENARIO
+    assert data_node5.validity_period == timedelta(1)
 
 def test_set_default_data_node_configuration_replace_old_default_config():
     Config.set_default_data_node_configuration(
@@ -578,5 +583,75 @@ def test_set_default_mongo_collection_data_node_configuration():
     assert dn3.db_host == "default_host"
     assert dn3.db_driver == "default server"
     assert dn3.db_extra_args == {"default": "default"}
+    assert dn3.scope == Scope.GLOBAL
+    assert dn3.validity_period == timedelta(1)
+
+
+def test_set_default_s3_object_data_node_configuration():
+    Config.set_default_data_node_configuration(
+        storage_type="s3_object",
+        aws_access_key="default_access_key",
+        aws_secret_access_key="default_secret_acces_key",
+        aws_s3_bucket_name ="default_bucket_name",
+        aws_s3_object_key="default_object_key",
+        aws_region="",
+        aws_s3_object_parameters={"default": "default"},
+        scope=Scope.GLOBAL,
+        validity_period=timedelta(2),
+    )
+
+    # Config with generic config_data_node without storage_type
+    # should return the default DataNode
+    dn1 = Config.configure_data_node(id="dn1")
+    assert dn1.storage_type == "s3_object"
+    assert dn1.aws_access_key == "default_access_key"
+    assert dn1.aws_secret_access_key == "default_secret_acces_key"
+    assert dn1.aws_s3_bucket_name == "default_bucket_name"
+    assert dn1.aws_s3_object_key == "default_object_key"
+    assert dn1.aws_region == ""
+    assert dn1.aws_s3_object_parameters == {"default": "default"}
+    assert dn1.scope == Scope.GLOBAL
+    assert dn1.validity_period == timedelta(2)
+
+    # Config with generic config_data_node without storage_type
+    # with custom properties
+    dn2 = Config.configure_data_node(
+        id="dn2",
+        aws_access_key="custom_access_key_2",
+        aws_secret_access_key="custom_secret_acces_key_2",
+        aws_s3_bucket_name ="custom_bucket_name_2",
+        aws_s3_object_key="custom_object_key_2",
+    )
+    assert dn2.storage_type == "s3_object"
+    assert dn2.aws_access_key == "custom_access_key_2"
+    assert dn2.aws_secret_access_key == "custom_secret_acces_key_2"
+    assert dn2.aws_s3_bucket_name == "custom_bucket_name_2"
+    assert dn2.aws_s3_object_key == "custom_object_key_2"
+    assert dn2.aws_region == ""
+    assert dn2.aws_s3_object_parameters == {"default": "default"}
+    assert dn2.scope == Scope.GLOBAL
+    assert dn2.validity_period == timedelta(2)
+
+    # Config a datanode with specific "storage_type" = "s3_object"
+    # should use properties from the default datanode
+    dn3 = Config.configure_data_node(
+        id="dn3",
+        storage_type="s3_object",
+        aws_access_key="custom_access_key_3",
+        aws_secret_access_key="custom_secret_acces_key_3",
+        aws_s3_bucket_name ="custom_bucket_name_3",
+        aws_s3_object_key="custom_object_key_3",
+        aws_region="",
+        aws_s3_object_parameters={"default": "default"},
+        scope=Scope.GLOBAL,
+        validity_period=timedelta(1),
+    )
+    assert dn3.storage_type == "s3_object"
+    assert dn3.aws_access_key == "custom_access_key_3"
+    assert dn3.aws_secret_access_key == "custom_secret_acces_key_3"
+    assert dn3.aws_s3_bucket_name == "custom_bucket_name_3"
+    assert dn3.aws_s3_object_key == "custom_object_key_3"
+    assert dn3.aws_region == ""
+    assert dn3.aws_s3_object_parameters == {"default": "default"}
     assert dn3.scope == Scope.GLOBAL
     assert dn3.validity_period == timedelta(1)

--- a/tests/core/config/test_configure_default_config.py
+++ b/tests/core/config/test_configure_default_config.py
@@ -47,6 +47,7 @@ def test_set_default_data_node_configuration():
     assert data_node5.scope == Scope.SCENARIO
     assert data_node5.validity_period == timedelta(1)
 
+
 def test_set_default_data_node_configuration_replace_old_default_config():
     Config.set_default_data_node_configuration(
         "in_memory",
@@ -592,7 +593,7 @@ def test_set_default_s3_object_data_node_configuration():
         storage_type="s3_object",
         aws_access_key="default_access_key",
         aws_secret_access_key="default_secret_acces_key",
-        aws_s3_bucket_name ="default_bucket_name",
+        aws_s3_bucket_name="default_bucket_name",
         aws_s3_object_key="default_object_key",
         aws_region="",
         aws_s3_object_parameters={"default": "default"},
@@ -619,7 +620,7 @@ def test_set_default_s3_object_data_node_configuration():
         id="dn2",
         aws_access_key="custom_access_key_2",
         aws_secret_access_key="custom_secret_acces_key_2",
-        aws_s3_bucket_name ="custom_bucket_name_2",
+        aws_s3_bucket_name="custom_bucket_name_2",
         aws_s3_object_key="custom_object_key_2",
     )
     assert dn2.storage_type == "s3_object"
@@ -639,7 +640,7 @@ def test_set_default_s3_object_data_node_configuration():
         storage_type="s3_object",
         aws_access_key="custom_access_key_3",
         aws_secret_access_key="custom_secret_acces_key_3",
-        aws_s3_bucket_name ="custom_bucket_name_3",
+        aws_s3_bucket_name="custom_bucket_name_3",
         aws_s3_object_key="custom_object_key_3",
         aws_region="",
         aws_s3_object_parameters={"default": "default"},

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -126,7 +126,7 @@ def test_data_node_config_check(caplog):
         Config.check()
     expected_error_message = (
         "`storage_type` field of DataNodeConfig `data_nodes` must be either csv, sql_table,"
-        " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory. Current"
+        " sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory. Current"
         ' value of property `storage_type` is "bar".'
     )
     assert expected_error_message in caplog.text
@@ -148,7 +148,7 @@ def test_data_node_config_check(caplog):
         Config.check()
     expected_error_message = (
         "`storage_type` field of DataNodeConfig `data_nodes` must be either csv, sql_table,"
-        " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory."
+        " sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory."
         ' Current value of property `storage_type` is "bar".'
     )
     assert expected_error_message in caplog.text

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -95,16 +95,18 @@ def test_data_node_config_default_parameter():
     assert mongo_dn_cfg.validity_period is None
 
     aws_s3_object_dn_cfg = Config.configure_data_node(
-        "data_node_11", "s3_object", aws_access_key="test", aws_secret_access_key="test_secret", aws_s3_bucket_name="test_bucket", aws_s3_object_key="test_file.txt"
+        "data_node_11", "s3_object", aws_access_key="test", aws_secret_access_key="test_secret",
+        aws_s3_bucket_name="test_bucket", aws_s3_object_key="test_file.txt"
     )
     assert aws_s3_object_dn_cfg.scope == Scope.SCENARIO
     assert aws_s3_object_dn_cfg.aws_access_key == "test"
     assert aws_s3_object_dn_cfg.aws_secret_access_key == "test_secret"
     assert aws_s3_object_dn_cfg.aws_s3_bucket_name == "test_bucket"
-    assert aws_s3_object_dn_cfg.aws_s3_object_key=="test_file.txt"
+    assert aws_s3_object_dn_cfg.aws_s3_object_key == "test_file.txt"
     assert aws_s3_object_dn_cfg.aws_region is None
     assert aws_s3_object_dn_cfg.aws_s3_object_parameters is None
     assert aws_s3_object_dn_cfg.validity_period is None
+
 
 def test_data_node_config_check(caplog):
     data_node_config = Config.configure_data_node("data_nodes1", "pickle")

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -95,12 +95,13 @@ def test_data_node_config_default_parameter():
     assert mongo_dn_cfg.validity_period is None
 
     aws_s3_object_dn_cfg = Config.configure_data_node(
-        "data_node_11", "s3_object", aws_access_key="test", aws_secret_acces_key="test_secret", aws_s3_bucket_name="test_bucket"
+        "data_node_11", "s3_object", aws_access_key="test", aws_secret_access_key="test_secret", aws_s3_bucket_name="test_bucket", aws_s3_object_key="test_file.txt"
     )
     assert aws_s3_object_dn_cfg.scope == Scope.SCENARIO
     assert aws_s3_object_dn_cfg.aws_access_key == "test"
-    assert aws_s3_object_dn_cfg.aws_secret_acces_key == "test_secret"
+    assert aws_s3_object_dn_cfg.aws_secret_access_key == "test_secret"
     assert aws_s3_object_dn_cfg.aws_s3_bucket_name == "test_bucket"
+    assert aws_s3_object_dn_cfg.aws_s3_object_key=="test_file.txt"
     assert aws_s3_object_dn_cfg.aws_region is None
     assert aws_s3_object_dn_cfg.aws_s3_object_parameters is None
     assert aws_s3_object_dn_cfg.validity_period is None

--- a/tests/core/config/test_data_node_config.py
+++ b/tests/core/config/test_data_node_config.py
@@ -94,6 +94,16 @@ def test_data_node_config_default_parameter():
     assert mongo_dn_cfg.db_driver == ""
     assert mongo_dn_cfg.validity_period is None
 
+    aws_s3_object_dn_cfg = Config.configure_data_node(
+        "data_node_11", "s3_object", aws_access_key="test", aws_secret_acces_key="test_secret", aws_s3_bucket_name="test_bucket"
+    )
+    assert aws_s3_object_dn_cfg.scope == Scope.SCENARIO
+    assert aws_s3_object_dn_cfg.aws_access_key == "test"
+    assert aws_s3_object_dn_cfg.aws_secret_acces_key == "test_secret"
+    assert aws_s3_object_dn_cfg.aws_s3_bucket_name == "test_bucket"
+    assert aws_s3_object_dn_cfg.aws_region is None
+    assert aws_s3_object_dn_cfg.aws_s3_object_parameters is None
+    assert aws_s3_object_dn_cfg.validity_period is None
 
 def test_data_node_config_check(caplog):
     data_node_config = Config.configure_data_node("data_nodes1", "pickle")

--- a/tests/core/data/test_aws_s3_data_node.py
+++ b/tests/core/data/test_aws_s3_data_node.py
@@ -18,19 +18,20 @@ from moto import mock_s3
 import pytest
 
 from src.taipy.core.data.data_node_id import DataNodeId
-from src.taipy.core.data.aws_s3 import S3DataNode
+from src.taipy.core.data.aws_s3 import S3ObjectDataNode
 from src.taipy.core.exceptions.exceptions import InvalidCustomDocument, MissingRequiredProperty
 from taipy.config.common.scope import Scope
 
 
 
-class TestS3DataNode:
+class TestS3ObjectDataNode:
     __properties = [
         {
             "aws_access_key": "testing",
             "aws_secret_acces_key": "testing",
             "aws_region": "us-east-1",
             "aws_s3_bucket_name":"taipy",
+            "aws_s3_object_key":"taipy-object",
             "db_extra_args": {},
         }
     ]
@@ -38,27 +39,25 @@ class TestS3DataNode:
     @mock_s3
     @pytest.mark.parametrize("properties", __properties)
     def test_create(self, properties):
-        aws_s3_dn = S3DataNode(
+        aws_s3_object_dn = S3ObjectDataNode(
             "foo_bar_aws_s3",
             Scope.SCENARIO,
             properties=properties,
         )
-        assert isinstance(aws_s3_dn, S3DataNode)
-        assert aws_s3_dn.storage_type() == "aws_s3"
-        assert aws_s3_dn.config_id == "foo_bar_aws_s3"
-        assert aws_s3_dn.scope == Scope.SCENARIO
-        assert aws_s3_dn.id is not None
-        assert aws_s3_dn.owner_id is None
-        assert aws_s3_dn.job_ids == []
-        assert aws_s3_dn.is_ready_for_reading
+        assert isinstance(aws_s3_object_dn, S3ObjectDataNode)
+        assert aws_s3_object_dn.storage_type() == "aws_s3"
+        assert aws_s3_object_dn.config_id == "foo_bar_aws_s3"
+        assert aws_s3_object_dn.scope == Scope.SCENARIO
+        assert aws_s3_object_dn.id is not None
+        assert aws_s3_object_dn.owner_id is None
+        assert aws_s3_object_dn.job_ids == []
+        assert aws_s3_object_dn.is_ready_for_reading
 
 
     @mock_s3
-    @pytest.mark.parametrize(' object_key, data', [
-        ('taipy-object', 'Hello, world!'),
-    ])
+    @pytest.mark.parametrize('data', [('Hello, world!'),])
     @pytest.mark.parametrize("properties", __properties)
-    def test_write(self, properties , object_key, data ):
+    def test_write(self, properties, data ):
         bucket_name = properties["aws_s3_bucket_name"]
 
         # Create an S3 client
@@ -67,20 +66,18 @@ class TestS3DataNode:
         # Create a bucket
         s3_client.create_bucket(Bucket=bucket_name)
 
-        aws_s3_dn = S3DataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
-        aws_s3_dn._write( object_key ,  data)
+        aws_s3_object_dn = S3ObjectDataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
+        aws_s3_object_dn._write(data)
 
-        response = aws_s3_dn._read( object_key)
+        response = aws_s3_object_dn._read()
 
         assert response == data
 
 
     @mock_s3
-    @pytest.mark.parametrize(' object_key, data', [
-        ( 'taipy-other-object', 'Hello, other world!'),
-    ])
+    @pytest.mark.parametrize('data', [('Hello, other world!'),])
     @pytest.mark.parametrize("properties", __properties)
-    def test_read(self, properties , object_key, data ):
+    def test_read(self, properties, data ):
 
         bucket_name = properties["aws_s3_bucket_name"]
         # Create an S3 client
@@ -89,12 +86,9 @@ class TestS3DataNode:
         # Create a bucket
         s3_client.create_bucket(Bucket=bucket_name)
 
-        aws_s3_dn = S3DataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
-        aws_s3_dn._write( object_key ,  data)
+        aws_s3_object_dn = S3ObjectDataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
+        aws_s3_object_dn._write(data)
 
-        response = aws_s3_dn._read( object_key)
+        response = aws_s3_object_dn._read()
 
         assert response == data
-
-
-

--- a/tests/core/data/test_aws_s3_data_node.py
+++ b/tests/core/data/test_aws_s3_data_node.py
@@ -1,0 +1,96 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import os
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import boto3
+from moto import mock_s3
+import pytest
+
+from src.taipy.core.data.data_node_id import DataNodeId
+from src.taipy.core.data.aws_s3 import AWSs3DataNode
+from src.taipy.core.exceptions.exceptions import InvalidCustomDocument, MissingRequiredProperty
+from taipy.config.common.scope import Scope
+
+
+
+class TestAWSs3DataNode:
+    __properties = [
+        {
+            "aws_access_key": "testing",
+            "aws_secret_acces_key": "testing",
+            "aws_region": "us-east-1",
+            "aws_s3_bucket_name":"taipy",
+            "db_extra_args": {},
+        }
+    ]
+
+    @mock_s3
+    @pytest.mark.parametrize("properties", __properties)
+    def test_create(self, properties):
+        aws_s3_dn = AWSs3DataNode(
+            "foo_bar_aws_s3",
+            Scope.SCENARIO,
+            properties=properties,
+        )
+        assert isinstance(aws_s3_dn, AWSs3DataNode)
+        assert aws_s3_dn.storage_type() == "aws_s3_bucket"
+        assert aws_s3_dn.config_id == "foo_bar_aws_s3"
+        assert aws_s3_dn.scope == Scope.SCENARIO
+        assert aws_s3_dn.id is not None
+        assert aws_s3_dn.owner_id is None
+        assert aws_s3_dn.job_ids == []
+        assert aws_s3_dn.is_ready_for_reading
+
+
+    @mock_s3
+    @pytest.mark.parametrize('bucket_name, object_key, data', [
+        ('taipy-bucket', 'taipy-object', 'Hello, world!'),
+    ])
+    @pytest.mark.parametrize("properties", __properties)
+    def test_write_object_stream(self, properties ,bucket_name, object_key, data ):
+        # Create an S3 client
+        s3_client = boto3.client('s3')
+
+        # Create a bucket
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        aws_s3_dn = AWSs3DataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
+        aws_s3_dn.write_object_stream(bucket_name , object_key ,  data)
+
+        response = aws_s3_dn.read_object_stream(bucket_name , object_key)
+
+        assert response == data
+
+
+    @mock_s3
+    @pytest.mark.parametrize('bucket_name, object_key, data', [
+        ('taipy-other-bucket', 'taipy-other-object', 'Hello, other world!'),
+    ])
+    @pytest.mark.parametrize("properties", __properties)
+    def test_read_object_stream(self, properties ,bucket_name, object_key, data ):
+        # Create an S3 client
+        s3_client = boto3.client('s3')
+
+        # Create a bucket
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        aws_s3_dn = AWSs3DataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
+        aws_s3_dn.write_object_stream(bucket_name , object_key ,  data)
+
+        response = aws_s3_dn.read_object_stream(bucket_name , object_key)
+
+        assert response == data
+
+
+

--- a/tests/core/data/test_aws_s3_data_node.py
+++ b/tests/core/data/test_aws_s3_data_node.py
@@ -53,7 +53,7 @@ class TestS3ObjectDataNode:
         assert aws_s3_object_dn.is_ready_for_reading
 
     @mock_s3
-    @pytest.mark.parametrize('data', [('Hello, write world!'),])
+    @pytest.mark.parametrize('data', [('Hello, write world!'), ])
     @pytest.mark.parametrize("properties", __properties)
     def test_write(self, properties, data):
         bucket_name = properties["aws_s3_bucket_name"]
@@ -73,7 +73,7 @@ class TestS3ObjectDataNode:
         assert response['Body'].read().decode('utf-8') == "Hello, write world!"
 
     @mock_s3
-    @pytest.mark.parametrize('data', [('Hello, read world!'),])
+    @pytest.mark.parametrize('data', [('Hello, read world!'), ])
     @pytest.mark.parametrize("properties", __properties)
     def test_read(self, properties, data):
         bucket_name = properties["aws_s3_bucket_name"]

--- a/tests/core/data/test_aws_s3_data_node.py
+++ b/tests/core/data/test_aws_s3_data_node.py
@@ -23,14 +23,13 @@ from src.taipy.core.exceptions.exceptions import InvalidCustomDocument, MissingR
 from taipy.config.common.scope import Scope
 
 
-
 class TestS3ObjectDataNode:
     __properties = [
         {
             "aws_access_key": "testing",
             "aws_secret_access_key": "testing",
-            "aws_s3_bucket_name":"taipy",
-            "aws_s3_object_key":"taipy-object",
+            "aws_s3_bucket_name": "taipy",
+            "aws_s3_object_key": " taipy-object",
             "aws_region": "us-east-1",
             "aws_s3_object_parameters": {},
         }
@@ -53,11 +52,10 @@ class TestS3ObjectDataNode:
         assert aws_s3_object_dn.job_ids == []
         assert aws_s3_object_dn.is_ready_for_reading
 
-
     @mock_s3
     @pytest.mark.parametrize('data', [('Hello, write world!'),])
     @pytest.mark.parametrize("properties", __properties)
-    def test_write(self, properties, data ):
+    def test_write(self, properties, data):
         bucket_name = properties["aws_s3_bucket_name"]
         # Create an S3 client
         s3_client = boto3.client('s3')
@@ -74,7 +72,6 @@ class TestS3ObjectDataNode:
 
         assert response['Body'].read().decode('utf-8') == "Hello, write world!"
 
-
     @mock_s3
     @pytest.mark.parametrize('data', [('Hello, read world!'),])
     @pytest.mark.parametrize("properties", __properties)
@@ -89,7 +86,7 @@ class TestS3ObjectDataNode:
         object_body = 'Hello, read world!'
         client.put_object(Body=object_body, Bucket=bucket_name, Key=object_key)
         # Create Taipy S3ObjectDataNode
-        aws_s3_object_dn = S3ObjectDataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)        
+        aws_s3_object_dn = S3ObjectDataNode("foo_aws_s3", Scope.SCENARIO, properties=properties)
         # Read the Object from bucket with Taipy
         response = aws_s3_object_dn._read()
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -29,7 +29,7 @@ class TestCore:
             core.run()
         expected_error_message = (
             "`storage_type` field of DataNodeConfig `d0` must be either csv, sql_table,"
-            " sql, mongo_collection, pickle, excel, generic, json, parquet, or in_memory."
+            " sql, mongo_collection, pickle, excel, generic, json, parquet, s3_object, or in_memory."
             ' Current value of property `storage_type` is "toto".'
         )
         assert expected_error_message in caplog.text


### PR DESCRIPTION
### Added AWS S3 DataNode
![image](https://github.com/Avaiga/taipy-core/assets/24577149/46dfc721-ba8e-4d38-a038-7dc746e69ca7)

Fixes Avaiga/taipy#536
- [x] Implemented a new predefined storage type "s3" in DataNodeConfig, to model data stored on an S3 bucket.
- [x] List and design the configuration attributes required.
        -    Create S3 datanode.
        -    Read stream object from s3 bucket.
        -    Write  stream object  to s3 bucket.
- [x] Implemented the corresponding S3DataNode inheriting from the parent DataNode class.

### Todo
- [ ] Add reference manual documentation.
- [ ] Write file to s3 bucket