### PR TITLE
bug/ fixed import path broke enterprise repo import

### DIFF
--- a/src/taipy/core/sequence/_sequence_manager.py
+++ b/src/taipy/core/sequence/_sequence_manager.py
@@ -14,8 +14,6 @@ import pathlib
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
-from src.taipy.core.notification.event import _make_event
-
 from .._entity._entity_ids import _EntityIds
 from .._manager._manager import _Manager
 from .._version._version_mixin import _VersionMixin
@@ -31,6 +29,7 @@ from ..exceptions.exceptions import (
 from ..job._job_manager_factory import _JobManagerFactory
 from ..job.job import Job
 from ..notification import Event, EventEntityType, EventOperation, Notifier
+from ..notification.event import _make_event
 from ..scenario._scenario_manager_factory import _ScenarioManagerFactory
 from ..scenario.scenario import Scenario
 from ..scenario.scenario_id import ScenarioId


### PR DESCRIPTION
## Issue
The tests in enterprise repo are failing due to unable to import `from src.taipy.core.notification.event import _make_event`.
https://github.com/Avaiga/taipy-enterprise/actions/runs/6958399104/job/18933316373?pr=267

## Change
Due to the structure of our dependencies, relative import is preferred as absolute import doesn't work. This PR provides a simple fix to the issue by replacing absolute import with relative import
